### PR TITLE
GLM is not fitted if all priors are specified manually

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -101,19 +101,13 @@ class Model:
             return ""
 
         priors = [f"  {term.name} ~ {term.prior}" for term in self.terms.values()]
+        # Priors for nuisance parameters, i.e., standar deviation in normal linear model
         priors_extra_params = [
             f"  {k} ~ {v}"
             for k, v in self.family.prior.args.items()
             if k not in ["observed", self.family.parent]
         ]
-        priors = priors + priors_extra_params
-        foot = ["* To see a plot of the priors call the .plot_priors() method."]
-
-        if self.backend.fit:
-            foot_ = "* To see a summary or plot of the posterior pass the object returned by"
-            foot_ += " .fit() to az.summary() or az.plot_trace()"
-            foot += [foot_]
-
+        priors += priors_extra_params
         str_list = [
             f"Formula: {self.formula}",
             f"Family name: {self.family.name.capitalize()}",
@@ -121,9 +115,15 @@ class Model:
             "Priors:",
             "\n".join(priors),
             "------",
+            "* To see a plot of the priors call the .plot_priors() method.",
         ]
 
-        return "\n".join(str_list + foot)
+        if self.backend.fit:
+            extra_foot = "* To see a summary or plot of the posterior pass the object returned by"
+            extra_foot += " .fit() to az.summary() or az.plot_trace()"
+            str_list += [extra_foot]
+
+        return "\n".join(str_list)
 
     def __repr__(self):
         return self.__str__()


### PR DESCRIPTION
Currently, a maximum-likelihood fit of the common part of the model is obtained at `PriorScaler` instantiation. This causes problems when the ML estimators don't exist, such as the one reported in #320. The ML fit is required when automatic priors are used, but it is not required otherwise. However, Bambi is always fitting the model via MLE; no matter that all the priors are set manually. 

This PR moves the ML fit to `PriorScaler.scale()` call and it is only performed if there is at least one term that receives automatic priors.

**Example**

The error has a message that attempts to guide the user about what to do in this situation.

```python
data = pd.DataFrame({
    "y": [0] * 5 + [1] * 5,
    "g": ["a"] * 5 + ["b"] * 5
})
model = bmb.Model(data)
fitted = model.fit("y ~ g", family = "bernoulli")
# PerfectSeparationError: Perfect separation detected, automatic priors are not available. Please indicate priors manually.
```

And if the user sets the priors manually, it just works.

```python
priors = {
    "common": bmb.Prior('Normal', mu=0, sigma=10)
}
model = bmb.Model(data)
fitted = model.fit("y ~ g", family = "bernoulli", priors = priors)
```

![image](https://user-images.githubusercontent.com/25507629/114099529-547f9e00-9899-11eb-8441-90ba8e4dff12.png)
![image](https://user-images.githubusercontent.com/25507629/114099711-a9bbaf80-9899-11eb-9c79-c8b53fe91c4b.png)

**PS** I've also modified `Model.__str__()` a little, but the output is the same.