### PR TITLE
Result names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 - sleep 3 # give xvfb some time to start
 
 script:
-- py.test --pyargs bambi --cov-report term-missing --cov=bambi
+- travis_wait py.test --pyargs bambi --cov-report term-missing --cov=bambi
 
 after_success:
 - coveralls

--- a/bambi/results.py
+++ b/bambi/results.py
@@ -70,44 +70,49 @@ class PyMC3Results(ModelResults):
             if hide_transformed else self.trace.varnames
         # helper function to put parameter names in same format as random_terms
         def _format(name):
-            regex = re.match(r'^u_([^\|]+)\|([^_\1]+)_\1', name)
-            return name if regex is None else 'u_{}|{}'.format(
-                regex.group(1), regex.group(2))
+            regex = re.match(r'^u_([^\|]+)\|([^_\1]+)_\1(.*_sd$)?', name)
+            return name if regex is None or regex.group(3) is not None \
+                else 'u_{}|{}'.format(regex.group(1), regex.group(2))
         if exclude_ranefs:
             names = [x for x in names
                 if _format(x)[2:] not in list(self.model.random_terms.keys())]
         return names
 
     def _prettify_name(self, old_name):
-        # re1 chops 'u_subj__7' into 3 groups: {1:'u_', 2:'subj', 3:'7'}
-        re1 = re.match(r'^([bu]_)?(.+[^__\d+]+)(__\d+)?$', old_name)
+        # re1 chops 'u_subj__7' into {1:'u_', 2:'subj', 3:'7'}
+        re1 = re.match(r'^([bu]_)(.+[^__\d+]+)(__\d+)?$', old_name)
         # params like the residual SD will have no matches, so just return
         if re1 is None:
             return old_name
-        else:
-            # handle random slopes first because their format is weird.
-            # re2 chops 'x|subj_x[a]' into {1:'x', 2:'subj', 3:'x[a]'}
-            re2 = re.match(r'^([^\|]+)\|([^_\1]+)(_\1\[.+\])?$', re1.group(2))
-            if re2 is not None:
-                term = self.model.terms['{}|{}'.format(
-                    re2.group(1), re2.group(2))]
-                # random slopes of factors
-                if re2.group(3) is not None:
-                    return '{}|{}'.format(
-                        re2.group(3)[1:], term.levels[int(re1.group(3)[2:])])
-                # random slopes of continuous predictors
-                else:
-                    return '{}|{}'.format(
-                        re2.group(1), term.levels[int(re1.group(3)[2:])])
-            # handle SD terms by just chopping off the 'u_'
-            if re1.group(3) is None: return re1.group(2)
-            # handle fixed effects and random intercepts
-            term = self.model.terms[re1.group(2)]
-            if re1.group(1)=='b_':
-                return term.levels[int(re1.group(3)[2:])]
-            if re1.group(1)=='u_':
-                return '1|{}[{}]'.format(
-                    re1.group(2), term.levels[int(re1.group(3)[2:])])
+        # handle random slopes first because their format is weird.
+        # re2 chops 'x|subj_x[a]' into {1:'x', 2:'subj', 3:'x', 4:'[a]'}
+        re2 = re.match(r'^([^\|]+)\|([^_\1]+)(_\1)?(\[.+\])?$', re1.group(2))
+        if re2 is not None:
+            term = self.model.terms['{}|{}'.format(re2.group(1), re2.group(2))]
+            # random slopes of factors
+            if re2.group(4) is not None:
+                return '{}{}|{}'.format(re2.group(3)[1:],
+                    re2.group(4), term.levels[int(re1.group(3)[2:])])
+            # random slopes of continuous predictors
+            else:
+                return '{}|{}'.format(
+                    re2.group(1), term.levels[int(re1.group(3)[2:])])
+        # handle SD terms
+        # re3 chops 'u_x|subj_x[a]_sd' into {'x', '|subj', '_x', '[a]'}
+        re3 = re.match(r'^([^\|]+)(\|[^_\1]+)?(_\1)?(\[\d+\])?_sd$',
+            re1.group(2))
+        if re1.group(3) is None and re3 is not None:
+            if re3.group(2) is None: return '1|{}_sd'.format(re3.group(1))
+            if re3.group(4) is not None: return '{}{}{}_sd'.format(
+                re3.group(3)[1:], re3.group(4), re3.group(2))
+            return '{}{}_sd'.format(re3.group(1), re3.group(2))
+        # handle fixed effects and random intercepts
+        term = self.model.terms[re1.group(2)]
+        if re1.group(1)=='b_': return re1.group(2) if re1.group(3) is None \
+            else term.levels[int(re1.group(3)[2:])]
+        if re1.group(1)=='u_':
+            return '1|{}[{}]'.format(
+                re1.group(2), term.levels[int(re1.group(3)[2:])])
 
     def plot(self, burn_in=0, names=None, annotate=True, exclude_ranefs=False, 
         hide_transformed=True, kind='trace', **kwargs):
