### PR TITLE
Load data

### DIFF
--- a/bambi/__init__.py
+++ b/bambi/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from .data import clear_data_home, load_data
 from .models import Model
 from .priors import Prior, Family
 from .backends import PyMC3BackEnd

--- a/bambi/data/__init__.py
+++ b/bambi/data/__init__.py
@@ -1,0 +1,4 @@
+"""Code for loading datasets."""
+from .datasets import clear_data_home, load_data
+
+__all__ = ["clear_data_home", "load_data"]

--- a/bambi/data/datasets.py
+++ b/bambi/data/datasets.py
@@ -113,7 +113,8 @@ def load_data(dataset=None, data_home=None):
             return _list_datasets(home_dir)
         else:
             raise ValueError(
-                f"Dataset {dataset} not found! The following are available:\n{_list_datasets(home_dir)}"
+                f"Dataset {dataset} not found! "
+                f"The following are available:\n{_list_datasets(home_dir)}"
             )
 
 
@@ -123,9 +124,9 @@ def _list_datasets(home_dir):
     for filename, resource in itertools.chain(DATASETS.items()):
         file_path = os.path.join(home_dir, filename)
         if not os.path.exists(file_path):
-            location = f"remote: {resource.url}"
+            location = f"location: {resource.url}"
         else:
-            location = f"local: {file_path}"
+            location = f"location: {file_path}"
         lines.append(f"{filename}\n{'=' * len(filename)}\n{resource.description}\n{location}")
 
     return f"\n\n{10 * '-'}\n\n".join(lines)

--- a/bambi/data/datasets.py
+++ b/bambi/data/datasets.py
@@ -1,0 +1,131 @@
+"""Base IO code for datasets. Heavily influenced by Arviz's (and scikit-learn's) implementation."""
+import hashlib
+import itertools
+import os
+import shutil
+from collections import namedtuple
+from urllib.request import urlretrieve
+
+import pandas as pd
+
+
+FileMetadata = namedtuple("FileMetadata", ["filename", "url", "checksum", "description"])
+DATASETS = {
+    "my_data.csv": FileMetadata(
+        filename="my_data.csv",
+        url="https://ndownloader.figshare.com/files/28850355",
+        checksum="1bfcdd10d0848c1811e33e467c92734fb488406ef3f9b9aae16a57b258a30fac",
+        description="""
+Toy dataset with one response variable "y" and two covariates "x" and "z".
+""",
+    ),
+}
+
+
+def get_data_home(data_home=None):
+    """Return the path of the Bambi data dir.
+
+    This folder is used to avoid downloading the data several times.
+
+    By default the data dir is set to a folder named 'bambi_data' in the user home folder.
+    Alternatively, it can be set by the 'BAMBI_DATA' environment variable or programmatically by
+    giving an explicit folder path. The '~' symbol is expanded to the user home folder. If the
+    folder does not already exist, it is automatically created.
+
+    Parameters
+    ----------
+    data_home : str
+        The path to Bambi data dir.
+    """
+    if data_home is None:
+        data_home = os.environ.get("BAMBI_DATA", os.path.join("~", "bambi_data"))
+    data_home = os.path.expanduser(data_home)
+    if not os.path.exists(data_home):
+        os.makedirs(data_home)
+    return data_home
+
+
+def clear_data_home(data_home=None):
+    """Delete all the content of the data home cache.
+
+    Parameters
+    ----------
+    data_home : str
+        The path to Bambi data dir. By default a folder named 'bambi_data' in the user home folder.
+    """
+    data_home = get_data_home(data_home)
+    shutil.rmtree(data_home)
+
+
+def _sha256(path):
+    """Calculate the sha256 hash of the file at path."""
+
+    sha256hash = hashlib.sha256()
+    chunk_size = 8192
+    with open(path, "rb") as buff:
+        while True:
+            buffer = buff.read(chunk_size)
+            if not buffer:
+                break
+            sha256hash.update(buffer)
+
+    return sha256hash.hexdigest()
+
+
+def load_data(dataset=None, data_home=None):
+    """Load a dataset.
+
+    Run with no parameters to get a list of all available models.
+
+    The directory to save can also be set with the environment variable `BAMBI_HOME`.
+    The checksum of the dataset is checked against a hardcoded value to watch for data corruption.
+    Run `bmb.clear_data_home` to clear the data directory.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of dataset to load.
+    data_home : str, optional
+        Where to save remote datasets
+
+    Returns
+    -------
+    Pandas DataFrame
+    """
+    home_dir = get_data_home(data_home=data_home)
+
+    if dataset in DATASETS:
+        datafile = DATASETS[dataset]
+        file_path = os.path.join(home_dir, datafile.filename)
+
+        if not os.path.exists(file_path):
+            urlretrieve(datafile.url, file_path)
+            checksum = _sha256(file_path)
+            if datafile.checksum != checksum:
+                raise IOError(
+                    "{file_path} has an SHA256 checksum ({checksum}) differing from expected "
+                    "({datafile.checksum}), file may be corrupted. Run `bambi.clear_data_home()` "
+                    "and try again, or please open an issue."
+                )
+        return pd.read_csv(file_path)
+    else:
+        if dataset is None:
+            return _list_datasets(home_dir)
+        else:
+            raise ValueError(
+                f"Dataset {dataset} not found! The following are available:\n{_list_datasets(home_dir)}"
+            )
+
+
+def _list_datasets(home_dir):
+    """Get a string representation of all available datasets with descriptions."""
+    lines = []
+    for filename, resource in itertools.chain(DATASETS.items()):
+        file_path = os.path.join(home_dir, filename)
+        if not os.path.exists(file_path):
+            location = f"remote: {resource.url}"
+        else:
+            location = f"local: {file_path}"
+        lines.append(f"{filename}\n{'=' * len(filename)}\n{resource.description}\n{location}")
+
+    return f"\n\n{10 * '-'}\n\n".join(lines)

