### PR TITLE
Adding non-optional argument to kdeplot_op

### DIFF
--- a/bambi/results.py
+++ b/bambi/results.py
@@ -196,7 +196,7 @@ class MCMCResults(ModelResults):
             axes[row, 0].set_title(title)
             if pma is not None:
                 arr = np.atleast_2d(data.values.T).T
-                pma.kdeplot_op(axes[row, 0], arr)
+                pma.kdeplot_op(axes[row, 0], arr, bw = 4.5)
             else:
                 data.plot(kind='kde', ax=axes[row, 0], legend=False)
 


### PR DESCRIPTION
Fixed plotting issue by adding default bw=4.5 to kdeplot_op function as proposed by @djmannion in issue #120