### PR TITLE
Implement predictions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -38,6 +38,8 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+# Scipy.special functions are written in C and not accessible by pylint
+--ignored-modules=scipy.special
 
 [MESSAGES CONTROL]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -38,8 +38,6 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
-# Scipy.special functions are written in C and not accessible by pylint
---ignored-modules=scipy.special
 
 [MESSAGES CONTROL]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -263,6 +263,8 @@ good-names=b,
            _log,
            _,
            NA_handler,
+           X,
+           Z
 
 
 # Include a hint for the correct naming format with invalid-name

--- a/.pylintrc
+++ b/.pylintrc
@@ -264,7 +264,8 @@ good-names=b,
            _,
            NA_handler,
            X,
-           Z
+           Z,
+           nu
 
 
 # Include a hint for the correct naming format with invalid-name

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -27,8 +27,6 @@ class PyMC3BackEnd(BackEnd):
         "probit": probit,
     }
 
-    dists = {"HalfFlat": pm.Bound(pm.Flat, lower=0)}
-
     def __init__(self):
         self.name = pm.__name__
         self.version = pm.__version__
@@ -270,8 +268,6 @@ class PyMC3BackEnd(BackEnd):
         if isinstance(dist, str):
             if hasattr(pm, dist):
                 dist = getattr(pm, dist)
-            elif dist in self.dists:
-                dist = self.dists[dist]
             else:
                 raise ValueError(
                     f"The Distribution {dist} was not found in PyMC3 or the PyMC3BackEnd."

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -16,8 +16,8 @@ _log = logging.getLogger("bambi")
 class PyMC3BackEnd(BackEnd):
     """PyMC3 model-fitting backend."""
 
-    # Available link functions
-    links = {
+    # Available inverse link functions
+    INVLINKS = {
         "cloglog": cloglog,
         "identity": lambda x: x,
         "inverse_squared": lambda x: tt.inv(tt.sqrt(x)),
@@ -231,13 +231,15 @@ class PyMC3BackEnd(BackEnd):
         """Build and return a response distribution."""
         data = spec.response.data.squeeze()
         name = spec.response.name
-        link = spec.family.link
-        if isinstance(link, str):
-            link = self.links[link]
+
+        if spec.family.link.name in self.INVLINKS:
+            linkinv = self.INVLINKS[spec.family.link.name]
+        else:
+            linkinv = spec.family.link.linkinv_backend
 
         likelihood = spec.family.likelihood
         dist = self.get_distribution(likelihood.name)
-        kwargs = {likelihood.parent: link(self.mu), "observed": data}
+        kwargs = {likelihood.parent: linkinv(self.mu), "observed": data}
         if likelihood.priors:
             kwargs.update(
                 {

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -18,13 +18,13 @@ class PyMC3BackEnd(BackEnd):
 
     # Available link functions
     links = {
+        "cloglog": cloglog,
         "identity": lambda x: x,
+        "inverse_squared": lambda x: tt.inv(tt.sqrt(x)),
+        "inverse": tt.inv,
+        "log": tt.exp,
         "logit": tt.nnet.sigmoid,
         "probit": probit,
-        "cloglog": cloglog,
-        "inverse": tt.inv,
-        "inverse_squared": lambda x: tt.inv(tt.sqrt(x)),
-        "log": tt.exp,
     }
 
     dists = {"HalfFlat": pm.Bound(pm.Flat, lower=0)}

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -269,9 +269,7 @@ class PyMC3BackEnd(BackEnd):
             if hasattr(pm, dist):
                 dist = getattr(pm, dist)
             else:
-                raise ValueError(
-                    f"The Distribution {dist} was not found in PyMC3 or the PyMC3BackEnd."
-                )
+                raise ValueError(f"The Distribution '{dist}' was not found in PyMC3")
         return dist
 
     def expand_prior_args(self, key, value, label, noncentered, **kwargs):

--- a/bambi/defaults/defaults.py
+++ b/bambi/defaults/defaults.py
@@ -123,9 +123,9 @@ def generate_prior(dist, **kwargs):
     return prior
 
 
-def generate_likelihood(name, args, parent, pps_):
+def generate_likelihood(name, args, parent, pps):  # pylint: disable=redefined-outer-name
     priors = {k: generate_prior(v) for k, v in args.items()}
-    return Likelihood(name, parent, pps_, **priors)
+    return Likelihood(name, parent, pps, **priors)
 
 
 def generate_family(name, likelihood, link):

--- a/bambi/defaults/defaults.py
+++ b/bambi/defaults/defaults.py
@@ -1,3 +1,4 @@
+from . import pps
 from ..priors import Family, Likelihood, Prior
 
 
@@ -25,7 +26,8 @@ SETTINGS_FAMILIES = {
         "likelihood": {
             "name": "Bernoulli",
             "args": {},
-            "parent": "p"
+            "parent": "p",
+            "pps": pps.pps_bernoulli
         },
         "link": "logit"
     },
@@ -35,7 +37,8 @@ SETTINGS_FAMILIES = {
             "args": {
                 "kappa": "HalfCauchy"
             },
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_beta
         },
         "link": "logit"
     },
@@ -45,7 +48,8 @@ SETTINGS_FAMILIES = {
             "args": {
                 "alpha": "HalfCauchy"
             },
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_gamma
         },
         "link": "inverse",
     },
@@ -55,7 +59,8 @@ SETTINGS_FAMILIES = {
             "args": {
                 "sigma": "HalfNormal"
             },
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_gaussian
         },
         "link": "identity",
     },
@@ -65,7 +70,8 @@ SETTINGS_FAMILIES = {
             "args": {
                 "alpha": "HalfCauchy"
             },
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_negativebinomial
         },
         "link": "log",
     },
@@ -73,7 +79,8 @@ SETTINGS_FAMILIES = {
         "likelihood": {
             "name": "Poisson",
             "args": {},
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_poisson
         },
         "link": "log"
     },
@@ -84,7 +91,8 @@ SETTINGS_FAMILIES = {
                 "lam": "HalfCauchy",
                 "nu": 2
             },
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_t
         },
         "link": "identity",
     },