--- a/bambi/tests/test_data.py
+++ b/bambi/tests/test_data.py
@@ -1,5 +1,4 @@
 import os
-from collections import namedtuple
 from urllib.parse import urlunsplit
 
 import pandas as pd
@@ -14,8 +13,8 @@ def no_remote_data(monkeypatch, tmpdir):
     """Run tests without relying on remote data"""
 
     filename = os.path.join(str(tmpdir), os.path.basename("test_remote.csv"))
-    with open(filename, 'w') as fd:
-        fd.write("x,y\n0,1")
+    with open(filename, "w") as fdo:
+        fdo.write("x,y\n0,1")
     url = urlunsplit(("file", "", filename, "", ""))
 
     monkeypatch.setitem(
@@ -46,7 +45,7 @@ def test_clear_data_home():
 
 def test_load_data():
     df = load_data("test_remote")
-    df_ = pd.DataFrame({"x":[0], "y":[1]})
+    df_ = pd.DataFrame({"x": [0], "y": [1]})
     assert df.equals(df_)
 
 
@@ -65,7 +64,5 @@ def test_missing_dataset():
 def test_list_datasets():
     dataset_string = load_data()
     # make sure all the names of the data sets are in the dataset description
-    for key in (
-        "my_data",
-    ):
+    for key in ("my_data",):
         assert key in dataset_string

--- a/bambi/tests/test_data.py
+++ b/bambi/tests/test_data.py
@@ -1,0 +1,72 @@
+import os
+from collections import namedtuple
+from urllib.parse import urlunsplit
+
+import pandas as pd
+import pytest
+
+from bambi import clear_data_home, load_data
+from bambi.data.datasets import DATASETS, FileMetadata
+#RemoteFileMetadata
+
+
+@pytest.fixture(autouse=True)
+def no_remote_data(monkeypatch, tmpdir):
+    """Run tests without relying on remote data"""
+
+    filename = os.path.join(str(tmpdir), os.path.basename("test_remote.csv"))
+    with open(filename, 'w') as fd:
+        fd.write("x,y\n0,1")
+    url = urlunsplit(("file", "", filename, "", ""))
+
+    monkeypatch.setitem(
+        DATASETS,
+        "test_remote",
+        FileMetadata(
+            filename=filename,
+            url=url,
+            checksum="2c5501a9f5d7b6998fc7e6a4651030b9765032b2e5a1d7331f5b1f3df6c632a5",
+            description="aquella solitaria vaca cubana",
+        ),
+    )
+    monkeypatch.setitem(
+        DATASETS,
+        "bad_checksum",
+        FileMetadata(
+            filename=filename, url=url, checksum="bad!", description="aquella solitaria vaca cubana"
+        ),
+    )
+
+
+def test_clear_data_home():
+    resource = DATASETS["test_remote"]
+    assert os.path.exists(resource.filename)
+    clear_data_home(data_home=os.path.dirname(resource.filename))
+    assert not os.path.exists(resource.filename)
+
+
+def test_load_data():
+    df = load_data("test_remote")
+    df_ = pd.DataFrame({"x":[0], "y":[1]})
+    assert df.equals(df_)
+
+
+def test_bad_checksum():
+    resource = DATASETS["test_remote"]
+    clear_data_home(data_home=os.path.dirname(resource.filename))
+    with pytest.raises(IOError):
+        load_data("bad_checksum")
+
+
+def test_missing_dataset():
+    with pytest.raises(ValueError):
+        load_data("does not exist")
+
+
+def test_list_datasets():
+    dataset_string = load_data()
+    # make sure all the names of the data sets are in the dataset description
+    for key in (
+        "my_data",
+    ):
+        assert key in dataset_string

--- a/bambi/tests/test_data.py
+++ b/bambi/tests/test_data.py
@@ -7,7 +7,6 @@ import pytest
 
 from bambi import clear_data_home, load_data
 from bambi.data.datasets import DATASETS, FileMetadata
-#RemoteFileMetadata
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR closely follows the ArviZ implementation of `load_arviz_data`. but with some differences. closes #373

It provides two new functions `load_data()` and `clear_home_cache`, the first one load a csv file from figshare or from a home folder if already downloaded and returns a DataFrame. If called without arguments it list all available datasets.  The second one deleted the home cache folder. Currently only one dataset is available, but ideally we should add all the ones used in the examples/documentation. 