### PR TITLE
Add potentials to models

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 ### New features
 * It is possible to specify priors for parameters in the response distribution (#335)
 * Add probit and cloglog link functions (#340)
+* Add option to specify potentials (#379)
 
 ### Maintenance and fixes
 * Informative message when default priors fail because of perfect separation. Model can be fit with custom priors (#330)

--- a/bambi/__init__.py
+++ b/bambi/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from pymc3 import math
+
 from .data import clear_data_home, load_data
 from .models import Model
 from .priors import Prior, Family

--- a/bambi/backends/pymc.py
+++ b/bambi/backends/pymc.py
@@ -117,6 +117,19 @@ class PyMC3BackEnd(BackEnd):
         with self.model:
             self.build_response(spec)
 
+        # add potentials to the model
+        if spec.potentials is not None:
+            with self.model:
+                count = 0
+                for variable, constraint in spec.potentials:
+                    if isinstance(variable, (list, tuple)):
+                        lambda_args = [self.model[var] for var in variable]
+                        potential = constraint(*lambda_args)
+                    else:
+                        potential = constraint(self.model[variable])
+                    pm.Potential(f"pot_{count}", potential)
+                    count += 1
+
         self.spec = spec
 
     # pylint: disable=arguments-differ, inconsistent-return-statements

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -95,6 +95,7 @@ class Model:
         noncentered=True,
         priors_cor=None,
         taylor=None,
+        potentials=None,
     ):
         # attributes that are set later
         self.terms = {}
@@ -115,6 +116,7 @@ class Model:
         self.dropna = dropna
         self.taylor = taylor
         self.noncentered = noncentered
+        self.potentials = potentials
 
         # Read and clean data
         if isinstance(data, str):
@@ -184,9 +186,7 @@ class Model:
         self._build_priors()
 
     def fit(
-        self,
-        omit_offsets=True,
-        **kwargs,
+        self, omit_offsets=True, **kwargs,
     ):
         """Fit the model using the specified backend.
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -194,7 +194,9 @@ class Model:
         self._build_priors()
 
     def fit(
-        self, omit_offsets=True, **kwargs,
+        self,
+        omit_offsets=True,
+        **kwargs,
     ):
         """Fit the model using the specified backend.
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -55,6 +55,14 @@ class Model:
         the ``DataFrame`` will be used to infer handling. In cases where numeric columns are
         to be treated as categoricals (e.g., group specific factors coded as numerical IDs),
         explicitly passing variable names via this argument is recommended.
+    potentials : A list of 2-tuples.
+        Optional specification of potentials. A potential is an arbitrary expression added to the
+        likelihood, this is generally useful to add constrains to models, that are difficult to
+        express otherwise. The first term of a 2-tuple is the name of a variable in the model, the
+        second a lambda function expressing the desired constraint.
+        If a constraint involves n variables, you can pass n 2-tuples or pass a tuple which first
+        element is a n-tuple and second element is a lambda function with n arguments. The number
+        and order of the lambda function has to match the number and order of the variables names.
     dropna : bool
         When ``True``, rows with any missing values in either the predictors or outcome are
         automatically dropped from the dataset in a listwise manner.
@@ -89,13 +97,13 @@ class Model:
         priors=None,
         link=None,
         categorical=None,
+        potentials=None,
         dropna=False,
         auto_scale=True,
         automatic_priors="default",
         noncentered=True,
         priors_cor=None,
         taylor=None,
-        potentials=None,
     ):
         # attributes that are set later
         self.terms = {}

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -107,7 +107,10 @@ def test_many_common_many_group_specific(crossed_data):
         dropna=True,
     )
     model0.fit(
-        init=None, tune=10, draws=10, chains=2,
+        init=None,
+        tune=10,
+        draws=10,
+        chains=2,
     )
 
     model1 = Model(
@@ -116,7 +119,9 @@ def test_many_common_many_group_specific(crossed_data):
         dropna=True,
     )
     model1.fit(
-        tune=10, draws=10, chains=2,
+        tune=10,
+        draws=10,
+        chains=2,
     )
     # check that the group specific effects design matrices have the same shape
     X0 = pd.concat([pd.DataFrame(t.data) for t in model0.group_specific_terms.values()], axis=1)
@@ -281,7 +286,10 @@ def test_logistic_regression(crossed_data):
     model0 = Model(
         "threecats['b'] ~ continuous + dummy", crossed_data, family="bernoulli", link="logit"
     )
-    fitted0 = model0.fit(tune=0, draws=1000,)
+    fitted0 = model0.fit(
+        tune=0,
+        draws=1000,
+    )
 
     # build model using fit, pymc3 and theano link function
     model1 = Model(
@@ -290,7 +298,10 @@ def test_logistic_regression(crossed_data):
         family="bernoulli",
         link=tt.nnet.sigmoid,
     )
-    fitted1 = model1.fit(tune=0, draws=1000,)
+    fitted1 = model1.fit(
+        tune=0,
+        draws=1000,
+    )
 
     # check that using a theano link function works
     assert np.allclose(az.summary(fitted0)["mean"], az.summary(fitted1)["mean"], atol=0.2)
@@ -521,7 +532,12 @@ def test_potentials():
     ]
 
     model = Model(
-        "w ~ 1", data, family="bernoulli", link="identity", priors=priors, potentials=potentials,
+        "w ~ 1",
+        data,
+        family="bernoulli",
+        link="identity",
+        priors=priors,
+        potentials=potentials,
     )
     model.build()
     assert len(model.backend.model.potentials) == 2


### PR DESCRIPTION
A potential is an arbitrary expression added to the likelihood, this is generally useful to add constrains to models. For example 

```python
data = pd.DataFrame(np.repeat((0, 1), (18, 20)), columns=['w'])
priors = {'Intercept': bmb.Prior('Uniform', lower=0, upper=1)}
potentials = [('Intercept', lambda x : bmb.math.switch((x < 0.45) | (x  > 0.55), 0, -999))]
model = bmb.Model('w ~ 1', data, family='bernoulli', link='identity', priors=priors, 
                  potentials=potentials,
                  )
results = model.fit()
```

will produce 

![index](https://user-images.githubusercontent.com/1338958/126450868-e0212a39-6601-4f16-b104-d170b2145bb6.png)
