### PR TITLE
Result names

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -508,7 +508,6 @@ class Model(object):
             data = dmatrix(f, data=data, NA_action=Ignore_NA())
             cols = data.design_info.column_names
             data = pd.DataFrame(data, columns=cols)
-            # data = pd.DataFrame(data, columns=[c.split(':')[0] for c in cols])
 
             # For categorical effects, one variance term per predictor level
             if categorical:
@@ -521,7 +520,7 @@ class Model(object):
                         c.split(':')[0] for c in level_data.columns]
                     level_data = level_data.loc[
                         :, (level_data != 0).any(axis=0)]
-                    split_data[g] = level_data#.values
+                    split_data[g] = level_data
                 data = split_data
             else:
                 data.columns = [c.split(':')[0] for c in cols]
@@ -532,7 +531,7 @@ class Model(object):
             label = variable
             if over is not None:
                 label += '|%s' % over
-        
+
         term = Term(name=label, data=data, categorical=categorical,
                     random=random, prior=prior)
         self.terms[term.name] = term
@@ -660,11 +659,11 @@ class Term(object):
         if isinstance(data, pd.DataFrame):
             self.levels = list(data.columns)
             data = data.values
+        # Random effects pass through here
         elif isinstance(data, dict):
             self.levels = list(data[list(data.keys())[0]].columns)
             for k, v in data.items():
                 data[k] = v.values
-            # pass   # Random effects pass through here
         else:
             data = np.atleast_2d(data)
             self.levels = list(range(data.shape[1]))

--- a/bambi/results.py
+++ b/bambi/results.py
@@ -68,6 +68,7 @@ class PyMC3Results(ModelResults):
     def _filter_names(self, names, exclude_ranefs=True, hide_transformed=True):
         names = self.untransformed_vars \
             if hide_transformed else self.trace.varnames
+        # helper function to put parameter names in same format as random_terms
         def _format(name):
             regex = re.match(r'^u_([^\|]+)\|([^_\1]+)_\1', name)
             return name if regex is None else 'u_{}|{}'.format(

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -329,13 +329,13 @@ def test_cell_means_with_random_intercepts(crossed_data):
     test_set = fitted.summary(hide_transformed=False).index
     test_set = set([re.sub(r'_$', r'', x) for x in test_set])
     assert test_set == full.difference(
-        set(['subj[{}]'.format(i) for i in range(10)]))
+        set(['1|subj[{}]'.format(i) for i in range(10)]))
 
     # test get_trace
     test_set = fitted.get_trace().columns
     test_set = set([re.sub(r'_$', r'', x) for x in test_set])
     assert test_set == full.difference(set(['Y_sd_interval', 'u_subj_sd_log'])) \
-        .difference(set(['subj[{}]'.format(i) for i in range(10)]))
+        .difference(set(['1|subj[{}]'.format(i) for i in range(10)]))
 
     # test plots
     fitted.plot(kind='priors')


### PR DESCRIPTION
This fixes a few different bugs with .summary() and .get_trace(). Some of these were bugs that were introduced in the previous commits that add diagnostic info to .summary(), but that only occurred in cases that don't appear in our tests. One appeared to be a long-standing (but not previously documented) bug with models that feature random slopes of categorical predictors with >2 levels.

The reason these cases have slipped through our tests is because testing them would require actually compiling/sampling such models, which would add a lot of testing time, and we have been trying to compile as few models as possible in the tests because they already take forever. 

Sadly I suspect most of this new code will have to be reworked again when we eventually merge in the Stan branch, but in the meantime I think these fixes are fairly high-priority. 