### PR TITLE
Change argument order in Model.fit()

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -269,10 +269,10 @@ class Model:
 
     def fit(
         self,
-        fixed=None,
-        random=None,
         common=None,
         group_specific=None,
+        fixed=None,
+        random=None,
         priors=None,
         family="gaussian",
         link=None,


### PR DESCRIPTION
Changing the order of arguments in `Model.fit()`. 

Instead of `Model.fit(fixed, random, common, group_specific)` we'll have `Model.fit(common, group_specific, fixed, random)` so we prevent unexpected messages like here

```python
model.fit('Val ~ Group')
# The fixed argument has been deprecated, please use common
```

And the following still works, but with the message properly signed
```
model.fit(fixed = 'Val ~ Group')
# The fixed argument has been deprecated, please use common
```