@@ -94,7 +102,8 @@ SETTINGS_FAMILIES = {
             "args": {
                 "lam": "HalfCauchy"
             },
-            "parent": "mu"
+            "parent": "mu",
+            "pps": pps.pps_wald
         },
         "link": "inverse_squared",
     },
@@ -114,9 +123,9 @@ def generate_prior(dist, **kwargs):
     return prior
 
 
-def generate_likelihood(name, args, parent):
+def generate_likelihood(name, args, parent, pps_):
     priors = {k: generate_prior(v) for k, v in args.items()}
-    return Likelihood(name, parent, **priors)
+    return Likelihood(name, parent, pps_, **priors)
 
 
 def generate_family(name, likelihood, link):

--- a/bambi/defaults/pps.py
+++ b/bambi/defaults/pps.py
@@ -1,0 +1,68 @@
+"""Utility functions to sample from the posterior predictive distributions"""
+
+import numpy as np
+
+from scipy import stats
+
+
+def _get_mu_and_idxs(mu, draws): #pylint: disable=unused-argument
+    # mu has shape (chain, draw, obs)
+    idxs = np.random.randint(low=0, high=draws, size=draws)
+    mu = mu[:, idxs, :]
+    return mu, idxs
+
+
+def pps_bernoulli(model, posterior, mu, draws): #pylint: disable=unused-argument
+    mu, _ = _get_mu_and_idxs(mu, draws)
+    return np.random.binomial(1, mu)
+
+
+def pps_beta(model, posterior, mu, draws):
+    mu, idxs = _get_mu_and_idxs(mu, draws)
+    kappa = posterior[model.response.name + "_kappa"].values[:, idxs, np.newaxis]
+    alpha = mu * kappa
+    beta = (1 - mu) * kappa
+    return np.random.beta(alpha, beta)
+
+
+def pps_gamma(model, posterior, mu, draws):
+    mu, idxs = _get_mu_and_idxs(mu, draws)
+    alpha = posterior[model.response.name + "_alpha"].values[:, idxs, np.newaxis]
+    beta = alpha / mu
+    return np.random.gamma(alpha, 1 / beta)
+
+
+def pps_gaussian(model, posterior, mu, draws):
+    mu, idxs = _get_mu_and_idxs(mu, draws)
+    sigma = posterior[model.response.name + "_sigma"].values[:, idxs, np.newaxis]
+    return np.random.normal(mu, sigma)
+
+
+def pps_negativebinomial(model, posterior, mu, draws):
+    mu, idxs = _get_mu_and_idxs(mu, draws)
+    n = posterior[model.response.name + "_alpha"].values[:, idxs, np.newaxis]
+    p = n / (mu + n)
+    return np.random.negative_binomial(n, p)
+
+
+def pps_poisson(model, posterior, mu, draws): #pylint: disable=unused-argument
+    mu, _ = _get_mu_and_idxs(mu, draws)
+    return np.random.poisson(mu)
+
+
+def pps_t(model, posterior, mu, draws):
+    mu, idxs = _get_mu_and_idxs(mu, draws)
+    if isinstance(model.family.likelihood.priors["nu"], (int, float)):
+        nu = model.family.likelihood.priors["nu"]
+    else:
+        nu = posterior[model.response.name + "_nu"].values[:, idxs, np.newaxis]
+
+    lam = posterior[model.response.name + "_lam"].values[:, idxs, np.newaxis]
+    sigma = lam ** -0.5
+    return stats.t.rvs(nu, mu, sigma)
+
+
+def pps_wald(model, posterior, mu, draws):
+    mu, idxs = _get_mu_and_idxs(mu, draws)
+    lam = posterior[model.response.name + "_lam"].values[:, idxs, np.newaxis]
+    return np.random.wald(mu, lam)

