### PR TITLE
fixes Poisson link function; closes #111

### DIFF
--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -22,7 +22,8 @@ class PyMC3BackEnd(BackEnd):
         'identity': lambda x: x,
         'logit': theano.tensor.nnet.sigmoid,
         'inverse': theano.tensor.inv,
-        'log': theano.tensor.log
+        'log': theano.tensor.log,
+        'exp': theano.tensor.exp
     }
 
     dists = {

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -22,8 +22,8 @@ class PyMC3BackEnd(BackEnd):
         'identity': lambda x: x,
         'logit': theano.tensor.nnet.sigmoid,
         'inverse': theano.tensor.inv,
-        'log': theano.tensor.log,
-        'exp': theano.tensor.exp
+        'inverse_squared': lambda x: theano.tensor.inv(theano.tensor.sqrt(x)),
+        'log': theano.tensor.exp
     }
 
     dists = {
@@ -108,8 +108,7 @@ class PyMC3BackEnd(BackEnd):
             y = spec.y.data
             y_prior = spec.family.prior
             link_f = spec.family.link
-            if not callable(link_f):
-                link_f = self.links[link_f]
+            link_f = self.links[link_f]
             y_prior.args[spec.family.parent] = link_f(self.mu)
             y_prior.args['observed'] = y
             y_like = self._build_dist(spec, spec.y.name, y_prior.name,
@@ -126,7 +125,8 @@ class PyMC3BackEnd(BackEnd):
             - set(trans)
         # add any "centered" random effects to the list
         for varname in [var.name for var in rvs]:
-            if re.search(r'_offset$', varname) is not None: trans.add(varname)
+            if re.search(r'_offset$', varname) is not None:
+                trans.add(varname)
 
         return trans
 

--- a/bambi/backends/stan.py
+++ b/bambi/backends/stan.py
@@ -50,7 +50,8 @@ class StanBackEnd(BackEnd):
     links = {
         'identity': '',
         'logit': 'inv_logit',
-        'log': 'exp'
+        'log': 'exp',
+        'inverse_squared': 'inv_sqrt'
     }
 
     def __init__(self):
@@ -193,8 +194,6 @@ class StanBackEnd(BackEnd):
 
             var_name = _sanitize_name(name)
 
-            # self.parameters.append('%s%s %s;' % (stan_par, _bounds, var_name))
-
             # non-centered parameterization
             if spec.noncentered and 'sd' in kwargs and \
                     isinstance(kwargs['sd'], string_types):
@@ -306,7 +305,7 @@ class StanBackEnd(BackEnd):
     def _convert_to_results(self):
         # grab samples as big, unlabelled array
         # dimensions 0, 1, 2 = samples, chains, variables
-        data = self.fit.extract(permuted=False, inc_warmup=True)     
+        data = self.fit.extract(permuted=False, inc_warmup=True)
 
         # grab info necessary for making samplearray pretty
         names = [self._original_names[x] \

--- a/bambi/config/priors.json
+++ b/bambi/config/priors.json
@@ -45,7 +45,7 @@
           "mu": "#halfcauchy"
         }
       ],
-      "link": "exp",
+      "link": "log",
       "parent": "mu"
     },
     "t": {

--- a/bambi/config/priors.json
+++ b/bambi/config/priors.json
@@ -45,7 +45,7 @@
           "mu": "#halfcauchy"
         }
       ],
-      "link": "log",
+      "link": "exp",
       "parent": "mu"
     },
     "t": {


### PR DESCRIPTION
Fixes the link function for the Poisson family (now uses exp instead of log). See #111 for details.