### PR TITLE
remove from __future__ import absolute_import

### DIFF
--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 from collections import OrderedDict
 

--- a/bambi/backends/stan.py
+++ b/bambi/backends/stan.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 
 from six import string_types

--- a/bambi/external/patsy.py
+++ b/bambi/external/patsy.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import numpy as np
 import re
 from patsy.util import safe_scalar_isnan

--- a/bambi/external/six.py
+++ b/bambi/external/six.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import absolute_import
-
 import functools
 import itertools
 import operator


### PR DESCRIPTION
Since we moved to python3 we don't need this anymore