### PR TITLE
Add argument to optionally keep offsets in InferenceData object returned by Model.fit()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@
 * Use logging instead of warnings (#270)
 * Omits ploting group-level effects and offset variables (#276)
 * Logistic regression works with no explicit index (#277)
+* Add argument to optionally keep offsets in InferenceData (#288)
+* Add argument to optionally keep group level effects and offsets variables in `plot_prior` (#288)
 
 ### Documentation
 * Update example notebooks (#232)

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -111,7 +111,7 @@ class PyMC3BackEnd(BackEnd):
 
     # pylint: disable=arguments-differ, inconsistent-return-statements
     def run(
-        self, start=None, method="mcmc", init="auto", n_init=50000, keep_offsets=False, **kwargs
+        self, start=None, method="mcmc", init="auto", n_init=50000, omit_offsets=True, **kwargs
     ):
         """Run the PyMC3 MCMC sampler.
 
@@ -132,9 +132,9 @@ class PyMC3BackEnd(BackEnd):
             Number of initialization iterations if init = 'advi' or 'nuts'. Default is kind of in
             PyMC3 for the kinds of models we expect to see run with Bambi, so we lower it
             considerably.
-        keep_offsets: bool
-            Whether to keep offset terms when the model includes group specific effects.
-            Defaults to False.
+        omit_offsets: bool
+            Omits offset terms in the InferenceData object when the model includes
+            group specific effects. Defaults to True.
 
         Returns
         -------
@@ -153,7 +153,7 @@ class PyMC3BackEnd(BackEnd):
 
             idata = from_pymc3(self.trace, model=model)
 
-            if not keep_offsets:
+            if omit_offsets:
                 offset_dims = [vn for vn in idata.posterior.dims if "offset" in vn]
                 idata.posterior = idata.posterior.drop_dims(offset_dims)
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -297,7 +297,7 @@ class Model:
         family : str or Family
             A specification of the model family (analogous to the family object in R). Either a
             string, or an instance of class priors.Family. If a string is passed, a family with
-            the corresponding name must backend.runbe defined in the defaults loaded at Model
+            the corresponding name be defined in the defaults loaded at Model
             initialization.
             Valid pre-defined families are 'gaussian', 'bernoulli', 'poisson', and 't'.
         link : str

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -278,6 +278,7 @@ class Model:
         link=None,
         run=True,
         categorical=None,
+        keep_offsets=False,
         backend="pymc",
         **kwargs,
     ):
@@ -296,7 +297,8 @@ class Model:
         family : str or Family
             A specification of the model family (analogous to the family object in R). Either a
             string, or an instance of class priors.Family. If a string is passed, a family with
-            the corresponding name must be defined in the defaults loaded at Model initialization.
+            the corresponding name must backend.runbe defined in the defaults loaded at Model
+            initialization.
             Valid pre-defined families are 'gaussian', 'bernoulli', 'poisson', and 't'.
         link : str
             The model link function to use. Can be either a string (must be one of the options
@@ -312,6 +314,9 @@ class Model:
             DataFrame will be used to infer handling. In cases where numeric columns are to be
             treated as categoricals (e.g., group specific factors coded as numerical IDs),
             explicitly passing variable names via this argument is recommended.
+        keep_offsets: bool
+            Whether to keep offset terms when the model includes group specific effects.
+            Defaults to False.
         backend : str
             The name of the BackEnd to use. Currently only 'pymc' backend is supported.
         """
@@ -340,7 +345,7 @@ class Model:
         if run:
             if not self.built or backend != self._backend_name:
                 self.build(backend)
-            return self.backend.run(**kwargs)
+            return self.backend.run(keep_offsets=keep_offsets, **kwargs)
 
         self._backend_name = backend
         return None
@@ -821,7 +826,7 @@ class Model:
             Only works if `kind == hist`. If None (default) it will use `auto` for continuous
             variables and `range(xmin, xmax + 1)` for discrete variables.
         omit_vars: bool
-            Defaults to False. Omits ploting group-level effects and offset variables.
+            Defaults to True. Omits ploting group-level effects and offset variables.
         ax: numpy array-like of matplotlib axes or bokeh figures, optional
             A 2D array of locations into which to plot the densities. If not supplied, ArviZ will
             create its own array of plot areas (and return it).

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -259,7 +259,7 @@ def test_categorical_term():
         assert model.terms[term].categorical is expected
 
 
-def test_keep_offsets_true():
+def test_omit_offsets_false():
     data = pd.DataFrame(
         {
             "y": np.random.normal(size=100),
@@ -268,12 +268,12 @@ def test_keep_offsets_true():
         }
     )
     model = Model(data)
-    fitted = model.fit("y ~ x1", group_specific=["x1|g1"], keep_offsets=True)
+    fitted = model.fit("y ~ x1", group_specific=["x1|g1"], omit_offsets=False)
     offsets = [v for v in fitted.posterior.dims if "offset" in v]
     assert offsets == ["1|g1_offset_dim_0", "x1|g1_offset_dim_0"]
 
 
-def test_keep_offsets_false():
+def test_omit_offsets_true():
     data = pd.DataFrame(
         {
             "y": np.random.normal(size=100),
@@ -282,6 +282,6 @@ def test_keep_offsets_false():
         }
     )
     model = Model(data)
-    fitted = model.fit("y ~ x1", group_specific=["x1|g1"], keep_offsets=False)
+    fitted = model.fit("y ~ x1", group_specific=["x1|g1"], omit_offsets=True)
     offsets = [v for v in fitted.posterior.dims if "offset" in v]
     assert not offsets

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -257,3 +257,31 @@ def test_categorical_term():
 
     for term, expected in zip(terms, expecteds):
         assert model.terms[term].categorical is expected
+
+
+def test_keep_offsets_true():
+    data = pd.DataFrame(
+        {
+            "y": np.random.normal(size=100),
+            "x1": np.random.normal(size=100),
+            "g1": ["a"] * 50 + ["b"] * 50,
+        }
+    )
+    model = Model(data)
+    fitted = model.fit("y ~ x1", group_specific=["x1|g1"], keep_offsets=True)
+    offsets = [v for v in fitted.posterior.dims if "offset" in v]
+    assert offsets == ["1|g1_offset_dim_0", "x1|g1_offset_dim_0"]
+
+
+def test_keep_offsets_false():
+    data = pd.DataFrame(
+        {
+            "y": np.random.normal(size=100),
+            "x1": np.random.normal(size=100),
+            "g1": ["a"] * 50 + ["b"] * 50,
+        }
+    )
+    model = Model(data)
+    fitted = model.fit("y ~ x1", group_specific=["x1|g1"], keep_offsets=False)
+    offsets = [v for v in fitted.posterior.dims if "offset" in v]
+    assert offsets == []

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -284,4 +284,4 @@ def test_keep_offsets_false():
     model = Model(data)
     fitted = model.fit("y ~ x1", group_specific=["x1|g1"], keep_offsets=False)
     offsets = [v for v in fitted.posterior.dims if "offset" in v]
-    assert offsets == []
+    assert not offsets


### PR DESCRIPTION
Offset variables were removed from the posterior in #276. However, it may be the case that someone may want to keep them. 

This PR adds an argument `keep_offsets` to `Model.fit()` which defaults to `False`.

**Checklist**

* [x] Add `keep_offsets` argument.
* [x] Fix  `omit_vars` documentation.
* [x] Add tests.
* [x] Discuss on existing argument names.