### PR TITLE
Fix a few typos in logistic regression notebook

### DIFF
--- a/docs/notebooks/logistic_regression.ipynb
+++ b/docs/notebooks/logistic_regression.ipynb
@@ -635,7 +635,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's check out the the results! We get traceplots and density estimates for the posteriors with `az.plot_trace()` and a summary of the posteriors with `az.summary()`."
+    "Now let's check out the results! We get traceplots and density estimates for the posteriors with `az.plot_trace()` and a summary of the posteriors with `az.summary()`."
    ]
   },
   {
@@ -922,7 +922,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A first look at the khat plot shows that most obervations' $\\hat \\kappa$ values are grouped toghether in a range that goes up to roughly 0.2. Above that value, we observe some dispersion and a few points that stand out by having the highest $\\hat \\kappa $ values. \n",
+    "A first look at the khat plot shows that most observations' $\\hat \\kappa$ values are grouped together in a range that goes up to roughly 0.2. Above that value, we observe some dispersion and a few points that stand out by having the highest $\\hat \\kappa$ values. \n",
     "\n",
     "An observation is influential in the sense that if we refit the data by first removing that observation from the data set, the fitted result will be more different than if we do the same for a non influential observation. Clearly the level of influence of observations can vary continuously. An observation can be influential either because it is an outlier (a measurement error, a data entry error, etc) or because the model is not flexible enough to capture the observation. The approximations used to compute LOO are no longer reliable for $\\hat \\kappa > 0.7$.\n",
     "\n",
@@ -1456,7 +1456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This assessment helped us to further understand the model and quality of the fit. It also illustratres the intuition that we should be cautious when predicting for under represented age groups and voting behaviours."
+    "This assessment helped us to further understand the model and quality of the fit. It also illustrates the intuition that we should be cautious when predicting for under represented age groups and voting behaviours."
    ]
   },
   {


### PR DESCRIPTION
Hi maintainers, thanks for creating an maintaining Bambi, it is so nice to have a familiar API hitting a sweet spot between R formulas and sklearn's `fit()`/`predict()` (looking forward to getting this one)! The error in rendering of $\\hat \\kappa $ was bothering me (in documentation, in notebooks it looks fine); while at I also corrected some other typos. I hope you find this tiny PR useful.