@@ -244,7 +249,7 @@ class PyMC3Results(ModelResults):
                         stat[self._prettify_name(k)] = v
                 # append to df
                 stat = pd.DataFrame(stat, index=[diag_name]).T
-                df = df.merge(stat, left_index=True, right_index=True)
+                df = df.merge(stat, how='left', left_index=True, right_index=True)
         else:
             warnings.warn('Multiple MCMC chains (i.e., njobs > 1) are required'
                           ' in order to compute convergence diagnostics.')

--- a/bambi/results.py
+++ b/bambi/results.py
@@ -139,7 +139,7 @@ class PyMC3Results(ModelResults):
 
         # compute means for all variables and factors
         if annotate:
-            kwargs['lines'] = {param: self.trace[param][burn_in:].mean() \
+            kwargs['lines'] = {param: self.trace[param, burn_in:].mean() \
                 for param in names}
             # factors (fixed terms with shape > 1) must be handled separately
             factors = {}
@@ -150,7 +150,7 @@ class PyMC3Results(ModelResults):
                     # add factor and its column means to dictionary of factors
                     factors.update({'b_'+fix.name:
                         {':'.join(re.findall('\[([^]]+)\]', x)):
-                         self.trace['b_'+fix.name][burn_in:].mean(0)[i]
+                         self.trace['b_'+fix.name, burn_in:].mean(0)[i]
                          for i,x in enumerate(fix.levels)}})
 
         # make the traceplot
@@ -298,7 +298,7 @@ class PyMC3Results(ModelResults):
                             for x in self.model.terms[var[2:]].levels]
 
         # construct the trace DataFrame
