### PR TITLE
Reorder requirements; Add matplotlib to requirements.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=4.3.1
+matplotlib>=2.2.4
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-matplotlib>=2.2.4
 numpy
 pandas>=0.18.0
 patsy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+matplotlib>=2.2.4
 numpy
 pandas>=0.18.0
 patsy
 pymc3>=3.6
-statsmodels
 pystan>=2.18.0.0
+statsmodels


### PR DESCRIPTION
Tests require matplotlib

I was not sure if python2.7 is still supported, and so I floored the requirement at `2.2.4` so that it would work with python3 as well. 