--- a/bambi/defaults/pps.py
+++ b/bambi/defaults/pps.py
@@ -6,6 +6,28 @@ from scipy import stats
 
 
 def _get_mu_and_idxs(mu, draws):  # pylint: disable=unused-argument
+    """Sample values from the posterior of the mean, return sampled values and their indexes
+
+    This function is used within ``pps_*`` auxiliary functions. Its goal is to simplify how we
+    sample from the posterior trace and the other parameters that may define the conditional
+    distribution of the response.
+
+    Parameters
+    ----------
+    mu: np.array
+        A 3-dimensional numpy array with samples from the posterior distribution of the mean. The
+        first dimension represents the chain, the second represents the draw, and the third the
+        individual.
+    draws: int
+        Number of samples to take.
+
+    Returns
+    -------
+    mu: np.array
+        A 3-dimensional numpy array with the new samples.
+    idxs: np.array
+        The indexes of the samples in the original sample of the posterior.
+    """
     # mu has shape (chain, draw, obs)
     idxs = np.random.randint(low=0, high=draws, size=draws)
     mu = mu[:, idxs, :]

--- a/bambi/defaults/pps.py
+++ b/bambi/defaults/pps.py
@@ -5,14 +5,14 @@ import numpy as np
 from scipy import stats
 
 
-def _get_mu_and_idxs(mu, draws): #pylint: disable=unused-argument
+def _get_mu_and_idxs(mu, draws):  # pylint: disable=unused-argument
     # mu has shape (chain, draw, obs)
     idxs = np.random.randint(low=0, high=draws, size=draws)
     mu = mu[:, idxs, :]
     return mu, idxs
 
 
-def pps_bernoulli(model, posterior, mu, draws): #pylint: disable=unused-argument
+def pps_bernoulli(model, posterior, mu, draws):  # pylint: disable=unused-argument
     mu, _ = _get_mu_and_idxs(mu, draws)
     return np.random.binomial(1, mu)
 
@@ -45,7 +45,7 @@ def pps_negativebinomial(model, posterior, mu, draws):
     return np.random.negative_binomial(n, p)
 
 
