### PR TITLE
update docs to main tag

### DIFF
--- a/docs/_assets/gh-pages-redirect.html
+++ b/docs/_assets/gh-pages-redirect.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Redirecting to https://bambinos.github.io/bambi/master/</title>
+    <title>Redirecting to https://bambinos.github.io/bambi/main/</title>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./master/index.html">
+    <meta http-equiv="refresh" content="0; url=./main/index.html">
     <link rel="canonical" href="https://bambinos.github.io/bambi/">
   </head>
 </html>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,7 +134,7 @@ html_static_path = ['_static']
 smv_remote_whitelist = r"^origin$"
 
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = r"^master$"
+smv_branch_whitelist = r"^main$"
 
 # Tags are released
 smv_released_pattern = r'^refs/tags/.*$'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ BAyesian Model-Building Interface (Bambi) in Python
 .. |Tests| image:: https://github.com/bambinos/bambi/actions/workflows/test.yml/badge.svg
     :target: https://github.com/bambinos/bambi
 
-.. |Coverage| image:: https://codecov.io/gh/bambinos/bambi/branch/master/graph/badge.svg?token=ZqH0KCLKAE
+.. |Coverage| image:: https://codecov.io/gh/bambinos/bambi/branch/main/graph/badge.svg?token=ZqH0KCLKAE
     :target: https://codecov.io/gh/bambinos/bambi
 
 .. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
@@ -25,7 +25,7 @@ Bambi is a high-level Bayesian model-building interface written in Python. It wo
 
 Dependencies
 ============
-Bambi is tested on Python 3.7+ and depends on ArviZ, formulae, NumPy, pandas, PyMC3 and statsmodels (see `requirements.txt <https://github.com/bambinos/bambi/blob/master/requirements.txt>`_ for version information).
+Bambi is tested on Python 3.7+ and depends on ArviZ, formulae, NumPy, pandas, PyMC3 and statsmodels (see `requirements.txt <https://github.com/bambinos/bambi/blob/main/requirements.txt>`_ for version information).
 
 Installation
 ============
@@ -93,7 +93,7 @@ Here is the citation in BibTeX format
 
 Contributing
 ============
-We welcome contributions from interested individuals or groups! For information about contributing to Bambi, check out our instructions, policies, and guidelines `here <https://github.com/bambinos/bambi/blob/master/CONTRIBUTING.md>`_.
+We welcome contributions from interested individuals or groups! For information about contributing to Bambi, check out our instructions, policies, and guidelines `here <https://github.com/bambinos/bambi/blob/main/CONTRIBUTING.md>`_.
 
 Contributors
 ============


### PR DESCRIPTION
There were some things still depending on the 'master' name, now they are updated to 'main'.