### PR TITLE
Make it possible to change default priors for response variable

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -401,12 +401,12 @@ class Model:
             theano tensor as the sole argument and returns one with the same shape.
         priors : dict
             Optional dictionary with specification of priors for the parameters in the family of
-            the response. Keys are nuisance parameters in the family (i.e. they cannot be equal to
-            family.parent) and values can be an instance of class ``Prior``, a numeric value,
-            or a string describing the width. In the numeric case, the distribution specified in
-            the defaults will be used, and the passed value will be used to scale the appropriate
-            variance parameter. For strings (e.g., ``'wide'``, ``'narrow'``, ``'medium'``, or
-            ``'superwide'``), predefined values will be used.
+            the response. Keys are names of other parameters than the mean in the family
+            (i.e. they cannot be equal to family.parent) and values can be an instance of class
+            ``Prior``, a numeric value, or a string describing the width. In the numeric case,
+            the distribution specified in the defaults will be used, and the passed value will be
+            used to scale the appropriate variance parameter. For strings (e.g., ``'wide'``,
+            ``'narrow'``, ``'medium'``, or ``'superwide'``), predefined values will be used.
         """
         if isinstance(family, str):
             family = self.default_priors.get(family=family)

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -152,11 +152,11 @@ class Model:
             if priors_ and self._design.common:
                 conflicts = [name for name in priors_ if name in self._design.common.terms_info]
                 if len(conflicts) > 0:
-                    _log.info(
+                    _log.warning(
                         "The prior for %s is ambiguous because its name conflicts "
                         "with the name of a parameter in the response distribution.\n"
                         "Consider renaming the term to prevent an unexpected behaviour.",
-                        ", ".join(conflicts)
+                        ", ".join(conflicts),
                     )
             self._add_response(self._design.response, family, link, priors_)
         else:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -333,6 +333,15 @@ class Model:
             targets.update({name: group_specific for name in self.group_specific_terms.keys()})
 
         if priors is not None:
+            # Update priors related to nuisance parameters of response distribution
+            priors_ = extract_family_prior(self.family, priors)
+            if priors_:
+                # Remove keys passed to the response.
+                for key in priors_:
+                    priors.pop(key)
+                self.response.prior.args.update(priors_)
+
+            # Prepare priors for explanatory terms.
             for k, prior in priors.items():
                 for name in listify(k):
                     term_names = list(self.terms.keys())
@@ -346,6 +355,7 @@ class Model:
                     else:
                         targets[name] = prior
 
+        # Set priors for explanatory terms.
         for name, prior in targets.items():
             self.terms[name].prior = prior
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -151,12 +151,11 @@ class Model:
             priors_ = extract_family_prior(family, priors)
             if priors_ and self._design.common:
                 conflicts = [name for name in priors_ if name in self._design.common.terms_info]
-                if len(conflicts) > 0:
-                    _log.warning(
-                        "The prior for %s is ambiguous because its name conflicts "
-                        "with the name of a parameter in the response distribution.\n"
-                        "Consider renaming the term to prevent an unexpected behaviour.",
-                        ", ".join(conflicts),
+                if conflicts:
+                    raise ValueError(
+                        f"The prior name for {', '.join(conflicts)} conflicts with the name of a "
+                        "parameter in the response distribution.\n"
+                        "Please rename the term(s) to prevent an unexpected behaviour."
                     )
             self._add_response(self._design.response, family, link, priors_)
         else:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -149,6 +149,15 @@ class Model:
 
         if self._design.response is not None:
             priors_ = extract_family_prior(family, priors)
+            if priors_ and self._design.common:
+                conflicts = [name for name in priors_ if name in self._design.common.terms_info]
+                if len(conflicts) > 0:
+                    _log.info(
+                        "The prior for %s is ambiguous because its name conflicts "
+                        "with the name of a parameter in the response distribution.\n"
+                        "Consider renaming the term to prevent an unexpected behaviour.",
+                        ", ".join(conflicts)
+                    )
             self._add_response(self._design.response, family, link, priors_)
         else:
             raise ValueError(

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -103,6 +103,17 @@ class Prior:
             kwargs_[key] = val
         self.args.update(kwargs_)
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return False
+        else:
+            return (
+                self.name == other.name
+                and self.args == other.args
+                and self.scale == other.scale
+                and self._auto_scale == other._auto_scale
+            )
+
     def __str__(self):
         args = ", ".join(
             [

--- a/bambi/priors.py
+++ b/bambi/priors.py
@@ -107,12 +107,7 @@ class Prior:
         if not isinstance(other, type(self)):
             return False
         else:
-            return (
-                self.name == other.name
-                and self.args == other.args
-                and self.scale == other.scale
-                and self._auto_scale == other._auto_scale
-            )
+            return self.__dict__ == other.__dict__
 
     def __str__(self):
         args = ", ".join(

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -154,9 +154,9 @@ def test_set_response_prior():
     priors = {"sigma": Prior("Uniform", lower=0, upper=50)}
     model = Model("y ~ x", data)
     model.set_priors(priors)
-    assert model.response.prior.args["sigma"] == priors["sigma"]
+    assert model.response.prior.args["sigma"] == Prior("Uniform", lower=0, upper=50)
 
     priors = {"mu": Prior("Uniform", lower=1, upper=20)}
     model = Model("y ~ x", data, family="negativebinomial")
     model.set_priors(priors)
-    assert model.response.prior.args["mu"] == priors["mu"]
+    assert model.response.prior.args["mu"] == Prior("Uniform", lower=1, upper=20)

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -134,3 +134,29 @@ def test_complete_separation():
     # No error is raised
     priors = {"common": Prior("Normal", mu=0, sigma=10)}
     Model("y ~ g", data, family="bernoulli", priors=priors).fit()
+
+
+def test_response_prior():
+    data = pd.DataFrame({"y": np.random.randint(3, 10, size=50), "x": np.random.normal(size=50)})
+
+    priors = {"sigma": Prior("Uniform", lower=0, upper=50)}
+    model = Model("y ~ x", data, priors=priors)
+    assert model.response.prior.args["sigma"] == priors["sigma"]
+
+    priors = {"mu": Prior("Uniform", lower=1, upper=20)}
+    model = Model("y ~ x", data, family="negativebinomial", priors=priors)
+    assert model.response.prior.args["mu"] == priors["mu"]
+
+
+def test_set_response_prior():
+    data = pd.DataFrame({"y": np.random.randint(3, 10, size=50), "x": np.random.normal(size=50)})
+
+    priors = {"sigma": Prior("Uniform", lower=0, upper=50)}
+    model = Model("y ~ x", data)
+    model.set_priors(priors)
+    assert model.response.prior.args["sigma"] == priors["sigma"]
+
+    priors = {"mu": Prior("Uniform", lower=1, upper=20)}
+    model = Model("y ~ x", data, family="negativebinomial")
+    model.set_priors(priors)
+    assert model.response.prior.args["mu"] == priors["mu"]

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -13,12 +13,10 @@ def listify(obj):
 
 
 def extract_family_prior(family, priors):
-    """
-    Given a family and a dictionary of priors, return the prior that could be
-    passed to update the prior of a parameter in that family.
-    """
+    # Given a family and a dictionary of priors, return the prior that could be
+    # passed to update the prior of a parameter in that family.
 
-    # Only gaussian and negativebinomial have nuisance parameters
+    # Only built-in gaussian and negativebinomial have nuisance parameters
     # i.e, parameters not related to the link-transformed predicted outcome
     if isinstance(family, str):
         if family == "gaussian" and "sigma" in priors:

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -1,3 +1,6 @@
+from .priors import Family
+
+
 def listify(obj):
     """Wrap all non-list or tuple objects in a list.
 