-def pps_poisson(model, posterior, mu, draws): #pylint: disable=unused-argument
+def pps_poisson(model, posterior, mu, draws):  # pylint: disable=unused-argument
     mu, _ = _get_mu_and_idxs(mu, draws)
     return np.random.poisson(mu)
 

--- a/bambi/priors/family.py
+++ b/bambi/priors/family.py
@@ -70,14 +70,11 @@ class Family:
             raise ValueError("'link' must be a string or a Link instance.")
 
     def __str__(self):
-        if self.link is None:
-            msg = "No family set"
-        else:
-            msg_list = [f"Response distribution: {self.likelihood.name}", f"Link: {self.link.name}"]
-            if self.likelihood.priors:
-                priors_msg = "\n  ".join([f"{k} ~ {v}" for k, v in self.likelihood.priors.items()])
-                msg_list += [f"Priors:\n  {priors_msg}"]
-            msg = "\n".join(msg_list)
+        msg_list = [f"Response distribution: {self.likelihood.name}", f"Link: {self.link.name}"]
+        if self.likelihood.priors:
+            priors_msg = "\n  ".join([f"{k} ~ {v}" for k, v in self.likelihood.priors.items()])
+            msg_list += [f"Priors:\n  {priors_msg}"]
+        msg = "\n".join(msg_list)
         return msg
 
     def __repr__(self):

--- a/bambi/priors/family.py
+++ b/bambi/priors/family.py
@@ -1,7 +1,6 @@
-import numpy as np
-
-from scipy import special
 from statsmodels.genmod import families as sm_families
