### PR TITLE
[WIP] Add more friendly print methods to objects used in Bambi

### DIFF
--- a/bambi/config/priors.json
+++ b/bambi/config/priors.json
@@ -57,6 +57,16 @@
       ],
       "link": "identity",
       "parent": "mu"
+    },
+    "negativebinomial": {
+      "dist": [
+        "#negativebinomial",
+        {
+          "mu": "#halfcauchy"
+        }
+      ],
+      "link": "log",
+      "parent": "alpha"
     }
   },
   "dists": {
@@ -118,6 +128,11 @@
       "Bernoulli",
       {
         "p": 0.5
+      }
+    ],
+    "negativebinomial": [
+      "NegativeBinomial", {
+        "alpha": 1
       }
     ]
   }

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -81,6 +81,22 @@ class Prior:
             kwargs_[key] = val
         self.args.update(kwargs_)
 
+    def __str__(self):
+        if any(isinstance(arg, Prior) for arg in self.args.values()):
+            args = ",\n  ".join(
+                [
+                    f"{k}: {'  '.join(str(v).splitlines(True)) if isinstance(v, Prior) else v}"
+                    for k, v in self.args.items()
+                ]
+            )
+            return f"{self.name}(\n  {args}\n)"
+        else:
+            args = ", ".join([f"{k}: {v}" for k, v in self.args.items()])
+            return f"{self.name}({args})"
+
+    def __repr__(self):
+        return self.__str__()
+
 
 class PriorFactory:
     """An object that supports specification and easy retrieval of default priors.


### PR DESCRIPTION
I think clearer `.__repr__()` methods can be beneficial to newcomers. 

So far, I've implemented this for `Prior`.

Using priors from [this example](https://bambinos.github.io/bambi/notebooks/multi-level_regression.html)

```python
model.terms["Time"].prior
```
`Normal(mu: 0, sigma: 2.1449214550272586)`

```python
model.terms["1|Pig"].prior
```
```
Normal(
  mu: 0,
  sigma: HalfNormal(sigma: 16.504333838133107)
)
```
