### PR TITLE
Llprior

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -97,9 +97,9 @@ class Model(object):
             else:
                 arrs.append(t.data)
         X = np.concatenate(arrs + [self.y.data], axis=1)
-        num_na = np.isnan(X).any(1).sum()
-        if num_na:
-            msg = "%d rows were found contain at least one missing value." % num_na
+        na_index = np.isnan(X).any(1)
+        if na_index.sum():
+            msg = "%d rows were found contain at least one missing value." % na_index.sum()
             if not self.dropna:
                 msg += "Please make sure the dataset contains no missing " \
                        "values. Alternatively, if you want rows with missing " \
@@ -107,8 +107,14 @@ class Model(object):
                        "manner (not recommended), please set dropna=True at " \
                        "model initialization."
                 raise ValueError(msg)
-            msg += " Automatically removing %d rows from the dataset." % num_na
+
+            # warn and then remove missing values
+            msg += " Automatically removing %d rows from the dataset." % na_index.sum()
             warnings.warn(msg)
+            keeps = np.invert(na_index)
+            for t in self.fixed_terms.values():
+                t.data = t.data[keeps]
+            self.y.data = self.y.data[keeps]
 
         # compute information used to set the default priors
         # X = fixed effects design matrix (excluding intercept/constant term)

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -200,9 +200,7 @@ class Model(object):
         if len(self.terms) > 0:
             # Get and scale default priors if none are defined yet
             scaler = PriorScaler(self)
-            for t in self.terms.values():
-                if not isinstance(t.prior, Prior):
-                    scaler.scale(t)
+            scaler.scale()
 
         # For binomial models with n_trials = 1 (most common use case),
         # tell user which event is being modeled

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -99,7 +99,8 @@ class Model(object):
         X = np.concatenate(arrs + [self.y.data], axis=1)
         na_index = np.isnan(X).any(1)
         if na_index.sum():
-            msg = "%d rows were found contain at least one missing value." % na_index.sum()
+            msg = "%d rows were found contain at least one missing value." \
+                % na_index.sum()
             if not self.dropna:
                 msg += "Please make sure the dataset contains no missing " \
                        "values. Alternatively, if you want rows with missing " \
@@ -109,7 +110,8 @@ class Model(object):
                 raise ValueError(msg)
 
             # warn and then remove missing values
-            msg += " Automatically removing %d rows from the dataset." % na_index.sum()
+            msg += " Automatically removing %d rows from the dataset." \
+                % na_index.sum()
             warnings.warn(msg)
             keeps = np.invert(na_index)
             for t in self.fixed_terms.values():
@@ -165,19 +167,21 @@ class Model(object):
                 'r2_x': pd.Series({
                     x: pd.stats.api.ols(
                         y=X[x], x=X.drop(x, axis=1),
-                        intercept=True if 'Intercept' in self.term_names else False).r2
+                        intercept=True if 'Intercept' in self.term_names \
+                            else False).r2
                     for x in list(X.columns)}),
                 'r2_y': pd.Series({
                     x: pd.stats.api.ols(
                         y=self.y.data.squeeze(), x=X.drop(x, axis=1),
-                        intercept=True if 'Intercept' in self.term_names else False).r2
+                        intercept=True if 'Intercept' in self.term_names \
+                            else False).r2
                     for x in list(X.columns)}),
                 'sd_x': X.std(),
                 'sd_y': sd_y_defaults[self.family.name][self.family.link],
                 'mean_x': X.mean(axis=0)
             }
 
-            # save potentially useful info for diagnostics and send to ModelResults
+            # save potentially useful info for diagnostics, send to ModelResults
             # mat = correlation matrix of X, w/ diagonal replaced by X means
             mat = X.corr()
             for x in list(mat.columns):
@@ -189,9 +193,10 @@ class Model(object):
                 'corr_mean_X': mat
             }
 
-            # throw informative error if there is perfect collinearity among the fixed effects
+            # throw informative error if perfect collinearity among fixed fx
             if any(self.dm_statistics['r2_x'] > .999):
-                raise ValueError("There is perfect collinearity among the fixed effects!\n" + \
+                raise ValueError(
+                    "There is perfect collinearity among the fixed effects!\n"+\
                     "Printing some design matrix statistics:\n" + \
                     str(self.dm_statistics) + '\n' + \
                     str(self._diagnostics))
@@ -331,7 +336,8 @@ class Model(object):
                 y_label = y.design_info.term_names[0]
                 if event is not None:
                     # pass in new Y data that has 1 if y=event and 0 otherwise
-                    y_data = y[:,y.design_info.column_names.index(event.group(1))]
+                    y_data = y[:, 
+                               y.design_info.column_names.index(event.group(1))]
                     y_data = pd.DataFrame({event.group(3): y_data})
                     self.add_y(y_label, family=family, link=link, data=y_data)
                 else:
@@ -359,7 +365,7 @@ class Model(object):
                                      "operators are currently supported in "
                                      "random effects specifications.")
 
