### PR TITLE
Change start_params to None in call to GLM.fit_constrained used to get automatic priors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 * Include missing files for sdist (#204)
 * Fixed if-else comparison that prevented HalfTStudent prior from being used (#205)
 * Sidestep plotting flat priors in `plot_priors()` (#258)
+* GLM.fit_constrained in automatic priors now uses start_params = None (#265)
 
 ### Documentation
 * Update example notebooks (#232)

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -248,7 +248,7 @@ class PriorScaler:
             null = [
                 GLM(
                     endog=self.model.y.data, exog=exog, family=self.model.family.smfamily()
-                ).fit_constrained(str(exog.columns[i]) + "=" + str(val), start_params=None)
+                ).fit_constrained(str(exog.columns[i]) + "=" + str(val))
                 for val in values[:-1]
             ]
             null = np.append(null, full_mod)

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -249,7 +249,7 @@ class PriorScaler:
                 GLM(
                     endog=self.model.y.data, exog=exog, family=self.model.family.smfamily()
                 ).fit_constrained(
-                    str(exog.columns[i]) + "=" + str(val), start_params=full_mod.params.values
+                    str(exog.columns[i]) + "=" + str(val), start_params=None
                 )
                 for val in values[:-1]
             ]

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -248,9 +248,7 @@ class PriorScaler:
             null = [
                 GLM(
                     endog=self.model.y.data, exog=exog, family=self.model.family.smfamily()
-                ).fit_constrained(
-                    str(exog.columns[i]) + "=" + str(val), start_params=None
-                )
+                ).fit_constrained(str(exog.columns[i]) + "=" + str(val), start_params=None)
                 for val in values[:-1]
             ]
             null = np.append(null, full_mod)


### PR DESCRIPTION
As mentioned in https://github.com/bambinos/bambi/issues/230#issuecomment-720718643, using start_params equal to unconstrained MLE was causing the following error from statsmodels

`ValueError: The first guess on the deviance function returned a nan.  This could be a boundary  problem and should be reported.`

This error was also reported in #164
