### PR TITLE
Fix test warnings

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -20,7 +20,7 @@ class Model(object):
     Args:
         data (DataFrame, str): the dataset to use. Either a pandas
             DataFrame, or the name of the file containing the data, which
-            will be passed to pd.read_table().
+            will be passed to pd.read_csv().
         default_priors (dict, str): An optional specification of the
             default priors to use for all model terms. Either a dict
             containing named distributions, families, and terms (see the
@@ -49,7 +49,7 @@ class Model(object):
                  dropna=False, taylor=None, noncentered=True):
 
         if isinstance(data, string_types):
-            data = pd.read_table(data, sep=None)
+            data = pd.read_csv(data, sep=None, engine="python")
 
         self.default_priors = PriorFactory(default_priors)
 

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -241,9 +241,17 @@ class PriorScaler(object):
         # c: intercept, d: shift parameter
         # a: quartic coefficient, b: quadratic coefficient
         c, d = ll[-1], -np.asscalar(full_mod.params[i])
-        X = np.matrix([(values+d)**4,
+        X = np.array([(values+d)**4,
                        (values+d)**2]).T
-        a, b = np.squeeze((np.linalg.inv(X.T * X) * X.T * (ll[:, None] - c)).A)
+        a, b = np.squeeze(
+            np.dot(
+                np.dot(
+                    np.linalg.inv(np.dot(X.T, X)),
+                    X.T
+                ), 
+                (ll[:, None] - c)
+            )
+        )
 
         # m, v: mean and variance of beta distribution of correlations
         # p, q: corresponding shape parameters of beta distribution

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -131,12 +131,12 @@ class PriorFactory(object):
     def _get_prior(self, spec, **kwargs):
 
         if isinstance(spec, string_types):
-            spec = re.sub('^\#', '', spec)
+            spec = re.sub(r'^\#', '', spec)
             return self._get_prior(self.dists[spec])
         elif isinstance(spec, (list, tuple)):
             name, args = spec
             if name.startswith('#'):
-                name = re.sub('^\#', '', name)
+                name = re.sub(r'^\#', '', name)
                 prior = self._get_prior(self.dists[name])
             else:
                 prior = Prior(name, **kwargs)

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -240,17 +240,15 @@ class PriorScaler(object):
         # compute params of quartic approximatino to log-likelihood
         # c: intercept, d: shift parameter
         # a: quartic coefficient, b: quadratic coefficient
-        c, d = ll[-1], -np.asscalar(full_mod.params[i])
+        c, d = ll[-1], -(full_mod.params[i].item())
         X = np.array([(values+d)**4,
                        (values+d)**2]).T
         a, b = np.squeeze(
-            np.dot(
-                np.dot(
-                    np.linalg.inv(np.dot(X.T, X)),
-                    X.T
-                ), 
+            np.linalg.multi_dot([
+                np.linalg.inv(np.dot(X.T, X)),
+                X.T,
                 (ll[:, None] - c)
-            )
+            ])
         )
 
         # m, v: mean and variance of beta distribution of correlations

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -3,9 +3,7 @@ from bambi.models import Term, Model
 from bambi.priors import Prior
 import pandas as pd
 import numpy as np
-import matplotlib
 import re
-matplotlib.use('Agg')
 
 
 @pytest.fixture(scope="module")
@@ -199,7 +197,7 @@ def test_many_fixed_many_random(crossed_data):
     # build model using fit
     model0 = Model(crossed_data_missing, dropna=True)
     fitted = model0.fit('Y ~ continuous + dummy + threecats',
-        random=['0+threecats|subj', '1|item', '0+continuous|item', 
+        random=['0+threecats|subj', '1|item', '0+continuous|item',
             'dummy|item', 'threecats|site'],
         backend='pymc3', init=None, tune=10, samples=10, chains=2)
     # model0.build(backend='pymc3')

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -12,8 +12,8 @@ def diabetes_data():
     data_dir = join(dirname(__file__), 'data')
     data = pd.read_csv(join(data_dir, 'diabetes.txt'), sep='\t')
     data['age_grp'] = 0
-    data['age_grp'][data['AGE'] > 40] = 1
-    data['age_grp'][data['AGE'] > 60] = 2
+    data.loc[data['AGE'] > 40, 'age_grp'] = 1
+    data.loc[data['AGE'] > 60, 'age_grp'] = 2
     return data
 
 

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -2,8 +2,6 @@ import pytest
 from os.path import dirname, join
 import pandas as pd
 import numpy as np
-import matplotlib
-matplotlib.use('Agg')
 from bambi.models import Term, Model
 
 

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -12,8 +12,8 @@ def diabetes_data():
     data_dir = join(dirname(__file__), 'data')
     data = pd.read_csv(join(data_dir, 'diabetes.txt'), sep='\t')
     data['age_grp'] = 0
-    data['age_grp'][data['AGE'] > 40] = 1
-    data['age_grp'][data['AGE'] > 60] = 2
+    data.loc[data['AGE'] > 40, 'age_grp'] = 1
+    data.loc[data['AGE'] > 60, 'age_grp'] = 2
     return data
 
 


### PR DESCRIPTION
Received deprecation warnings when running tests in python2.7 and python 3.6

* deprecated `pd.read_table` -> `pd.read_csv`
* deprecated `np.asscalar` -> `np.ndarray.item`
* deprecated `np.matrix` -> `np.array`
* pandas slicing warning `df["a" > 40]["b"]` -> `df.loc["a"  > 40, "b"]
* seemingly unnecessary `matplotlib` import

The unaddressed, but fixable, deprecation warning is from `re`

```
DeprecationWarning: invalid escape sequence \#
    name = re.sub('^\#', '', name)
```

Do you have any thoughts on how to resolve this?