### PR TITLE
adds more conservative PyMC3 sampling initialization defaults

### DIFF
--- a/bambi/backends.py
+++ b/bambi/backends.py
@@ -122,7 +122,8 @@ class PyMC3BackEnd(BackEnd):
 
             self.spec = spec
 
-    def run(self, start=None, method='mcmc', find_map=False, **kwargs):
+    def run(self, start=None, method='mcmc', init=None, n_init=10000,
+            find_map=False, **kwargs):
         '''
         Run the PyMC3 MCMC sampler.
         Args:
@@ -133,6 +134,11 @@ class PyMC3BackEnd(BackEnd):
                 Alternatively, 'advi', in which case the model will be fitted
                 using  automatic differentiation variational inference as
                 implemented in PyMC3.
+            init: Initialization method (see PyMC3 sampler documentation).
+                In PyMC3, this defaults to 'advi', but we set it to None.
+            n_init: Number of initialization iterations if init = 'advi' or
+                'nuts'. Default is kind of in PyMC3 for the kinds of models
+                we expect to see run with bambi, so we lower it considerably.
             find_map (bool): whether or not to use the maximum a posteriori
                 estimate as a starting point; passed directly to PyMC3.
             kwargs (dict): Optional keyword arguments passed onto the sampler.
@@ -143,7 +149,8 @@ class PyMC3BackEnd(BackEnd):
             with self.model:
                 if start is None and find_map:
                     start = pm.find_MAP()
-                self.trace = pm.sample(samples, start=start, **kwargs)
+                self.trace = pm.sample(samples, start=start, init=init,
+                                       n_init=n_init, **kwargs)
             return PyMC3Results(self.spec, self.trace)
 
         elif method == 'advi':


### PR DESCRIPTION
In recent releases, PyMC3 defaults to using ADVI to find a sensible starting point for sampling. It also defaults to a rather large number of initialization iterations (200,000). While this no doubt ensures saner starting points, for the kind of models our users are likely to be fitting, the initial ADVI run is likely to add a non-negligible amount of computation (e.g., I just started fitting a model with ~80k rows and no very many parameters, and the estimated time just for advi to finish is nearly 2 hours!). Also, at least in the one case I tested, initializing with ADVI rather bizarrely appears to break the sampler, in that it causes NUTS to return crazy values (with virtually no variances in the traces) for most parameters.

Since all extra args and kwargs passed to `Model.run()` are passed onto the sampler, the user can easily control this by setting `init=None` and/or `n_init` to a much smaller value. But since the point is to prevent our users from having to think about sampling details as much as possible, I suggest we explicitly set the default `init` to `None` and the default `n_init` to `10000`. I've made changes accordingly.