### PR TITLE
Omits ploting group-level effects and offset variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 * GLM.fit_constrained in automatic priors now uses start_params = None (#265)
 * Categorical `Term` within `Model` now have `Term.categorical` equal to `True`(#269)
 * Use logging instead of warnings (#270)
+* Omits ploting group-level effects and offset variables (#276)
 
 ### Documentation
 * Update example notebooks (#232)

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -155,6 +155,10 @@ class PyMC3BackEnd(BackEnd):
                 self.trace = pm.sample(draws, start=start, init=init, n_init=n_init, **kwargs)
 
             idata = from_pymc3(self.trace, model=model)
+
+            offset_dims = [vn for vn in idata.posterior.dims if "offset" in vn]
+            idata.posterior = idata.posterior.drop_dims(offset_dims)
+
             for group in idata.groups():
                 idata[group].attrs["modeling_interface"] = "bambi"
                 idata[group].attrs["modeling_interface_version"] = version.__version__


### PR DESCRIPTION
This partially address #275. Additionally, this also removes the offset variables from the posterior.