-                # replace explicit intercept terms like '1|subj' with just 'subj'
+                # replace explicit intercept terms like '1|subj' with 'subj'
                 f = re.sub(r'^1\s*\|(.*)', r'\1', f).strip()
 
                 # Split specification into intercept, predictor, and grouper
@@ -434,7 +440,8 @@ class Model(object):
 
         # implement default Uniform [0, sd(Y)] prior for residual SD
         if self.family.name == 'gaussian':
-            prior.update(sd=Prior('Uniform', lower=0, upper=self.data[variable].std()))
+            prior.update(sd=Prior('Uniform', lower=0,
+                upper=self.data[variable].std()))
 
         self.add_term(variable, prior=prior, *args, **kwargs)
         # use last-added term name b/c it could have been changed by add_term
@@ -589,7 +596,8 @@ class Model(object):
             dists = []
             for t in self.fixed_terms.values():
                 for i,l in enumerate(t.levels):
-                    params = {k: v[i % len(v)] if isinstance(v, np.ndarray) else v
+                    params = {k: v[i % len(v)] \
+                        if isinstance(v, np.ndarray) else v
                         for k,v in t.prior.args.items()}
                     dists += [getattr(pm, t.prior.name)(l, **params)]
 

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -27,12 +27,13 @@ class Family(object):
         self.prior = prior
         self.link = link
         self.parent = parent
-        self.smfamily = {
+        fams = {
             'gaussian': sm.families.Gaussian,
             'binomial': sm.families.Binomial,
             'poisson': sm.families.Poisson,
             't': None # not implemented in statsmodels
-        }[name]
+        }
+        self.smfamily = fams[name] if name in fams.keys() else None
 
 
 class Prior(object):

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -364,9 +364,9 @@ def test_random_intercepts(crossed_data):
     model2.add_y('Y')
     model2.add_intercept()
     model2.add_term('continuous')
-    model2.add_term('subj', random=True)
-    model2.add_term('item', random=True)
-    model2.add_term('site', random=True)
+    model2.add_term('subj', random=True, categorical=True, drop_first=False)
+    model2.add_term('item', random=True, categorical=True, drop_first=False)
+    model2.add_term('site', random=True, categorical=True, drop_first=False)
     model2.build()
     # model2.fit(samples=1)
 
@@ -408,10 +408,10 @@ def test_many_random_effects(crossed_data):
     # random effects
     model1.add_term('threecats', over='subj', drop_first=False, random=True,
                     categorical=True)
-    model1.add_term('item', random=True, categorical=True)
+    model1.add_term('item', random=True, categorical=True, drop_first=False)
     model1.add_term('continuous', over='item', random=True)
     model1.add_term('dummy', over='item', random=True)
-    model1.add_term('site', random=True, categorical=True)
+    model1.add_term('site', random=True, categorical=True, drop_first=False)
     model1.add_term('threecats', over='site', random=True, categorical=True)
     model1.build()
     # model1.fit(samples=1)
@@ -475,10 +475,10 @@ def test_cell_means_with_many_random_effects(crossed_data):
     # random effects
     model1.add_term('threecats', over='subj', drop_first=False, random=True,
                     categorical=True)
-    model1.add_term('item', random=True, categorical=True)
+    model1.add_term('item', random=True, categorical=True, drop_first=False)
     model1.add_term('continuous', over='item', random=True)
     model1.add_term('dummy', over='item', random=True)
-    model1.add_term('site', random=True, categorical=True)
+    model1.add_term('site', random=True, categorical=True, drop_first=False)
     model1.add_term('threecats', over='site', random=True, categorical=True)
     model1.build()
     # model1.fit(samples=1)


### PR DESCRIPTION
This changes the implementation of the default priors so that they are based entirely on the log-likelihood function, never referencing the multiple regressions of Y and X on the covariates as in the previous implementation. For Normal response models, the results are essentially the same as before, but not exactly, as the new implementation relies on a quadratic approximation to the log-likelihood function (which is close but not perfect). Non-normal response models are now handled exactly the same as Normal response models now. However, the quadratic approximation to the log-likelihood is not as good for non-Normal response models, so the interpretation of the priors in terms of the standard deviation of the implied partial correlation should be considered a fairly rough approximation. Nevertheless, the default priors for non-Normal models are now much more intuitively sensible than before. This same implementation should also work almost entirely "as-is" for other link functions / response distributions that we have not explicitly implemented; all we really need to do is point to the appropriate statsmodels distribution family in priors.py. 

We might be able to upgrade the quadratic approximation to a quartic approximation, which should give even better results. But I have not worked this out yet. In any case, for now this is ready for production.