@@ -17,9 +20,15 @@ def extract_family_prior(family, priors):
 
     # Only gaussian and negativebinomial have nuisance parameters
     # i.e, parameters not related to the link-transformed predicted outcome
-    if family == "gaussian" and "sigma" in priors:
-        return {"sigma": priors["sigma"]}
-    elif family == "negativebinomial" and "mu" in priors:
-        return {"mu": priors["mu"]}
-    else:
-        return None
+    if isinstance(family, str):
+        if family == "gaussian" and "sigma" in priors:
+            return {"sigma": priors["sigma"]}
+        elif family == "negativebinomial" and "mu" in priors:
+            return {"mu": priors["mu"]}
+    elif isinstance(family, Family):
+        # Only work if there are nuisance parameters in the family, and if any of these nuisance
+        # parameters is present in 'priors' dictionary.
+        nuisance_params = [k for k in family.prior.args if k not in ["observed", family.parent]]
+        if set(nuisance_params).intersection(set(priors)):
+            return {k: priors[k] for k in nuisance_params if k in priors}
+    return None

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -7,3 +7,19 @@ def listify(obj):
         return []
     else:
         return obj if isinstance(obj, (list, tuple, type(None))) else [obj]
+
+
+def extract_family_prior(family, priors):
+    """
+    Given a family and a dictionary of priors, return the prior that could be
+    passed to update the prior of a parameter in that family.
+    """
+
+    # Only gaussian and negativebinomial have nuisance parameters
+    # i.e, parameters not related to the link-transformed predicted outcome
+    if family == "gaussian" and "sigma" in priors:
+        return {"sigma": priors["sigma"]}
+    elif family == "negativebinomial" and "mu" in priors:
+        return {"mu": priors["mu"]}
+    else:
+        return None


### PR DESCRIPTION
See #331 

Current changes work for built-in families `"gaussian"` and `"negativebinomial"`. Other built-in families don't have nuisance parameters in the response distribution. There's still work to be done, however.

**Example**
In the past you couldn't pass priors for nuisance parameters in the response distribution. Now you can.
```python
import bambi as bmb
import numpy as np
import pandas as pd

data = pd.DataFrame({
    "y": np.random.randint(3, 10, size=50),
    "x": np.random.normal(size=50)
})
priors = {"sigma": bmb.Prior('Uniform', lower=0, upper=50)}
bmb.Model("y ~ x", data, priors=priors)
```
```
Formula: y ~ x
Family name: Gaussian
Link: identity
Observations: 50
Priors:
  Intercept ~ Normal(mu: 5.96, sigma: 2.02021478)
  x ~ Normal(mu: 0, sigma: 1.72275744)
  sigma ~ Uniform(lower: 1, upper: 50)
```

```python
priors = {"mu": bmb.Prior('Uniform', lower=1, upper=20)}
bmb.Model("y ~ x", data, family="negativebinomial", priors=priors)
```

```
Formula: y ~ x
Family name: Negativebinomial
Link: log
Observations: 50
Priors:
  Intercept ~ Normal(mu: 1.78507048, sigma: 1.08072027)
  x ~ Normal(mu: 0, sigma: 0.63288403)
  mu ~ Uniform(lower: 1, upper: 20)
```

* [x] Priors for parameters in the response distribution can be updated using `Model.set_priors()`.
* [x] Update nuisance parameters from custom families.
* [x] Check name conflicts, i.e. no term has the same name as any nuisance parameter in the response distribution
* [x] Update documentation in `.add_response()`.
* [x] Tests.