### PR TITLE
Add prior predictive sampling

### DIFF
--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -103,7 +103,6 @@ class PyMC3BackEnd(BackEnd):
             y = spec.y.data
             y_prior = spec.family.prior
             link_f = spec.family.link
-
             if isinstance(link_f, str):
                 link_f = self.links[link_f]
             y_prior.args[spec.family.parent] = link_f(self.mu)

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -48,7 +48,6 @@ class PyMC3BackEnd(BackEnd):
                 raise ValueError(
                     f"The Distribution {dist} was not found in PyMC3 or the PyMC3BackEnd."
                 )
-
         # Inspect all args in case we have hyperparameters
         def _expand_args(key, value, label):
             if isinstance(value, Prior):
@@ -86,17 +85,16 @@ class PyMC3BackEnd(BackEnd):
 
         with self.model:
             self.mu = 0.0
-
             for t in spec.terms.values():
                 data = t.data
                 label = t.name
                 dist_name = t.prior.name
                 dist_args = t.prior.args
+                dist_shape = t.data.shape[1]
+                if dist_shape == 1:
+                    dist_shape = ()
 
-                n_cols = t.data.shape[1]
-
-                coef = self._build_dist(spec, label, dist_name, shape=n_cols, **dist_args)
-
+                coef = self._build_dist(spec, label, dist_name, shape=dist_shape, **dist_args)
                 if t.random:
                     self.mu += coef[t.group_index][:, None] * t.predictor
                 else:
@@ -108,7 +106,6 @@ class PyMC3BackEnd(BackEnd):
 
             if isinstance(link_f, str):
                 link_f = self.links[link_f]
-
             y_prior.args[spec.family.parent] = link_f(self.mu)
             y_prior.args["observed"] = y
             self._build_dist(spec, spec.y.name, y_prior.name, **y_prior.args)

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -757,8 +757,8 @@ class Model:
         Returns
         -------
         dict or InferenceData
-            Dictionary with variable names as keys or InferenceData object with a prior and prior predictive
-            groups.
+            Dictionary with variable names as keys or InferenceData object with a
+            prior and prior predictive groups.
         """
         if var_names is None:
             variables = self.backend.model.unobserved_RVs + self.backend.model.observed_RVs
@@ -774,7 +774,7 @@ class Model:
 
         if idata is not None:
             if not isinstance(idata, InferenceData):
-                raise (TypeError, "idata must be an InferenceData object")
+                raise TypeError("idata must be an InferenceData object")
             idata.add_groups(
                 {"prior_predictive": {y_name: np.moveaxis(pps.pop(y_name), 2, 0)}, "prior": pps}
             )

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -72,14 +72,14 @@ class Prior:
                 Optional keyword arguments to add to prior args.
         """
         # Backends expect numpy arrays, so make sure all numeric values are represented as such.
-        kwargs = {}
+        kwargs_ = {}
         for key, val in kwargs.items():
             if isinstance(val, (int, float)):
                 val = np.array(val)
             elif isinstance(val, np.ndarray):
                 val = val.squeeze()
-            kwargs[key] = val
-        self.args.update(kwargs)
+            kwargs_[key] = val
+        self.args.update(kwargs_)
 
 
 class PriorFactory:

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -73,12 +73,12 @@ class Prior:
         """
         # Backends expect numpy arrays, so make sure all numeric values are represented as such.
         kwargs = {}
-        for k, v in kwargs.items():
-            if isinstance(v, (int, float)):
-                v = np.array(v)
-            elif isinstance(v, np.ndarray):
-                v = v.squeeze()
-            kwargs["k"] = v
+        for key, val in kwargs.items():
+            if isinstance(val, (int, float)):
+                val = np.array(val)
+            elif isinstance(val, np.ndarray):
+                val = val.squeeze()
+            kwargs[key] = val
         self.args.update(kwargs)
 
 

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -72,7 +72,13 @@ class Prior:
                 Optional keyword arguments to add to prior args.
         """
         # Backends expect numpy arrays, so make sure all numeric values are represented as such.
-        kwargs = {k: (np.array(v) if isinstance(v, (int, float)) else v) for k, v in kwargs.items()}
+        kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, (int, float)):
+                v = np.array(v)
+            elif isinstance(v, np.ndarray):
+                v = v.squeeze()
+            kwargs["k"] = v
         self.args.update(kwargs)
 
 

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -174,7 +174,7 @@ def test_cell_means_with_covariate(crossed_data):
     assert X0 == X1
 
     # check that threecats priors have finite variance
-    assert not any(np.isinf(model0.terms["threecats"].prior.args["sigma"]))
+    assert not np.isinf(model0.terms["threecats"].prior.args["sigma"])
 
     # check that fit and add models have same priors for fixed
     # effects

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -107,7 +107,7 @@ def test_update_term_priors_after_init(diabetes_data):
     model.build(backend="pymc")
     assert model.terms["S1"].prior.args["beta"] == 2
     assert model.terms["BMI"].prior.scale == 0.3
-    assert np.isclose(model.terms["BMI"].prior.args["sigma"], 4.7, rtol=0.1)[0]
+    assert np.isclose(model.terms["BMI"].prior.args["sigma"], 4.7, rtol=0.1)
 
     model.set_priors({("S1", "BMI"): p1})
     model.build(backend="pymc")
@@ -118,7 +118,7 @@ def test_update_term_priors_after_init(diabetes_data):
     model.set_priors(fixed=0.3, random=p3)
     model.build(backend="pymc")
     assert model.terms["BMI"].prior.scale == 0.3
-    assert np.isclose(model.terms["BMI"].prior.args["sigma"], 4.7, rtol=0.1)[0]
+    assert np.isclose(model.terms["BMI"].prior.args["sigma"], 4.7, rtol=0.1)
     assert model.terms["age_grp|BP"].prior.args["sigma"].args["sigma"] == 7
 
     # Invalid names should raise error


### PR DESCRIPTION
Fix #211

add `prior_predictive` method to Bambi's model. The method will return an InferenceData object with the groups, prior, prior_predictive and observed_data. This method will also be called when running  `plot_priors`.
