### PR TITLE
Fix double uppercase letters in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-BAyesian Model-Building Interface (Bambi) in Python
+Bayesian Model-Building Interface (Bambi) in Python
 ===================================================
 |Build|
 |Coverage|


### PR DESCRIPTION
Not sure if this is intentional or not -- feel free to close if it was intentional.