### PR TITLE
Index

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -190,6 +190,10 @@ class Model(object):
                     str(self.dm_statistics) + '\n' + \
                     str(self._diagnostics))
 
+        # throw informative error message if any categorical predictors have 1 category
+        if any(np.array([x.data.size for x in self.fixed_terms.values()])==0):
+            raise ValueError("At least one categorical predictor contains only 1 category!")
+
         # only set priors if there is at least one term in the model
         if len(self.terms) > 0:
             # Get and scale default priors if none are defined yet

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -203,7 +203,7 @@ class Model(object):
         if self.family.name=='binomial' and np.max(self.y.data) < 1.01:
             event = next(i for i,x in enumerate(self.y.data.flatten()) if x>.99)
             warnings.warn('Modeling the probability that {}==\'{}\''.format(
-                self.y.name, str(self.data[self.y.name][event])))
+                self.y.name, str(self.data[self.y.name].iloc[event])))
 
         self.backend.build(self)
         self.built = True


### PR DESCRIPTION
Fixes an indexing error with binomial models, and makes the error message more informative when one of the categorical predictors consists of only a single category.