### PR TITLE
Update tests for pymc3 v3.1

### DIFF
--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -37,12 +37,12 @@ def test_empty_model(crossed_data):
     model0 = Model(crossed_data)
     model0.add('Y ~ 0')
     model0.build(backend='pymc3')
-    model0.fit(samples=1)
+    model0.fit(tune=0, samples=1)
 
     model1 = Model(crossed_data)
     model1.fit('Y ~ 0', run=False)
     model1.build(backend='pymc3')
-    model1.fit(samples=1)
+    model1.fit(tune=0, samples=1)
 
     # check that both models have same priors for fixed effects
     priors0 = {
@@ -57,14 +57,14 @@ def test_intercept_only_model(crossed_data):
     model0 = Model(crossed_data)
     model0.fit('Y ~ 1', run=False)
     model0.build(backend='pymc3')
-    model0.fit(samples=1, init=None)
+    model0.fit(tune=0, samples=1, init=None)
 
     # using add
     model1 = Model(crossed_data)
     model1.add('Y ~ 0')
     model1.add('1')
     model1.build(backend='pymc3')
-    model1.fit(samples=1)
+    model1.fit(tune=0, samples=1)
 
     # check that fit and add models have same priors for fixed
     # effects
@@ -80,14 +80,14 @@ def test_slope_only_model(crossed_data):
     model0 = Model(crossed_data)
     model0.fit('Y ~ 0 + continuous', run=False)
     model0.build(backend='pymc3')
-    model0.fit(samples=1, init=None)
+    model0.fit(tune=0, samples=1, init=None)
 
     # using add
     model1 = Model(crossed_data)
     model1.add('Y ~ 0')
     model1.add('0 + continuous')
     model1.build(backend='pymc3')
-    model1.fit(samples=1)
+    model1.fit(tune=0, samples=1)
 
     # check that term names agree
     assert set(model0.term_names) == set(model1.term_names)
@@ -106,14 +106,14 @@ def test_cell_means_parameterization(crossed_data):
     model0 = Model(crossed_data)
     model0.fit('Y ~ 0 + threecats', run=False)
     model0.build(backend='pymc3')
-    model0.fit(samples=1, init=None)
+    model0.fit(tune=0, samples=1, init=None)
 
     # build model using add
     model1 = Model(crossed_data)
     model1.add('Y ~ 0')
     model1.add('0 + threecats')
     model1.build(backend='pymc3')
-    model1.fit(samples=1)
+    model1.fit(tune=0, samples=1)
 
     # check that design matrices are the same,
     # even if term names / level names / order of columns is different
@@ -141,7 +141,7 @@ def test_3x4_fixed_anova(crossed_data):
     model0 = Model(crossed_data)
     model0.fit('Y ~ threecats*fourcats', run=False)
     model0.build(backend='pymc3')
-    fitted0 = model0.fit(samples=1, init=None)
+    fitted0 = model0.fit(tune=0, samples=1, init=None)
     # make sure X has 11 columns (not including the intercept)
     assert len(fitted0.diagnostics['VIF']) == 11
 
@@ -149,7 +149,7 @@ def test_3x4_fixed_anova(crossed_data):
     model1 = Model(crossed_data)
     model1.fit('Y ~ 0 + threecats*fourcats', run=False)
     model1.build(backend='pymc3')
-    fitted1 = model1.fit(samples=1)
+    fitted1 = model1.fit(tune=0, samples=1)
     # make sure X has 12 columns
     assert len(fitted1.diagnostics['VIF']) == 12
 
@@ -159,7 +159,7 @@ def test_cell_means_with_covariate(crossed_data):
     model0 = Model(crossed_data)
     model0.fit('Y ~ 0 + threecats + continuous', run=False)
     model0.build(backend='pymc3')
-    # model0.fit(samples=1)
+    # model0.fit(tune=0, samples=1)
 
     # build model using add
     model1 = Model(crossed_data)
@@ -167,7 +167,7 @@ def test_cell_means_with_covariate(crossed_data):
     model1.add('0 + threecats')
     model1.add('0 + continuous')
     model1.build(backend='pymc3')
-    # model1.fit(samples=1)
+    # model1.fit(tune=0, samples=1)
 
     # check that design matrices are the same,
     # even if term names / level names / order of columns is different
@@ -201,9 +201,9 @@ def test_many_fixed_many_random(crossed_data):
     fitted = model0.fit('Y ~ continuous + dummy + threecats',
         random=['0+threecats|subj', '1|item', '0+continuous|item', 
             'dummy|item', 'threecats|site'],
-        backend='pymc3', samples=10, chains=2)
+        backend='pymc3', init=None, tune=10, samples=10, chains=2)
     # model0.build(backend='pymc3')
