### PR TITLE
Add negative binomial to config file

### DIFF
--- a/bambi/config/priors.json
+++ b/bambi/config/priors.json
@@ -132,7 +132,8 @@
     ],
     "negativebinomial": [
       "NegativeBinomial", {
-        "alpha": 1
+        "alpha": 1,
+        "mu": 1
       }
     ]
   }

--- a/bambi/config/priors.json
+++ b/bambi/config/priors.json
@@ -57,6 +57,16 @@
       ],
       "link": "identity",
       "parent": "mu"
+    },
+    "negativebinomial": {
+      "dist": [
+        "#negativebinomial",
+        {
+          "mu": "#halfcauchy"
+        }
+      ],
+      "link": "log",
+      "parent": "alpha"
     }
   },
   "dists": {
@@ -118,6 +128,11 @@
       "Bernoulli",
       {
         "p": 0.5
+      }
+    ],
+    "negativebinomial": [
+      "NegativeBinomial", {
+        "alpha": 1
       }
     ]
   }


### PR DESCRIPTION
See #323 

This is my first time modifying the config.json file. I'm using [this example](https://docs.pymc.io/notebooks/GLM-negative-binomial-regression.html) from PyMC3. Looks like it works fine, but the prior for `mu` is very weird. 

Does anyone know if this is related to the fact that I'm using the following? 
```json
    "negativebinomial": [
      "NegativeBinomial", {
        "alpha": 1
      }
    ]
```

*UPDATE*

This is the example, the priors and the posterior

```python
model = bmb.Model(df_pois)
fitted = model.fit("nsneeze ~ alcohol + nomeds + alcohol:nomeds", family = "negativebinomial")
```
![image](https://user-images.githubusercontent.com/25507629/113148390-2a2e4080-9208-11eb-8193-ac8fde2c95a8.png)

![image](https://user-images.githubusercontent.com/25507629/113148427-34503f00-9208-11eb-9cfd-3ec49e61f438.png)