-        trace_df = pd.concat([pd.DataFrame(self.trace[burn_in:][x],
+        trace_df = pd.concat([pd.DataFrame(self.trace[x, burn_in:],
                                            columns=get_cols(x))
                               for x in names], axis=1)
 

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -123,70 +123,6 @@ def test_slope_only_model(crossed_data):
     assert set(priors0) == set(priors1)
 
 
-def test_simple_regression(crossed_data):
-    # using formula
-    model0 = Model(crossed_data)
-    model0.fit('Y ~ continuous', run=False)
-    model0.build()
-    model0.fit(samples=1)
-
-    # using add_term
-    model1 = Model(crossed_data)
-    model1.add_y('Y')
-    model1.add_intercept()
-    model1.add_term('continuous')
-    model1.build()
-    model1.fit(samples=1)
-
-    # check that term names agree
-    assert set(model0.term_names) == set(model1.term_names)
-
-    # check that add_formula and add_term models have same priors for fixed
-    # effects
-    priors0 = {
-        x.name: x.prior.args for x in model0.terms.values() if not x.random}
-    priors1 = {
-        x.name: x.prior.args for x in model1.terms.values() if not x.random}
-    assert set(priors0) == set(priors1)
-
-
-def test_many_fixed_effects(crossed_data):
-    # build model using formula
-    model0 = Model(crossed_data)
-    model0.fit('Y ~ continuous + dummy + threecats', run=False)
-    model0.build()
-    model0.fit(samples=1)
-
-    # build model using add_term
-    model1 = Model(crossed_data)
-    model1.add_y('Y')
-    model1.add_intercept()
-    model1.add_term('continuous')
-    model1.add_term('dummy')
-    model1.add_term('threecats')
-    model1.build()
-    model1.fit(samples=1)
-
-    # check that term names agree
-    assert set(model0.term_names) == set(model1.term_names)
-
-    # check that design matries are the same,
-    # even if term names / level names / order of columns is different
-    X0 = set([tuple(t.data[:, lev]) for t in model0.fixed_terms.values()
-              for lev in range(len(t.levels))])
-    X1 = set([tuple(t.data[:, lev]) for t in model1.fixed_terms.values()
-              for lev in range(len(t.levels))])
-    assert X0 == X1
-
-    # check that add_formula and add_term models have same priors for fixed
-    # effects
-    priors0 = {
-        x.name: x.prior.args for x in model0.terms.values() if not x.random}
-    priors1 = {
-        x.name: x.prior.args for x in model1.terms.values() if not x.random}
-    assert set(priors0) == set(priors1)
-
-
 def test_cell_means_parameterization(crossed_data):
     # build model using formula
     model0 = Model(crossed_data)
@@ -245,7 +181,7 @@ def test_cell_means_with_covariate(crossed_data):
     model0 = Model(crossed_data)
     model0.fit('Y ~ 0 + threecats + continuous', run=False)
     model0.build()
-    model0.fit(samples=1)
+    # model0.fit(samples=1)
 
     # build model using add_term
     model1 = Model(crossed_data)
@@ -253,7 +189,7 @@ def test_cell_means_with_covariate(crossed_data):
     model1.add_term('threecats', drop_first=False)
     model1.add_term('continuous')
     model1.build()
-    model1.fit(samples=1)
+    # model1.fit(samples=1)
 
     # check that design matries are the same,
     # even if term names / level names / order of columns is different
@@ -275,128 +211,13 @@ def test_cell_means_with_covariate(crossed_data):
     assert set(priors0) == set(priors1)
 
 
-def test_cell_means_with_random_intercepts(crossed_data):
-    # using formula
-    model0 = Model(crossed_data)
-    model0.fit('Y ~ 0 + threecats', random=['subj'], run=False)
-    model0.build()
-    fitted = model0.fit(samples=100)
-
-    # using add_term
-    model1 = Model(crossed_data, intercept=False)
-    model1.add_y('Y')
-    model1.add_term('threecats', categorical=True, drop_first=False)
-    model1.add_term('subj', categorical=True, random=True, drop_first=False)
-    model1.build()
-    model1.fit(samples=1)
-
-    # check that they have the same random terms
-    assert set(model0.random_terms) == set(model1.random_terms)
-
-    # check that fixed effect design matries are the same,
-    # even if term names / level names / order of columns is different
-    X0 = set([tuple(t.data[:, lev]) for t in model0.fixed_terms.values()
-              for lev in range(len(t.levels))])
-    X1 = set([tuple(t.data[:, lev]) for t in model1.fixed_terms.values()
-              for lev in range(len(t.levels))])
-    assert X0 == X1
-
-    # check that add_formula and add_term models have same priors for fixed
-    # effects
-    priors0 = {
-        x.name: x.prior.args for x in model0.terms.values() if not x.random}
-    priors1 = {
-        x.name: x.prior.args for x in model1.terms.values() if not x.random}
-    assert set(priors0) == set(priors1)
-
-    # check that add_formula and add_term models have same priors for random
-    # effects
-    priors0 = {x.name: x.prior.args[
-        'sd'].args for x in model0.terms.values() if x.random}
-    priors1 = {x.name: x.prior.args[
-        'sd'].args for x in model1.terms.values() if x.random}
-    assert set(priors0) == set(priors1)
-
-    # test summary
-    # it looks like some versions of pymc3 add a trailing '_' to transformed
-    # vars and some dont. so here for consistency we strip out any trailing '_'
-    # that we find
-    full = fitted.summary(exclude_ranefs=False, hide_transformed=False).index
-    full = set([re.sub(r'_$', r'', x) for x in full])
-    test_set = fitted.summary(exclude_ranefs=False).index
-    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
-    assert test_set == full.difference(set(['Y_sd_interval', 'u_subj_sd_log']))
-    test_set = fitted.summary(hide_transformed=False).index
-    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
-    assert test_set == full.difference(
-        set(['1|subj[{}]'.format(i) for i in range(10)]))
-
-    # test get_trace
-    test_set = fitted.get_trace().columns
-    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
-    assert test_set == full.difference(set(['Y_sd_interval', 'u_subj_sd_log'])) \
-        .difference(set(['1|subj[{}]'.format(i) for i in range(10)]))
-
-    # test plots
-    fitted.plot(kind='priors')
-    fitted.plot()
-
-
-def test_random_intercepts(crossed_data):
-    # using formula and '1|' syntax
-    model0 = Model(crossed_data)
-    model0.fit(
-        'Y ~ continuous', random=['1|subj', '1|item', '1|site'], run=False)
-    model0.build()
-    # model0.fit(samples=1)
-
-    # # using formula and 'subj' syntax
-    # model1 = Model(crossed_data)
-    # model1.fit('Y ~ continuous', random=['subj','item','site'], run=False)
-    # model1.build()
-    # # model1.fit(samples=1)
-
-    # # check that they have the same random terms
-    # assert set(model1.random_terms) == set(model0.random_terms)
-
-    # using add_term
-    model2 = Model(crossed_data)
-    model2.add_y('Y')
-    model2.add_intercept()
-    model2.add_term('continuous')
-    model2.add_term('subj', random=True, categorical=True, drop_first=False)
-    model2.add_term('item', random=True, categorical=True, drop_first=False)
-    model2.add_term('site', random=True, categorical=True, drop_first=False)
-    model2.build()
-    # model2.fit(samples=1)
-
-    # check that this has the same random terms as above
-    assert set(model0.random_terms) == set(model2.random_terms)
-
-    # check that add_formula and add_term models have same priors for fixed
-    # effects
-    priors0 = {
-        x.name: x.prior.args for x in model0.terms.values() if not x.random}
-    priors2 = {
-        x.name: x.prior.args for x in model2.terms.values() if not x.random}
-    assert set(priors0) == set(priors2)
-
-    # check that add_formula and add_term models have same priors for random
-    # effects
-    priors0 = {x.name: x.prior.args[
-        'sd'].args for x in model0.terms.values() if x.random}
-    priors2 = {x.name: x.prior.args[
-        'sd'].args for x in model2.terms.values() if x.random}
-    assert set(priors0) == set(priors2)
-
-
-def test_many_random_effects(crossed_data):
+def test_many_fixed_many_random(crossed_data):
     # build model using formula
     model0 = Model(crossed_data)
-    model0.fit('Y ~ continuous',
-               random=['0+threecats|subj', 'continuous|item', 'dummy|item',
-                       'threecats|site'], run=False)
-    model0.build()
+    fitted = model0.fit('Y ~ continuous + dummy + threecats',
+               random=['0+threecats|subj', '1|item', '0+continuous|item',
+                       'dummy|item', 'threecats|site'], samples=10)
+    # model0.build()
     # model0.fit(samples=1)
 
     # build model using add_term
@@ -405,6 +226,8 @@ def test_many_random_effects(crossed_data):
     # fixed effects
     model1.add_intercept()
     model1.add_term('continuous')
+    model1.add_term('dummy')
+    model1.add_term('threecats')
     # random effects
     model1.add_term('threecats', over='subj', drop_first=False, random=True,
                     categorical=True)
@@ -456,6 +279,67 @@ def test_many_random_effects(crossed_data):
     priors1 = {x.name: x.prior.args[
         'sd'].args for x in model1.terms.values() if x.random}
     assert set(priors0) == set(priors1)
+
+    # test consistency between summary and get_trace
+    assert len(set(fitted.get_trace().columns)) == 15
+    assert set(fitted.get_trace().columns)==set(fitted.summary().index)
+
+    # check hide_transformed
+    # it looks like some versions of pymc3 add a trailing '_' to transformed
+    # vars and some dont. so here for consistency we strip out any trailing '_'
+    # that we find
+    full = fitted.summary(exclude_ranefs=False, hide_transformed=False).index
+    full = set([re.sub(r'_$', r'', x) for x in full])
+    test_set = fitted.summary(exclude_ranefs=False).index
+    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
+    answer = {'Y_sd_interval',
+     'u_continuous|item_sd_log',
+     'u_dummy|item_sd_log',
+     'u_item_sd_log',
+     'u_site_sd_log',
+     'u_threecats|site_threecats[0]_sd_log',
+     'u_threecats|site_threecats[1]_sd_log',
+     'u_threecats|subj_threecats[0]_sd_log',
+     'u_threecats|subj_threecats[1]_sd_log',
+     'u_threecats|subj_threecats[2]_sd_log'}
+    assert full.difference(test_set) == answer
+
+    # check exclude_ranefs
+    test_set = fitted.summary(hide_transformed=False).index
+    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
+    answer = {'1|item[0]','1|item[10]','1|item[11]','1|item[1]','1|item[2]',
+        '1|item[3]','1|item[4]','1|item[5]','1|item[6]','1|item[7]','1|item[8]',
+        '1|item[9]','1|site[0]','1|site[1]','1|site[2]','1|site[3]','1|site[4]',
+        'continuous|item[0]','continuous|item[10]','continuous|item[11]',
+        'continuous|item[1]','continuous|item[2]','continuous|item[3]',
+        'continuous|item[4]','continuous|item[5]','continuous|item[6]',
+        'continuous|item[7]','continuous|item[8]','continuous|item[9]',
+        'dummy|item[0]','dummy|item[10]','dummy|item[11]','dummy|item[1]',
+        'dummy|item[2]','dummy|item[3]','dummy|item[4]','dummy|item[5]',
+        'dummy|item[6]','dummy|item[7]','dummy|item[8]','dummy|item[9]',
+        'threecats[0]|site[0]','threecats[0]|site[1]','threecats[0]|site[2]',
+        'threecats[0]|site[3]','threecats[0]|site[4]','threecats[0]|subj[0]',
+        'threecats[0]|subj[1]','threecats[0]|subj[2]','threecats[0]|subj[3]',
+        'threecats[0]|subj[4]','threecats[0]|subj[5]','threecats[0]|subj[6]',
+        'threecats[0]|subj[7]','threecats[0]|subj[8]','threecats[0]|subj[9]',
+        'threecats[1]|site[0]','threecats[1]|site[1]','threecats[1]|site[2]',
+        'threecats[1]|site[3]','threecats[1]|site[4]','threecats[1]|subj[0]',
+        'threecats[1]|subj[1]','threecats[1]|subj[2]','threecats[1]|subj[3]',
+        'threecats[1]|subj[4]','threecats[1]|subj[5]','threecats[1]|subj[6]',
+        'threecats[1]|subj[7]','threecats[1]|subj[8]','threecats[1]|subj[9]',
+        'threecats[2]|subj[0]','threecats[2]|subj[1]','threecats[2]|subj[2]',
+        'threecats[2]|subj[3]','threecats[2]|subj[4]','threecats[2]|subj[5]',
+        'threecats[2]|subj[6]','threecats[2]|subj[7]','threecats[2]|subj[8]',
+        'threecats[2]|subj[9]','u_threecats|site_threecats[0]_sd_log',
+        'u_threecats|site_threecats[1]_sd_log',
+        'u_threecats|subj_threecats[0]_sd_log',
+        'u_threecats|subj_threecats[1]_sd_log',
+        'u_threecats|subj_threecats[2]_sd_log'}
+    assert full.difference(test_set) == answer
+
+    # test plots
+    fitted.plot(kind='priors')
+    fitted.plot()
 
 
 def test_cell_means_with_many_random_effects(crossed_data):


### PR DESCRIPTION
1. Fixes a few lingering problems with parameter display names on the current master.
2. Tweaks the built_model tests to remove some redundant tests and focus instead on thoroughly testing one big model that contains almost all term types that could be encountered. (We do still test some other specialized cases separately.)
3. Extends the travis timeout limit from 10min to 20min, which is necessary with the new tests.