### PR TITLE
adds NaN checking and dropna flag; closes #40

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -90,8 +90,13 @@ class Model(object):
                              " formula interface before build() or fit().")
 
         # Check for NaNs and halt if dropna is False--otherwise issue warning.
-        X = np.concatenate([t.data for t in self.terms.values()] + 
-                           [self.y.data], axis=1)
+        arrs = []
+        for t in self.terms.values():
+            if isinstance(t.data, dict):
+                arrs.extend(list(t.data.values()))
+            else:
+                arrs.append(t.data)
+        X = np.concatenate(arrs + [self.y.data], axis=1)
         num_na = np.isnan(X).any(1).sum()
         if num_na:
             msg = "%d rows were found contain at least one missing value." % num_na

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -55,6 +55,25 @@ def test_empty_model(crossed_data):
     assert set(priors0) == set(priors1)
 
 
+def test_nan_handling(crossed_data):
+    data = crossed_data.copy()
+
+    # Should fail because predictor has NaN
+    model_fail_na = Model(crossed_data)
+    model_fail_na.fit('Y ~ continuous', run=False)
+    model_fail_na.terms['continuous'].data[[4, 6, 8], :] = np.nan
+    with pytest.raises(ValueError):
+        model_fail_na.build()
+
+    # Should drop 3 rows with warning
+    model_drop_na = Model(crossed_data, dropna=True)
+    model_drop_na.fit('Y ~ continuous', run=False)
+    model_drop_na.terms['continuous'].data[[4, 6, 8], :] = np.nan
+    with pytest.warns(UserWarning) as w:
+        model_drop_na.build()
+    assert '3 rows' in w[0].message.args[0]
+
+
 def test_intercept_only_model(crossed_data):
     # using formula
     model0 = Model(crossed_data)


### PR DESCRIPTION
This PR adds a `dropna` argument to the `Model` initializer. Per discussion in #40, when `dropna=False` (default), an exception will be raised if any row contains a NaN. When `dropna=True`, a warning will be issued informing the user of how many rows were dropped.