### PR TITLE
Ordering of variables in plot()

### DIFF
--- a/bambi/results.py
+++ b/bambi/results.py
@@ -164,6 +164,13 @@ class MCMCResults(ModelResults):
         if not ranefs:
             names = [x for x in names if re.sub(r'_offset$', '', x)
                      not in self.model.random_terms]
+        Intercept = [n for n in names if "Intercept" in n]
+        std = [n for n in names if "_" in n]
+        rand_eff = [n for n in names if "|" in n and n not in std]
+        interac = [n for n in names if ":" in n and n not in rand_eff + std]
+        main_eff = [n for n in names if n not in interac + std + rand_eff + Intercept]
+        names = Intercept + sorted(main_eff, key=len) + sorted(interac, key=len) \
+            + sorted(rand_eff, key=len) + sorted(std, key=len)
         return names
 
     def plot(self, varnames=None, ranefs=True, transformed=False,


### PR DESCRIPTION
Following suggestion #114 Added a simple re-ordering code to produce an easier to read plot output. Order is defined as follow : Intercept, main effects, interactions, random effects and sd. Within a subcategory all names are ordered with length of the name.
Would be nice to apply to the summary output but I did not find a quick way to do it.