### PR TITLE
Improved custom priors

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ my_favorite_prior = Prior('Laplace', mu=0., b=10)
 
 # Set the prior when adding a term to the model;
 # more details on this below.
-priors = {'subject': my_favorite_prior}
+priors = {'1|subject': my_favorite_prior}
 results = model.fit('y ~ condition', random='1|subject', priors=priors)
 ```
 
@@ -293,7 +293,7 @@ Priors specified using the `Prior` class can be nested to arbitrary depths--mean
 ```python
 subject_sd = Prior('HalfCauchy', beta=5)
 subject_prior = Prior('Normal', mu=0, sd=subject_sd)
-priors = {'subject': my_favorite_prior}
+priors = {'1|subject': my_favorite_prior}
 results = model.fit('y ~ condition', random='1|subject', priors=priors)
 ```
 

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -61,9 +61,8 @@ class Prior(object):
         '''
         # Backends expect numpy arrays, so make sure all numeric values are
         # represented as such.
-        for k, v in kwargs.items():
-            kwargs = {k: (np.array(v) if isinstance(v, (int, float)) else v)
-                      for k, v in kwargs.items()}
+        kwargs = {k: (np.array(v) if isinstance(v, (int, float)) else v)
+                  for k, v in kwargs.items()}
         self.args.update(kwargs)
 
 

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -59,6 +59,11 @@ class Prior(object):
         Args:
             kwargs (dict): Optional keyword arguments to add to prior args.
         '''
+        # Backends expect numpy arrays, so make sure all numeric values are
+        # represented as such.
+        for k, v in kwargs.items():
+            kwargs = {k: (np.array(v) if isinstance(v, (int, float)) else v)
+                      for k, v in kwargs.items()}
         self.args.update(kwargs)
 
 


### PR DESCRIPTION
This PR makes minor changes related to prior handling:
* Fixes a problem where specifying a named custom prior causes model-fitting to break because some arguments are internally stored as numeric values instead of numpy arrays;
* Simplifies the processing of priors; instead of scattering `_prepare_prior` calls in several places, they're now consolidated into one call that only happens during the build;
* Fixes a minor error in the README.