-    # model0.fit(samples=1)
+    # model0.fit(tune=0, samples=1)
 
     # build model using add(append=True)
     model1 = Model(crossed_data_missing, dropna=True)
@@ -217,7 +217,7 @@ def test_many_fixed_many_random(crossed_data):
     model1.add(random='dummy|item')
     model1.add(random='threecats|site')
     model1.build(backend='pymc3')
-    # model1.fit(samples=1)
+    # model1.fit(tune=0, samples=1)
 
     # build model using stan backend
     model2 = Model(crossed_data_missing, dropna=True)
@@ -323,9 +323,9 @@ def test_many_fixed_many_random(crossed_data):
     # vars and some dont. so here for consistency we strip out any trailing '_'
     # that we find
     full = fitted.summary(ranefs=True, transformed=True).index
-    full = set([re.sub(r'_$', r'', x) for x in full])
+    full = set([re.sub(r'_+$', r'', x) for x in full])
     test_set = fitted.summary(ranefs=True, transformed=False).index
-    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
+    test_set = set([re.sub(r'_+$', r'', x) for x in test_set])
     answer = {'1|item_offset[0]','1|item_offset[10]','1|item_offset[11]',
         '1|item_offset[1]','1|item_offset[2]','1|item_offset[3]',
         '1|item_offset[4]','1|item_offset[5]','1|item_offset[6]',
@@ -422,7 +422,7 @@ def test_many_fixed_many_random(crossed_data):
 
     # check exclude_ranefs for pymc3
     test_set = fitted.summary(ranefs=False, transformed=True).index
-    test_set = set([re.sub(r'_$', r'', x) for x in test_set])
+    test_set = set([re.sub(r'_+$', r'', x) for x in test_set])
     answer = {'1|item[0]','1|item[10]','1|item[11]','1|item[1]','1|item[2]',
         '1|item[3]','1|item[4]','1|item[5]','1|item[6]','1|item[7]','1|item[8]',
         '1|item[9]','1|item_offset[0]','1|item_offset[10]','1|item_offset[11]',
@@ -571,7 +571,7 @@ def test_cell_means_with_many_random_effects(crossed_data):
                random=['0+threecats|subj', 'continuous|item', 'dummy|item',
                        'threecats|site'], run=False)
     model0.build(backend='pymc3')
-    # model0.fit(samples=1)
+    # model0.fit(tune=0, samples=1)
 
     # build model using add(append=True)
     model1 = Model(crossed_data)
@@ -583,7 +583,7 @@ def test_cell_means_with_many_random_effects(crossed_data):
     model1.add(random='dummy|item')
     model1.add(random='threecats|site')
     model1.build(backend='pymc3')
-    # model1.fit(samples=1)
+    # model1.fit(tune=0, samples=1)
 
     # check that the random effects design matrices have the same shape
     X0 = pd.concat([pd.DataFrame(t.data) if not isinstance(t.data, dict) else
@@ -632,7 +632,7 @@ def test_logistic_regression(crossed_data):
     model0 = Model(crossed_data)
     fitted = model0.fit('threecats[b] ~ continuous + dummy',
                family='bernoulli', link='logit',
-               backend='pymc3', samples=100)
+               backend='pymc3', tune=0, samples=100)
     # model0.build()
     # fitted = model0.fit()
 
@@ -642,7 +642,7 @@ def test_logistic_regression(crossed_data):
     model1.add('continuous')
     model1.add('dummy')
     model1.build(backend='pymc3')
-    model1.fit(samples=1)
+    model1.fit(tune=0, samples=1)
 
     # build model using fit and stan
     model2 = Model(crossed_data)
@@ -699,7 +699,7 @@ def test_poisson_regression(crossed_data):
     crossed_data['count'] = (crossed_data['Y'] - crossed_data['Y'].min()).round()
     model0 = Model(crossed_data)
     fitted = model0.fit('count ~ threecats + continuous + dummy',
-        family='poisson', backend='pymc3', samples=1, init=None)
+        family='poisson', backend='pymc3', tune=0, samples=1, init=None)
     # model0.build()
     # model0.fit()
 
@@ -710,7 +710,7 @@ def test_poisson_regression(crossed_data):
     model1.add('continuous')
     model1.add('dummy')
     model1.build(backend='pymc3')
-    model1.fit(samples=1, init=None)
+    model1.fit(tune=0, samples=1, init=None)
 
     # build model using fit and stan
     model2 = Model(crossed_data)


### PR DESCRIPTION
As of pymc3 v3.1, hidden/internal params now have 2 (not 1) trailing underscores and thus our tests need to be adjusted accordingly; and 500 burn-in samples are now added by `pm.sample()` by default unless explicitly suppressed, which our tests now do (for speed).