### PR TITLE
Random effects

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -155,8 +155,11 @@ class Model(object):
                     kwargs['drop_first'] = False
                     variable = f
                 else:
-                    variable, split_by = re.split('\s*\|\s*', f)
-                    kwargs['split_by'] = split_by
+                    a, b = re.split('\s*\|\s*', f)
+                    if self.data[a].dtype.name in ['object', 'category']:
+                        variable, kwargs['split_by'] = b, a
+                    else:
+                        variable, kwargs['split_by'] = a, b
                 self.add_term(variable=variable, label=f, **kwargs)
 
     def add_y(self, variable, family='gaussian', link=None, prior=None, *args,

--- a/bambi/tests/test_model.py
+++ b/bambi/tests/test_model.py
@@ -36,18 +36,21 @@ def test_term_split(diabetes_data):
     # Split a continuous fixed variable
     model = Model(diabetes_data)
     model.add_term('BMI', split_by='age_grp')
-    assert model.terms['BMI'].data.shape == (442, 3)
+    assert model.terms['BMI'].data.shape == (442, 2)
     # Split a categorical fixed variable
     model.reset()
-    model.add_term('BMI', split_by='age_grp', categorical=True)
+    model.add_term('BMI', split_by='age_grp', categorical=True,
+                   drop_first=False)
     assert model.terms['BMI'].data.shape == (442, 489)
     # Split a continuous random variable
     model.reset()
-    model.add_term('BMI', split_by='age_grp', categorical=False, random=True)
-    assert model.terms['BMI'].data.shape == (442, 3)
+    model.add_term('BMI', split_by='age_grp', categorical=False, random=True,
+                   drop_first=True)
+    assert model.terms['BMI'].data.shape == (442, 2)
     # Split a categorical random variable
     model.reset()
-    model.add_term('BMI', split_by='age_grp', categorical=True, random=True)
+    model.add_term('BMI', split_by='age_grp', categorical=True, random=True,
+                   drop_first=False)
     t = model.terms['BMI'].data
     assert isinstance(t, dict)
     assert t['age_grp[0]'].shape == (442, 83)


### PR DESCRIPTION
This is a substantial rewrite of the way random effects are handled. It now seems to behave very much like lme4 (though with more limited support). Specifically:

* Random intercepts are added by default; `X1|X2` will add both random intercepts and slopes for `X2`.
* Adding `0` to any term removes the intercept and results in full-rank representation of the X1:X2 interaction--e.g., `0+X1|X2` will result in N(X2) separate slope distributions, whereas `X1|X2` will result in random intercepts plus N(X2)-1 random slope distributions.

I've tested this a bit and it seems to behave properly, but should definitely be tested more extensively. Feel free to merge once you've reviewed and tested the code a bit.