### PR TITLE
Change 'start_params' to 'None' in GLM.fit_constrained() call used to get automatic priors

### DIFF
--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -249,7 +249,7 @@ class PriorScaler:
                 GLM(
                     endog=self.model.y.data, exog=exog, family=self.model.family.smfamily()
                 ).fit_constrained(
-                    str(exog.columns[i]) + "=" + str(val), start_params=full_mod.params.values
+                    str(exog.columns[i]) + "=" + str(val), start_params=None
                 )
                 for val in values[:-1]
             ]

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,9 +4,9 @@ Examples
 .. toctree::
   :maxdepth: 1
 
-  notebooks/bayesian_logistic_regression
-  notebooks/bayesian_multi-level_regression
-  notebooks/bayesian_t-test
+  notebooks/logistic_regression
+  notebooks/multi-level_regression
+  notebooks/t-test
   notebooks/ESCS_multiple_regression
   notebooks/shooter_crossed_random_ANOVA
   notebooks/Strack_RRR_re_analysis

--- a/docs/notebooks/ESCS_multiple_regression.ipynb
+++ b/docs/notebooks/ESCS_multiple_regression.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian Multiple Regression Example"
+    "# Multiple Regression"
    ]
   },
   {
@@ -1669,7 +1669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/Strack_RRR_re_analysis.ipynb
+++ b/docs/notebooks/Strack_RRR_re_analysis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian Workflow Example (Strack RRR Analysis Replication)"
+    "# Bayesian workflow (Strack RRR Analysis Replication)"
    ]
   },
   {
@@ -851,7 +851,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/Strack_RRR_re_analysis.ipynb
+++ b/docs/notebooks/Strack_RRR_re_analysis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian workflow (Strack RRR Analysis Replication)"
+    "# Bayesian Workflow (Strack RRR Analysis Replication)"
    ]
   },
   {

--- a/docs/notebooks/logistic_regression.ipynb
+++ b/docs/notebooks/logistic_regression.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian Logistic Regression Example"
+    "# Logistic Regression"
    ]
   },
   {
@@ -1075,7 +1075,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/multi-level_regression.ipynb
+++ b/docs/notebooks/multi-level_regression.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian Multi-level Regression"
+    "# Multi-level Regression"
    ]
   },
   {

--- a/docs/notebooks/t-test.ipynb
+++ b/docs/notebooks/t-test.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bayesian T-test"
+    "# T-test"
    ]
   },
   {


### PR DESCRIPTION
As mentioned in https://github.com/bambinos/bambi/issues/230#issuecomment-720718643, using `start_params` equal to unconstrained MLE was causing the following error from statsmodels
```
ValueError: The first guess on the deviance function returned a nan.  This could be a boundary  problem and should be reported.
```
This error was also reported in https://github.com/bambinos/bambi/issues/164