### PR TITLE
Refactor how variables are added to the model object

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 * Categorical `Term` within `Model` now have `Term.categorical` equal to `True`(#269)
 * Use logging instead of warnings (#270)
 * Omits ploting group-level effects and offset variables (#276)
+* Logistic regression works with no explicit index (#277)
 
 ### Documentation
 * Update example notebooks (#232)

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -27,8 +27,6 @@ class PyMC3BackEnd(BackEnd):
     dists = {"HalfFlat": pm.Bound(pm.Flat, lower=0)}
 
     def __init__(self):
-        # self.reset()
-
         self.name = pm.__name__
         self.version = pm.__version__
 

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -27,22 +27,17 @@ class PyMC3BackEnd(BackEnd):
     dists = {"HalfFlat": pm.Bound(pm.Flat, lower=0)}
 
     def __init__(self):
-        self.reset()
+        # self.reset()
 
         self.name = pm.__name__
         self.version = pm.__version__
 
         # Attributes defined elsewhere
+        self.model = None
         self.mu = None  # build()
         self.spec = None  # build()
         self.trace = None  # build()
         self.advi_params = None  # build()
-
-    def reset(self):
-        """Reset PyMC3 model and all tracked distributions and parameters."""
-        self.model = pm.Model()
-        self.mu = None
-        self.par_groups = {}
 
     def _build_dist(self, spec, label, dist, **kwargs):
         """Build and return a PyMC3 Distribution."""
@@ -77,18 +72,17 @@ class PyMC3BackEnd(BackEnd):
 
         return dist(label, **kwargs)
 
-    def build(self, spec, reset=True):  # pylint: disable=arguments-differ
+    def build(self, spec):  # pylint: disable=arguments-differ
         """Compile the PyMC3 model from an abstract model specification.
 
         Parameters
         ----------
         spec : Bambi model
             A Bambi Model instance containing the abstract specification of the model to compile.
-        reset : Bool
-            If True (default), resets the PyMC3BackEnd instance before compiling.
         """
-        if reset:
-            self.reset()
+
+        coords = spec._get_pymc_coords()  # pylint: disable=protected-access
+        self.model = pm.Model(coords=coords)
 
         with self.model:
             self.mu = 0.0

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -17,7 +17,7 @@ import bambi.version as version
 from .backends import PyMC3BackEnd
 from .external.patsy import Custom_NA
 from .priors import Prior, PriorFactory, PriorScaler
-from .utils import listify
+from .utils import listify, get_bernoulli_data
 
 _log = logging.getLogger("bambi")
 
@@ -178,8 +178,7 @@ class Model:
         if backend is None:
             if self._backend_name is None:
                 raise ValueError(
-                    "Error: no backend was passed or set in the "
-                    "Model; did you forget to call fit()?"
+                    "No backend was passed or set in the Model; did you forget to call fit()?"
                 )
             backend = self._backend_name
 
@@ -200,7 +199,6 @@ class Model:
 
             x_matrix = [pd.DataFrame(x.data, columns=x.levels) for x in terms]
             x_matrix = pd.concat(x_matrix, axis=1)
-
             self.dm_statistics = {
                 "r2_x": pd.Series(
                     {
@@ -462,125 +460,14 @@ class Model:
             data[cats] = data[cats].apply(lambda x: x.astype("category"))
 
         if fixed is not None:
-            if "~" in fixed:
-                # check to see if formula is using the 'y[event] ~ x' syntax
-                # (for bernoulli models). If so, chop it into groups:
-                # 1 = 'y[event]', 2 = 'y', 3 = 'event', 4 = 'x'
-                # If this syntax is not being used, event = None
-                event = re.match(r"^((\S+)\[(\S+)\])\s*~(.*)$", fixed)
-                if event is not None:
-                    fixed = "{}~{}".format(event.group(2), event.group(4))
-                y_vector, x_matrix = dmatrices(fixed, data=data, NA_action="raise")
-                y_label = y_vector.design_info.term_names[0]
-                if event is not None:
-                    # pass in new Y data that has 1 if y=event and 0 otherwise
-                    y_data = y_vector[:, y_vector.design_info.column_names.index(event.group(1))]
-                    y_data = pd.DataFrame({event.group(3): y_data})
-                    self._add_y(y_label, family=family, link=link, data=y_data)
-                else:
-                    # use Y as-is
-                    self._add_y(y_label, family=family, link=link)
-            else:
-                x_matrix = dmatrix(fixed, data=data, NA_action="raise")
+            print(fixed)
+            self._add_fixed(fixed, data, family, link, priors)
 
-            factor_infos = x_matrix.design_info.factor_infos
-
-            # Loop over predictor terms
-            for _name, _slice in x_matrix.design_info.term_name_slices.items():
-                cols = x_matrix.design_info.column_names[_slice]
-                term_data = pd.DataFrame(np.asfortranarray(x_matrix[:, _slice]), columns=cols)
-
-                if EvalFactor(_name) in factor_infos:
-                    categorical = factor_infos[EvalFactor(_name)].type == "categorical"
-                else:
-                    categorical = False
-                prior = priors.pop(_name, priors.get("fixed", None))
-                self.terms[_name] = Term(_name, term_data, categorical=categorical, prior=prior)
-
-        # Random effects
-        if random is not None:  # pylint: disable=too-many-nested-blocks
-
-            random = listify(random)
-            for random_effect in random:
-
-                random_effect = random_effect.strip()
-
-                # Split specification into intercept, predictor, and grouper
-                patt = r"^([01]+)*[\s\+]*([^\|]+)*\|(.*)"
-
-                intcpt, pred, grpr = re.search(patt, random_effect).groups()
-                label = "{}|{}".format(pred, grpr) if pred else grpr
-                prior = priors.pop(label, priors.get("random", None))
-
-                # Treat all grouping variables as categoricals, regardless of
-                # their dtype and what the user may have specified in the
-                # 'categorical' argument.
-                var_names = re.findall(r"(\w+)", grpr)
-                for var_name in var_names:
-                    if var_name in data.columns:
-                        data.loc[:, var_name] = data.loc[:, var_name].astype("category")
-                        self.clean_data.loc[:, var_name] = data.loc[:, var_name]
-
-                # Default to including random intercepts
-                intcpt = 1 if intcpt is None else int(intcpt)
-
-                grpr_df = dmatrix(f"0+{grpr}", data, return_type="dataframe", NA_action="raise")
-
-                # If there's no predictor, we must be adding random intercepts
-                if not pred and grpr not in self.terms:
-                    name = "1|" + grpr
-                    pred = np.ones((len(grpr_df), 1))
-                    term = RandomTerm(
-                        name, grpr_df, pred, grpr_df.values, categorical=True, prior=prior
-                    )
-                    self.terms[name] = term
-                else:
-                    pred_df = dmatrix(
-                        f"{intcpt}+{pred}", data, return_type="dataframe", NA_action="raise"
-                    )
-                    # determine value of the 'constant' attribute
-                    const = np.atleast_2d(pred_df.T).T.sum(1).var() == 0
-
-                    factor_infos = pred_df.design_info.factor_infos
-
-                    for col, i in pred_df.design_info.column_name_indexes.items():
-                        pred_data = pred_df.iloc[:, i]
-                        lev_data = grpr_df.multiply(pred_data, axis=0)
-
-                        # Also rename intercepts and skip if already added.
-                        # This can happen if user specifies something like
-                        # random=['1|school', 'student|school'].
-                        if col == "Intercept":
-                            if grpr in self.terms:
-                                continue
-                            label = f"1|{grpr}"
-                        else:
-                            label = col + "|" + grpr
-
-                        # Delete everything between brackets and the brackets
-                        col = re.sub(r"\[.*?\]\ *", "", col)
-                        if EvalFactor(col) in factor_infos:
-                            categorical = factor_infos[EvalFactor(col)].type == "categorical"
-                        else:
-                            categorical = False
-
-                        prior = priors.pop(label, priors.get("random", None))
-
-                        pred_data = pred_data.to_numpy()
-                        pred_data = pred_data[:, None]  # Must be 2D later
-                        term = RandomTerm(
-                            label,
-                            lev_data,
-                            pred_data,
-                            grpr_df.values,
-                            categorical=categorical,
-                            constant=const if const else None,
-                            prior=prior,
-                        )
-                        self.terms[label] = term
+        if random is not None:
+            self._add_random(listify(random), data, priors)
 
     # pylint: disable=keyword-arg-before-vararg
-    def _add_y(self, variable, prior=None, family="gaussian", link=None, *args, **kwargs):
+    def _add_y(self, vector, prior=None, family="gaussian", link=None, event=None):
         """Add a dependent (or outcome) variable to the model.
 
         Parameters
@@ -615,13 +502,128 @@ class Model:
         if prior is None:
             prior = self.family.prior
 
+        variable = vector.design_info.term_names[0]
+
         if self.family.name == "gaussian":
             prior.update(sigma=Prior("HalfStudentT", nu=4, sigma=self.clean_data[variable].std()))
 
-        data = kwargs.pop("data", self.clean_data[variable])
-        term = Term(variable, data, prior=prior, *args, **kwargs)
-        self.y = term
+        if event is not None:
+            # pass in new Y data that has 1 if y=event and 0 otherwise
+            data = vector[:, vector.design_info.column_names.index(event.group(1))]
+            data = pd.DataFrame({event.group(3): data})
+        else:
+            data = self.clean_data[variable]
+            if self.family.name == "bernoulli":
+                data = get_bernoulli_data(data)
+
+        self.y = Term(variable, data, prior=prior)
         self.built = False
+
+    def _add_fixed(self, fixed, data, family, link, priors):
+        if "~" in fixed:
+            # check to see if formula is using the 'y[event] ~ x' syntax.
+            # If so, chop it into groups:
+            # 1 = 'y[event]', 2 = 'y', 3 = 'event', 4 = 'x'
+            # If this syntax is not being used, event = None
+            event = re.match(r"^((\S+)\[(\S+)\])\s*~(.*)$", fixed)
+            if event is not None:
+                fixed = "{}~{}".format(event.group(2), event.group(4))
+            y_vector, x_matrix = dmatrices(fixed, data=data, NA_action="raise")
+            self._add_y(y_vector, family=family, link=link, event=event)
+        else:
+            x_matrix = dmatrix(fixed, data=data, NA_action="raise")
+
+        factor_infos = x_matrix.design_info.factor_infos
+
+        # Loop over predictor terms
+        for _name, _slice in x_matrix.design_info.term_name_slices.items():
+            cols = x_matrix.design_info.column_names[_slice]
+            term_data = pd.DataFrame(np.asfortranarray(x_matrix[:, _slice]), columns=cols)
+
+            if EvalFactor(_name) in factor_infos:
+                categorical = factor_infos[EvalFactor(_name)].type == "categorical"
+            else:
+                categorical = False
+            prior = priors.pop(_name, priors.get("fixed", None))
+            self.terms[_name] = Term(_name, term_data, categorical=categorical, prior=prior)
+
+    def _add_random(self, random, data, priors):
+        for random_effect in random:  # pylint: disable=too-many-nested-blocks
+
+            random_effect = random_effect.strip()
+
+            # Split specification into intercept, predictor, and grouper
+            patt = r"^([01]+)*[\s\+]*([^\|]+)*\|(.*)"
+
+            intcpt, pred, grpr = re.search(patt, random_effect).groups()
+            label = "{}|{}".format(pred, grpr) if pred else grpr
+            prior = priors.pop(label, priors.get("random", None))
+
+            # Treat all grouping variables as categoricals, regardless of
+            # their dtype and what the user may have specified in the
+            # 'categorical' argument.
+            var_names = re.findall(r"(\w+)", grpr)
+            for var_name in var_names:
+                if var_name in data.columns:
+                    data.loc[:, var_name] = data.loc[:, var_name].astype("category")
+                    self.clean_data.loc[:, var_name] = data.loc[:, var_name]
+
+            # Default to including random intercepts
+            intcpt = 1 if intcpt is None else int(intcpt)
+
+            grpr_df = dmatrix(f"0+{grpr}", data, return_type="dataframe", NA_action="raise")
+
+            # If there's no predictor, we must be adding random intercepts
+            if not pred and grpr not in self.terms:
+                name = "1|" + grpr
+                pred = np.ones((len(grpr_df), 1))
+                term = RandomTerm(
+                    name, grpr_df, pred, grpr_df.values, categorical=True, prior=prior
+                )
+                self.terms[name] = term
+            else:
+                pred_df = dmatrix(
+                    f"{intcpt}+{pred}", data, return_type="dataframe", NA_action="raise"
+                )
+                # determine value of the 'constant' attribute
+                const = np.atleast_2d(pred_df.T).T.sum(1).var() == 0
+                factor_infos = pred_df.design_info.factor_infos
+
+                for col, i in pred_df.design_info.column_name_indexes.items():
+                    pred_data = pred_df.iloc[:, i]
+                    lev_data = grpr_df.multiply(pred_data, axis=0)
+
+                    # Also rename intercepts and skip if already added.
+                    # This can happen if user specifies something like
+                    # random=['1|school', 'student|school'].
+                    if col == "Intercept":
+                        if grpr in self.terms:
+                            continue
+                        label = f"1|{grpr}"
+                    else:
+                        label = col + "|" + grpr
+
+                    # Delete everything between brackets and the brackets
+                    col = re.sub(r"\[.*?\]\ *", "", col)
+                    if EvalFactor(col) in factor_infos:
+                        categorical = factor_infos[EvalFactor(col)].type == "categorical"
+                    else:
+                        categorical = False
+
+                    prior = priors.pop(label, priors.get("random", None))
+
+                    pred_data = pred_data.to_numpy()
+                    pred_data = pred_data[:, None]  # Must be 2D later
+                    term = RandomTerm(
+                        label,
+                        lev_data,
+                        pred_data,
+                        grpr_df.values,
+                        categorical=categorical,
+                        constant=const if const else None,
+                        prior=prior,
+                    )
+                    self.terms[label] = term
 
     def _match_derived_terms(self, name):
         """Return all (random) terms whose named are derived from the specified string.

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -460,7 +460,6 @@ class Model:
             data[cats] = data[cats].apply(lambda x: x.astype("category"))
 
         if fixed is not None:
-            print(fixed)
             self._add_fixed(fixed, data, family, link, priors)
 
         if random is not None:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -516,6 +516,7 @@ class Model:
             success_event = event.group(1)
             categorical = True
             data = vector[:, vector.design_info.column_names.index(success_event)]
+            # recall group(3) contains 'event' from 'y[event]' notation
             data = pd.DataFrame({event.group(3): data})
         else:
             data = self.clean_data[variable]

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -198,7 +198,10 @@ class Model:
         if len(self.fixed_terms) > 1:
 
             x_matrix = [pd.DataFrame(x.data, columns=x.levels) for x in terms]
+            print(x_matrix)
             x_matrix = pd.concat(x_matrix, axis=1)
+            print(self.fixed_terms)
+            print(x_matrix)
 
             self.dm_statistics = {
                 "r2_x": pd.Series(
@@ -556,7 +559,7 @@ class Model:
             self.terms[_name] = Term(_name, term_data, categorical=categorical, prior=prior)
 
     def _add_random(self, random, data, priors):
-        for random_effect in random:  # pylint: disable=too-many-nested-blocks
+        for random_effect in random:
 
             random_effect = random_effect.strip()
 
@@ -1047,6 +1050,23 @@ class Term:
 
 
 class ResponseTerm(Term):
+    """Representation of a single response model term.
+
+    Parameters
+    ----------
+    name : str
+        Name of the term.
+    data : (DataFrame, Series, ndarray)
+        The term values.
+    categorical : bool
+        If True, the source variable is interpreted as nominal/categorical. If False, the source
+        variable is treated as continuous.
+    prior : Prior
+        A specification of the prior(s) to use. An instance of class priors.Prior.
+    success_event: str or None
+        Indicates the success level when the term is a categorical variable.
+    """
+
     def __init__(self, name, data, categorical=False, prior=None, success_event=None):
         super().__init__(name, data, categorical, prior)
         self.success_event = str(success_event)
@@ -1059,6 +1079,28 @@ class ResponseTerm(Term):
 
 
 class RandomTerm(Term):
+    """Representation of a single (random) model term.
+
+    Parameters
+    ----------
+    name : str
+        Name of the term.
+    data : (DataFrame, Series, ndarray)
+        The term values.
+    predictor: (DataFrame, Series, ndarray)
+        Data of the predictor variable in the random term.
+    grouper: (DataFrame, Series, ndarray)
+        Data of the grouping variable in the random term.
+    categorical : bool
+        If True, the source variable is interpreted as nominal/categorical. If False, the source
+        variable is treated as continuous.
+    prior : Prior
+        A specification of the prior(s) to use. An instance of class priors.Prior.
+    constant : bool
+        indicates whether the term levels collectively act as a constant, in which case the term is
+        treated as an intercept for prior distribution purposes.
+    """
+
     random = True
 
     def __init__(

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -200,6 +200,7 @@ class PriorScaler:
     def __init__(self, model, taylor):
         self.model = model
         self.stats = model.dm_statistics if hasattr(model, "dm_statistics") else None
+        # Here we have the problem!
         self.dm = pd.DataFrame(
             {
                 lev: t.data[:, i]
@@ -207,6 +208,7 @@ class PriorScaler:
                 for i, lev in enumerate(t.levels)
             }
         )
+
         self.priors = {}
         missing = "drop" if self.model.dropna else "none"
         self.mle = GLM(

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -200,7 +200,6 @@ class PriorScaler:
     def __init__(self, model, taylor):
         self.model = model
         self.stats = model.dm_statistics if hasattr(model, "dm_statistics") else None
-        # Here we have the problem!
         self.dm = pd.DataFrame(
             {
                 lev: t.data[:, i]

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -422,21 +422,18 @@ def test_logistic_regression(crossed_data):
 
 
 def test_logistic_regression_empty_index():
-    np.random.seed(303456)
     data = pd.DataFrame({"y": np.random.choice(["a", "b"], 50), "x": np.random.normal(size=50)})
     model = Model(data)
     fitted = model.fit("y ~ x", family="bernoulli")
 
 
 def test_logistic_regression_good_numeric():
-    np.random.seed(303456)
     data = pd.DataFrame({"y": np.random.choice([1, 0], 50), "x": np.random.normal(size=50)})
     model = Model(data)
     fitted = model.fit("y ~ x", family="bernoulli")
 
 
 def test_logistic_regression_bad_numeric():
-    np.random.seed(303456)
     data = pd.DataFrame({"y": np.random.choice([1, 2], 50), "x": np.random.normal(size=50)})
     with pytest.raises(ValueError):
         model = Model(data)
@@ -444,7 +441,6 @@ def test_logistic_regression_bad_numeric():
 
 
 def test_logistic_regression_categoric():
-    np.random.seed(303456)
     y = pd.Series(np.random.choice(["a", "b"], 50), dtype="category")
     data = pd.DataFrame({"y": y, "x": np.random.normal(size=50)})
     model = Model(data)

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -434,7 +434,6 @@ def test_logistic_regression_good_numeric():
     model = Model(data)
     fitted = model.fit("y ~ x", family="bernoulli")
 
-
 def test_logistic_regression_bad_numeric():
     np.random.seed(303456)
     data = pd.DataFrame({"y": np.random.choice([1, 2], 50), "x": np.random.normal(size=50)})
@@ -442,6 +441,12 @@ def test_logistic_regression_bad_numeric():
         model = Model(data)
         fitted = model.fit("y ~ x", family="bernoulli")
 
+def test_logistic_regression_categoric():
+    np.random.seed(303456)
+    y = pd.Series(np.random.choice(["a", "b"], 50), dtype="category")
+    data = pd.DataFrame({"y": y, "x": np.random.normal(size=50)})
+    model = Model(data)
+    fitted = model.fit("y ~ x", family="bernoulli")
 
 def test_poisson_regression(crossed_data):
     # build model using fit and pymc3

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -421,6 +421,28 @@ def test_logistic_regression(crossed_data):
     assert all([dicts_close(priors0[x], priors1[x]) for x in priors0.keys()])
 
 
+def test_logistic_regression_empty_index():
+    np.random.seed(303456)
+    data = pd.DataFrame({"y": np.random.choice(["a", "b"], 50), "x": np.random.normal(size=50)})
+    model = Model(data)
+    fitted = model.fit("y ~ x", family="bernoulli")
+
+
+def test_logistic_regression_good_numeric():
+    np.random.seed(303456)
+    data = pd.DataFrame({"y": np.random.choice([1, 0], 50), "x": np.random.normal(size=50)})
+    model = Model(data)
+    fitted = model.fit("y ~ x", family="bernoulli")
+
+
+def test_logistic_regression_bad_numeric():
+    np.random.seed(303456)
+    data = pd.DataFrame({"y": np.random.choice([1, 2], 50), "x": np.random.normal(size=50)})
+    with pytest.raises(ValueError):
+        model = Model(data)
+        fitted = model.fit("y ~ x", family="bernoulli")
+
+
 def test_poisson_regression(crossed_data):
     # build model using fit and pymc3
     crossed_data["count"] = (crossed_data["Y"] - crossed_data["Y"].min()).round()

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -434,6 +434,7 @@ def test_logistic_regression_good_numeric():
     model = Model(data)
     fitted = model.fit("y ~ x", family="bernoulli")
 
+
 def test_logistic_regression_bad_numeric():
     np.random.seed(303456)
     data = pd.DataFrame({"y": np.random.choice([1, 2], 50), "x": np.random.normal(size=50)})
@@ -441,12 +442,14 @@ def test_logistic_regression_bad_numeric():
         model = Model(data)
         fitted = model.fit("y ~ x", family="bernoulli")
 
+
 def test_logistic_regression_categoric():
     np.random.seed(303456)
     y = pd.Series(np.random.choice(["a", "b"], 50), dtype="category")
     data = pd.DataFrame({"y": y, "x": np.random.normal(size=50)})
     model = Model(data)
     fitted = model.fit("y ~ x", family="bernoulli")
+
 
 def test_poisson_regression(crossed_data):
     # build model using fit and pymc3

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -81,7 +81,7 @@ def test_add_to_model(diabetes_data):
     model.add(random="C(age_grp)|BP")
     model.build(backend="pymc")
     assert isinstance(model.terms["C(age_grp)[T.1]|BP"], Term)
-    assert "108.0" in model.terms["C(age_grp)[T.1]|BP"].levels
+    assert "108.0" in model.terms["C(age_grp)[T.1]|BP"].cleaned_levels
 
 
 def test_one_shot_formula_fit(diabetes_data):

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -81,7 +81,7 @@ def test_add_to_model(diabetes_data):
     model.add(random="C(age_grp)|BP")
     model.build(backend="pymc")
     assert isinstance(model.terms["C(age_grp)[T.1]|BP"], Term)
-    assert "BP[108.0]" in model.terms["C(age_grp)[T.1]|BP"].levels
+    assert "108.0" in model.terms["C(age_grp)[T.1]|BP"].levels
 
 
 def test_one_shot_formula_fit(diabetes_data):

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -1,3 +1,4 @@
+import re
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype, is_string_dtype, is_categorical_dtype
@@ -28,3 +29,20 @@ def get_bernoulli_data(data):
     else:
         raise ValueError("Response variable is of the wrong type.")
     return data, success
+
+
+def extract_label(string, kind="fixed"):
+    """Receives a level as returned by patsy and returns a cleaned version of it.
+    Fixed and random effects are handled differently because their representations differ.
+    """
+    assert kind in ["fixed", "random"], "kind must be 'fixed' or 'random'"
+
+    out = re.search(r"\[(.+)\]", string)
+    if out is None:
+        return string
+    else:
+        out = out.group(1)
+    if kind == "fixed":
+        out = re.sub(r"^(.*?)\.", "", out)
+
+    return out

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -20,9 +20,11 @@ def get_bernoulli_data(data):
     if is_numeric_dtype(data):
         if not all(data.isin([0, 1])):
             raise ValueError("Numeric response must be all 0 and 1 for 'bernoulli' family.")
-    # If string/object, convert to 0-1 using first value as reference
+        success = 1
+    # If string/object/categorical, convert to 0-1 using first value as reference
     elif is_string_dtype(data) or is_categorical_dtype(data):
-        data = pd.Series(np.where(data.values == data.values[0], 1, 0))
+        success = data.values[0]
+        data = pd.Series(np.where(data.values == success, 1, 0))
     else:
         raise ValueError("Response variable is of the wrong type.")
-    return data
+    return data, success

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -37,7 +37,7 @@ def extract_label(string, kind="fixed"):
     """
     assert kind in ["fixed", "random"], "kind must be 'fixed' or 'random'"
 
-    out = re.search(r"\[(.+)\]", string)
+    out = re.search(r"\[(.+)\]", str(string))
     if out is None:
         return string
     else:

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -1,3 +1,8 @@
+import numpy as np
+import pandas as pd
+from pandas.api.types import is_numeric_dtype, is_string_dtype, is_categorical_dtype
+
+
 def listify(obj):
     """Wrap all non-list or tuple objects in a list.
 
@@ -7,3 +12,17 @@ def listify(obj):
         return []
     else:
         return obj if isinstance(obj, (list, tuple, type(None))) else [obj]
+
+
+def get_bernoulli_data(data):
+    """Checks and converts a pandas.Series of numerics/string/object/categoric"""
+    # If numeric, must be 0-1
+    if is_numeric_dtype(data):
+        if not all(data.isin([0, 1])):
+            raise ValueError("Numeric response must be all 0 and 1 for 'bernoulli' family.")
+    # If string/object, convert to 0-1 using first value as reference
+    elif is_string_dtype(data) or is_categorical_dtype(data):
+        data = pd.Series(np.where(data.values == data.values[0], 1, 0))
+    else:
+        raise ValueError("Response variable is of the wrong type.")
+    return data

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -34,9 +34,18 @@ def get_bernoulli_data(data):
 def extract_label(string, kind="fixed"):
     """Receives a level as returned by patsy and returns a cleaned version of it.
     Fixed and random effects are handled differently because their representations differ.
-    """
-    assert kind in ["fixed", "random"], "kind must be 'fixed' or 'random'"
 
+    Parameters
+    ----------
+    string: str
+        A string containing a label, as returned by patsy.
+    kind: str
+        Indicates if this is a fixed or random effect. Must be 'fixed' or 'random'
+
+    Returns
+    -------
+    out: cleaned string with label
+    """
     out = re.search(r"\[(.+)\]", str(string))
     if out is None:
         return string


### PR DESCRIPTION
Currently, `Model._add()` is a long method that does a lot of stuff and I think it that a first sight it not clear what is going on. In this PR I'm adding a variety of changes to make `Model._add()` clearer as well as solving #275, #271 and (maybe) #224

A list of (planned) changes

* [x] Split `Model._add()` into `Model._add_fixed()` and `Model._add_random()`
* [x] Added `get_bernoulli_data()` to `utils.py`. This function is called to handle the response variable when `family='bernoulli'`.
* [x] Add more tests. For example, check Bambi works when no response level is explicitly passed and `family='bernoulli'`.
* [x] Added `ResponseTerm` class, see comments.
* [x] Add tests for new plot labels

I deleted this point 

* [Use `Term` and `RandomTerm` consistently (see https://github.com/bambinos/bambi/issues/275#issuecomment-734498678)

Because (as mentioned below) I think it should be part of another refactor.