+
+from .link import Link
 
 STATSMODELS_FAMILIES = {
     "bernoulli": sm_families.Binomial,
@@ -23,34 +22,6 @@ STATSMODELS_LINKS = {
 }
 
 
-def cloglog(x):
-    """Cloglog function that ensures result is in (0, 1)"""
-    result = 1 - np.exp(-np.exp(x))
-    result = force_within_unit_interval(result)
-    return result
-
-
-def probit(x):
-    """Probit function that ensures result is in (0, 1)"""
-    result = 0.5 + 0.5 * special.erf(x / 2 ** 0.5)
-    result = force_within_unit_interval(result)
-    return result
-
-
-def expit(x):
-    """Expit function that ensures result is in (0, 1)"""
-    result = special.expit(x)
-    result = force_within_unit_interval(result)
-    return result
-
-
-def force_within_unit_interval(x):
-    eps = np.finfo(float).eps
-    x[x == 0] = eps
-    x[x == 1] = 1 - eps
-    return x
-
-
 class Family:
     """A specification of model family.
 
@@ -60,26 +31,15 @@ class Family:
         Family name.
     likelihood: Likelihood
         A ``Likelihood`` instace specifying the model likelihood function.
-    link : str or function
+    link : str or Link
         The name of the link function, or the function itself, transforming the linear model
         prediction to the mean parameter of the likelihood. If a function, it must be able to
         operate over theano tensors rather than numpy arrays.
     """
 
-    LINKS = {
-        "cloglog": cloglog,
-        "identity": lambda x: x,
-        "inverse_squared": lambda x: 1 / np.sqrt(x),
-        "inverse": lambda x: 1 / x,
-        "log": np.exp,
-        "logit": expit,
-        "probit": probit,
-    }
-
     def __init__(self, name, likelihood, link):
         self.smlink = None
         self.link = None
-        self._link = None
         self.name = name
         self.likelihood = likelihood
         self.smfamily = STATSMODELS_FAMILIES.get(name, None)
@@ -88,30 +48,32 @@ class Family:
     def _set_link(self, link):
         """Set new link function.
 
-        It updates both ``self.link`` (a string or function passed to the backend) and
-        ``self.smlink`` (the link instance for the statsmodel family).
+        If ``link`` is a ``str``, this method updates passes tries to create a ``Link`` instance
+        using the name in ``link``. If it is a recognized name, a builtin ``Link`` will be used.
+        Otherwise, ``Link`` instantiation will raise an error.
+
+        Parameters
+        ----------
+        link: str or Link
+            If a string, it must the name of a link function recognized by Bambi.
+
+        Returns
+        -------
+        None
         """
         if isinstance(link, str):
-            if link in self.LINKS:
-                self.link = link
-                self._link = self.LINKS[link]
-                self.smlink = STATSMODELS_LINKS.get(link, None)
-            else:
-                raise ValueError(f"Link name '{link}' is not supported.")
-        # Things like classes are still callable, so this is not ideal.
-        # But it is hard to check whether something is a function OR something like
-        # 'tt.nnet.sigmoid'. These return False for inspect.isfunction().
-        elif callable(link):
+            self.link = Link(link)
+            self.smlink = STATSMODELS_LINKS.get(link, None)
+        elif isinstance(link, Link):
             self.link = link
-            self._link = link
         else:
-            raise ValueError("'link' must be a string or a function.")
+            raise ValueError("'link' must be a string or a Link instance.")
 
     def __str__(self):
         if self.link is None:
             msg = "No family set"
         else:
-            msg_list = [f"Response distribution: {self.likelihood.name}", f"Link: {self.link}"]
+            msg_list = [f"Response distribution: {self.likelihood.name}", f"Link: {self.link.name}"]
             if self.likelihood.priors:
                 priors_msg = "\n  ".join([f"{k} ~ {v}" for k, v in self.likelihood.priors.items()])
                 msg_list += [f"Priors:\n  {priors_msg}"]

--- a/bambi/priors/likelihood.py
+++ b/bambi/priors/likelihood.py
@@ -30,11 +30,12 @@ class Likelihood:
 
     DISTRIBUTIONS = DISTRIBUTIONS
 
-    def __init__(self, name, parent=None, **kwargs):
+    def __init__(self, name, parent=None, pps=None, **kwargs):
         if name in self.DISTRIBUTIONS:
             self.name = name
             self.parent = self._get_parent(parent)
             self.priors = self._check_priors(kwargs)
+            self.pps = pps
         else:
             # On your own risk
             self.name = name
@@ -42,6 +43,7 @@ class Likelihood:
             check_all_are_priors(kwargs)
             self.priors = kwargs
             self.parent = parent
+            self.pps = pps
 
     def _get_parent(self, parent):
         if parent is None:

--- a/bambi/priors/link.py
+++ b/bambi/priors/link.py
@@ -1,0 +1,107 @@
+import numpy as np
+
+from scipy import special
+
+
+def force_within_unit_interval(x):
+    eps = np.finfo(float).eps
+    x[x == 0] = eps
+    x[x == 1] = 1 - eps
+    return x
+
+
+def force_greater_than_zero(x):
+    eps = np.finfo(float).eps
+    x[x == 0] = eps
+    return x
+
+
+def cloglog(mu):
+    """Cloglog function that ensures the input is greater than 0."""
+    mu = force_greater_than_zero(mu)
+    return np.log(-np.log(1 - mu))
+
+
+def invcloglog(eta):
+    """Inverse of the cloglog function that ensures result is in (0, 1)"""
+    result = 1 - np.exp(-np.exp(eta))
+    return force_within_unit_interval(result)
+
+
+def probit(mu):
+    """Probit function that ensures the input is in (0, 1)"""
+    mu = force_within_unit_interval(mu)
+    return 2 ** 0.5 * special.erfinv(2 * mu - 1)  # pylint: disable=no-member
+
+
+def invprobit(eta):
+    """Inverse of the probit function that ensures result is in (0, 1)"""
+    result = 0.5 + 0.5 * special.erf(eta / 2 ** 0.5)  # pylint: disable=no-member
+    return force_within_unit_interval(result)
+
+
+def expit(eta):
+    """Expit function that ensures result is in (0, 1)"""
+    result = special.expit(eta)  # pylint: disable=no-member
+    result = force_within_unit_interval(result)
+    return result
+
+
+def logit(mu):
+    """Logit function that ensures the input is in (0, 1)"""
+    mu = force_within_unit_interval(mu)
+    return special.logit(mu)  # pylint: disable=no-member
+
+
+# linkfun: These are g. They map the response to the linear predictor scale.
+# linkinv: These are g^(-1). They map the linear predictor to the response scale.
+# fmt: off
+LINKS = {
+    "cloglog": {
+        "link": cloglog,
+        "linkinv": invcloglog
+    },
+    "identity": {
+        "link": lambda mu: mu,
+        "linkinv": lambda eta: eta
+    },
+    "inverse_squared": {
+        "link": lambda mu: 1 / mu ** 2,
+        "linkinv": lambda eta: 1 / np.sqrt(eta)
+    },
+    "inverse": {
+        "link": cloglog,
+        "linkinv": invcloglog
+    },
+    "log": {
+        "link": np.log,
+        "linkinv": np.exp
+    },
+    "logit": {
+        "link": logit,
+        "linkinv": expit
+    },
+    "probit": {
+        "link": probit,
+        "linkinv": invprobit
+    }
+}
+# fmt: on
+
+
+class Link:
+    def __init__(self, name, link=None, linkinv=None, linkinv_backend=None):
+        self.name = name
+        self.link = link
+        self.linkinv = linkinv
+        self.linkinv_backend = linkinv_backend
+
+        if name in LINKS:
+            self.link = LINKS[name]["link"]
+            self.linkinv = LINKS[name]["linkinv"]
+        else:
+            if not link or not linkinv or linkinv_backend:
+                raise ValueError(
+                    f"Link name '{name}' is not supported and at least one of 'link', "
+                    "'linkinv' or 'linkinv_backend' are unespecified."
+                )

--- a/bambi/priors/scaler_default.py
+++ b/bambi/priors/scaler_default.py
@@ -17,7 +17,7 @@ class PriorScaler:
         self.priors = {}
 
         # Compute mean and std of the response
-        if self.model.family.name == "gaussian":
+        if self.model.family.name in ["gaussian", "t"]:
             self.response_mean = np.mean(model.response.data)
             self.response_std = np.std(self.model.response.data)
         else:

--- a/bambi/tests/test_predict.py
+++ b/bambi/tests/test_predict.py
@@ -1,0 +1,198 @@
+from os.path import dirname, join
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bambi.models import Model
+
+
+@pytest.fixture(scope="module")
+def data_numeric_xy():
+    x = np.random.uniform(size=100)
+    y = x + np.random.normal(scale=0.5, size=100)
+    data = pd.DataFrame({"y": y, "x": x})
+    return data
+
+
+@pytest.fixture(scope="module")
+def data_bernoulli():
+    # Taken from https://juanitorduz.github.io/glm_pymc3/
+    n = 250
+    x1 = np.random.normal(loc=0.0, scale=2.0, size=n)
+    x2 = np.random.normal(loc=0.0, scale=2.0, size=n)
+    intercept = -0.5
+    beta_x1 = 1
+    beta_x2 = -1
+    beta_interaction = 2
+    z = intercept + beta_x1 * x1 + beta_x2 * x2 + beta_interaction * x1 * x2
+    p = 1 / (1 + np.exp(-z))
+    y = np.random.binomial(n=1, p=p, size=n)
+    df = pd.DataFrame(dict(x1=x1, x2=x2, y=y))
+    return df
+
+
+@pytest.fixture(scope="module")
+def data_beta():
+    return pd.read_csv(join(dirname(__file__), "data", "gasoline.csv"))
+
+
+@pytest.fixture(scope="module")
+def data_gamma():
+    N = 200
+    x = np.random.uniform(-1, 1, N)
+    a = 0.5
+    b = 1.1
+    shape = 10
+    y = np.random.gamma(shape, np.exp(a + b * x) / shape, N)
+    data = pd.DataFrame({"x": x, "y": y})
+    return data
+
+
+@pytest.fixture(scope="module")
+def data_count():
+    data = pd.DataFrame(
+        {"y": np.random.poisson(list(range(10)) * 10), "x": np.random.uniform(size=100)}
+    )
+    return data
+
+
+def test_predict_bernoulli(data_bernoulli):
+    data = data_bernoulli
+    model = Model("y ~ x1*x2", data, family="bernoulli")
+    idata = model.fit(target_accept=0.90)
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    assert (0 < idata.posterior["y_mean"]).all() & (idata.posterior["y_mean"] < 1).all()
+    assert (idata.posterior_predictive["y"].isin([0, 1])).all()
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+    assert (0 < idata.posterior["y_mean"]).all() & (idata.posterior["y_mean"] < 1).all()
+    assert (idata.posterior_predictive["y"].isin([0, 1])).all()
+
+
+def test_predict_beta(data_beta):
+    data = data_beta
+    data["batch"] = pd.Categorical(data["batch"], [10, 1, 2, 3, 4, 5, 6, 7, 8, 9], ordered=True)
+    model = Model("yield ~ temp + batch", data, family="beta")
+    idata = model.fit(target_accept=0.90)
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    assert (0 < idata.posterior["yield_mean"]).all() & (idata.posterior["yield_mean"] < 1).all()
+    assert (0 < idata.posterior_predictive["yield"]).all() & (
+        idata.posterior_predictive["yield"] < 1
+    ).all()
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+    assert (0 < idata.posterior["yield_mean"]).all() & (idata.posterior["yield_mean"] < 1).all()
+    assert (0 < idata.posterior_predictive["yield"]).all() & (
+        idata.posterior_predictive["yield"] < 1
+    ).all()
+
+
+def test_predict_gamma(data_gamma):
+    data = data_gamma
+
+    model = Model("y ~ x", data, family="gamma", link="log")
+    idata = model.fit()
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (0 < idata.posterior_predictive["y"]).all()
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (0 < idata.posterior_predictive["y"]).all()
+
+
+def test_predict_gaussian(data_numeric_xy):
+    data = data_numeric_xy
+    model = Model("y ~ x", data, family="gaussian")
+    idata = model.fit()
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+
+def test_predict_negativebinomial(data_count):
+    data = data_count
+
+    model = Model("y ~ x", data, family="negativebinomial")
+    idata = model.fit()
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (np.equal(np.mod(idata.posterior_predictive["y"].values, 1), 0)).all()
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (np.equal(np.mod(idata.posterior_predictive["y"].values, 1), 0)).all()
+
+
+def test_predict_poisson(data_count):
+    data = data_count
+
+    model = Model("y ~ x", data, family="negativebinomial")
+    idata = model.fit()
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (np.equal(np.mod(idata.posterior_predictive["y"].values, 1), 0)).all()
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (np.equal(np.mod(idata.posterior_predictive["y"].values, 1), 0)).all()
+
+
+def test_predict_t(data_numeric_xy):
+    data = data_numeric_xy
+    model = Model("y ~ x", data, family="t")
+    idata = model.fit()
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+
+def test_predict_wald(data_gamma):
+    data = data_gamma
+
+    model = Model("y ~ x", data, family="wald", link="log")
+    idata = model.fit()
+
+    model.predict(idata, kind="mean")
+    model.predict(idata, kind="pps")
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (0 < idata.posterior_predictive["y"]).all()
+
+    model.predict(idata, kind="mean", data=data.iloc[:20, :])
+    model.predict(idata, kind="pps", data=data.iloc[:20, :])
+
+    assert (0 < idata.posterior["y_mean"]).all()
+    assert (0 < idata.posterior_predictive["y"]).all()

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -81,7 +81,7 @@ def test_likelihood_bad_priors():
 def test_family_class():
     cheese = Prior("CheeseWhiz", holes=0, taste=-10)
     likelihood = Likelihood("Cheese", parent="holes", cheese=cheese)
-    family = Family("cheese", likelihood=likelihood, link="ferment")
+    family = Family("cheese", likelihood=likelihood, link="logit")
 
     for name in ["name", "likelihood", "link"]:
         assert hasattr(family, name)
@@ -137,7 +137,7 @@ def test_prior_eq():
 def test_family_link_unsupported():
     cheese = Prior("CheeseWhiz", holes=0, taste=-10)
     likelihood = Likelihood("Cheese", parent="holes", cheese=cheese)
-    family = Family("cheese", likelihood=likelihood, link="ferment")
+    family = Family("cheese", likelihood=likelihood, link="cloglog")
     with pytest.raises(ValueError):
         family._set_link("Empty")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-formulae>=0.1.0
+formulae>=0.1.1
 numpy>=1.16.1
 pandas>=1.0.0
 pymc3>=3.9.0
+scipy>=1.7.0
 statsmodels>=0.9
 arviz @ git+https://git@github.com/arviz-devs/arviz.git@e8e9f79
 


### PR DESCRIPTION
Add a `.predict()` method to the `Model` class. This enables both in-sample and out-sample prediction. The `.predict()` method has the following arguments

* `idata`: `InfereceData` with samples from the posterior distribution. This is mandatory.
* `kind`: `str` either `"mean"` or ~`"distribution"`~ `"pps"`. Defaults to `"mean"`.
* ~`scale`: `str` either `"response"` or `"link"`. Defaults to `"response"`.~
* `data`: `pd.DataFrame` or `None`. If `pd.DataFrame`, it is where we look for variables with which to predict (out of sample predictions). If `None`, it uses the original data and thus obtains in-sample predictions.

## How it works

Let's say we have a logistic regression with mixed effects

```python
import bambi as bmb
import numpy as np
import pandas as pd

f_delta = pd.DataFrame({
    "A": np.random.choice([0, 1], size=100),
    "B": np.random.normal(size=100),
    "C": np.random.normal(size=100),
    "D": np.random.normal(size=100),
    "E": ["Group 1"] * 25 + ["Group 2"] * 25 + ["Group 3"] * 25 + ["Group 4"] * 25
})

# Fit the model
model = bmb.Model('A ~ 0 + B + C + D + (1|E)', f_delta, family = 'bernoulli')
idata = model.fit()

# Select some random rows from the original data
# In practice this would be another data set.
rows = np.random.choice(np.arange(f_delta.shape[0]), size = 20)
f_delta_2 = f_delta.iloc[rows, :]
```
### Mean prediction in the response scale

This is the default behavior

```python
model.predict(idata, data=f_delta_2)
array([0.63472875, 0.57823079, 0.45717866, 0.494302  , 0.61275881,
       0.52552663, 0.51325799, 0.35138795, 0.53079801, 0.51123194,
       0.62658852, 0.51519193, 0.51138368, 0.56288993, 0.64367165,
       0.53358324, 0.42119659, 0.60092995, 0.44419184, 0.49119846])
```

### Predictive distribution in the response scale

```python
predictions = model.predict(idata, kind="distribution", data=f_delta_2)
predictions.shape # (20, 2000)
```

```python
predictions
array([[0.57790498, 0.63729905, 0.57557616, ..., 0.5984925 , 0.77373198,
        0.55506065],
       [0.5476052 , 0.49407264, 0.44980499, ..., 0.54965804, 0.76856762,
        0.6191289 ],
       [0.43681045, 0.49063546, 0.60930524, ..., 0.43931939, 0.38990382,
        0.46463923],
       ...,
       [0.49536406, 0.60846616, 0.61157835, ..., 0.53008153, 0.69289172,
        0.52488174],
       [0.4375965 , 0.38921687, 0.39291667, ..., 0.41222194, 0.33595178,
        0.52009173],
       [0.52432786, 0.48379762, 0.46095579, ..., 0.50706812, 0.53381684,
        0.40977213]])
```

### Other usages

* With `scale="link"` the predictions are obtained in the scale of the linear predictor (e.g. log-odds for the model above)
* If `data=None`, the predictions are obtained for the sample used to fit the model.

### Notes

* What about having an option that returns both the mean and quantiles and/or the whole distribution? This could be useful when you want to plot credibility bands for the mean as well as the mean value.
* This implementation uses the trace obtained when sampling from the posterior. As far as I understand, `pm.sample_posterior_predictive()` draws samples of parameters from that trace and, for each sample, it draws N random values from the response distribution with its parameters based on the given draw from the trace. 




