### PR TITLE
Fix dropna

### DIFF
--- a/bambi/external/patsy.py
+++ b/bambi/external/patsy.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+class Ignore_NA(object):
+    """
+    Custom patsy.missing.NAAction class to force Patsy to ignore missing values.
+    See Patsy code/API for NAAction documentation.
+    """
+    def __init__(self, on_NA="ignore", NA_types=["None", "NaN"]):
+        self.on_NA = on_NA
+        if isinstance(NA_types, str):
+            raise ValueError("NA_types should be a list of strings")
+        self.NA_types = tuple(NA_types)
+
+    def is_categorical_NA(self, obj):
+        if "NaN" in self.NA_types and safe_scalar_isnan(obj):
+            return True
+        if "None" in self.NA_types and obj is None:
+            return True
+        return False
+
+    def is_numerical_NA(self, arr):
+        mask = np.zeros(arr.shape, dtype=bool)
+        if "NaN" in self.NA_types:
+            mask |= np.isnan(arr)
+        if mask.ndim > 1:
+            mask = np.any(mask, axis=1)
+        return mask
+
+    def handle_NA(self, values, is_NAs, origins):
+        return values

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -4,6 +4,7 @@ import pymc3 as pm
 from pymc3.model import FreeRV
 import matplotlib.pyplot as plt
 from bambi.external.six import string_types
+from bambi.external.patsy import Ignore_NA
 from collections import OrderedDict, defaultdict
 from bambi.utils import listify
 from patsy import dmatrices, dmatrix
@@ -124,8 +125,14 @@ class Model(object):
                 % na_index.sum()
             warnings.warn(msg)
             keeps = np.invert(na_index)
-            for t in self.fixed_terms.values():
-                t.data = t.data[keeps]
+            for t in self.terms.values():
+                # remove missing values from random effects
+                if isinstance(t.data, dict):
+                    t.data[list(t.data.keys())[0]] = \
+                        t.data[list(t.data.keys())[0]][keeps]
+                # remove missing values from fixed effects
+                else:
+                    t.data = t.data[keeps]
             self.y.data = self.y.data[keeps]
 
         # X = fixed effects design matrix (excluding intercept/constant term)
@@ -657,34 +664,4 @@ class Term(object):
             self.levels = list(range(data.shape[1]))
 
         self.data = data
-
-class Ignore_NA(object):
-    """
-    Custom patsy.missing.NAAction class to force Patsy to ignore missing values.
-    See Patsy code/API for NAAction documentation.
-    """
-    def __init__(self, on_NA="ignore", NA_types=["None", "NaN"]):
-        self.on_NA = on_NA
-        if isinstance(NA_types, str):
-            raise ValueError("NA_types should be a list of strings")
-        self.NA_types = tuple(NA_types)
-
-    def is_categorical_NA(self, obj):
-        if "NaN" in self.NA_types and safe_scalar_isnan(obj):
-            return True
-        if "None" in self.NA_types and obj is None:
-            return True
-        return False
-
-    def is_numerical_NA(self, arr):
-        mask = np.zeros(arr.shape, dtype=bool)
-        if "NaN" in self.NA_types:
-            mask |= np.isnan(arr)
-        if mask.ndim > 1:
-            mask = np.any(mask, axis=1)
-        return mask
-
-    def handle_NA(self, values, is_NAs, origins):
-        return values
-
-
+        

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -138,38 +138,6 @@ class Model(object):
             X = [pd.DataFrame(x.data, columns=x.levels) for x in terms]
             X = pd.concat(X, axis=1)
 
-            # interim solution for handling non-normal models
-            sd_y_defaults = {
-                'gaussian': {
-                    'identity': self.y.data.std(),
-                    'logit': self.y.data.std(),
-                    'probit': self.y.data.std(),
-                    'inverse': self.y.data.std(),
-                    'log': self.y.data.std()
-                },
-                'binomial': {
-                    'identity': self.y.data.std(),
-                    'logit': np.pi / 3**.5,
-                    'probit': 1,
-                    'inverse': self.y.data.std(),
-                    'log': self.y.data.std()
-                },
-                'poisson': {
-                    'identity': self.y.data.std(),
-                    'logit': self.y.data.std(),
-                    'probit': self.y.data.std(),
-                    'inverse': self.y.data.std(),
-                    'log': self.y.data.std()
-                },
-                't': {
-                    'identity': self.y.data.std(),
-                    'logit': self.y.data.std(),
-                    'probit': self.y.data.std(),
-                    'inverse': self.y.data.std(),
-                    'log': self.y.data.std()
-                }
-            }
-
             self.dm_statistics = {
                 'r2_x': pd.Series({
                     x: sm.OLS(endog=X[x],
@@ -178,7 +146,6 @@ class Model(object):
                             else X.drop(x, axis=1)).fit().rsquared
                     for x in list(X.columns)}),
                 'sd_x': X.std(),
-                'sd_y': sd_y_defaults[self.family.name][self.family.link],
                 'mean_x': X.mean(axis=0)
             }
 


### PR DESCRIPTION
Missing values were not being handled correctly because Patsy was silently dropping rows w/ missing data before the data reached our `dropna` code. Now missing values are handled as intended.

Also removes some old, unused code from previous implementations of the default priors.