### PR TITLE
Rebuild all documentation from scratch when there is a new release

### DIFF
--- a/.github/workflows/publish-docs-release.yml
+++ b/.github/workflows/publish-docs-release.yml
@@ -1,10 +1,9 @@
-name: Build and publish documentation
+name: Rebuilt entire documentation
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  release:
+    types:
+      - created
 
 jobs:
   build:
@@ -33,29 +32,19 @@ jobs:
           python setup.py install
 
       - name: Checkout gh-pages
-        # As we already did a deploy of gh-pages above, it is guaranteed to be there
-        # so check it out so we can selectively build docs below
         uses: actions/checkout@v2
         with:
           ref: gh-pages
           path: docs/_build/html
 
-      - name: Test Build Docs
-        if: github.ref != 'refs/heads/main' && ! startsWith(github.ref, 'refs/tags')
+      - name: Remove and build documentation from scratch
         run: |
-          BUILDDIR=_build/html/main make -C docs/ local
-
-      - name: Build Docs
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
-        # Use the args we normally pass to sphinx-build, but run sphinx-multiversion
-        run: |
+          rm -rd docs/_build/html
           sphinx-multiversion docs docs/_build/html
           touch docs/_build/html/.nojekyll
           cp docs/_assets/gh-pages-redirect.html docs/_build/html/index.html
 
       - name: Publish Docs to gh-pages
-        # Only once from main or a tag
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
         uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -41,12 +41,12 @@ jobs:
           path: docs/_build/html
 
       - name: Test Build Docs
-        if: github.ref != 'refs/heads/main' && ! startsWith(github.ref, 'refs/tags')
+        #if: github.ref != 'refs/heads/main' && ! startsWith(github.ref, 'refs/tags')
         run: |
           BUILDDIR=_build/html/main make -C docs/ local
 
       - name: Build Docs
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
+        #if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
         # Use the args we normally pass to sphinx-build, but run sphinx-multiversion
         run: |
           sphinx-multiversion docs docs/_build/html
@@ -58,7 +58,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501  # v3.7.3
+        uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501 # v3.7.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,21 +9,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.7"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,17 @@
 name: Run tests
 
 on:
-    push:
-        branches:
-         - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9' ]
+        python-version: ["3.7", "3.8", "3.9"]
 
     name: Set up Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
Our current approach does not rebuild documentation for previous versions. On one hand, this is good because it takes less time. On the other hand, it means that old pages aren't updated to reflect changes in newer versions.

This PR adds `.github/workflows/publish-docs-release.yml` which runs when there's a new release. This GA builds and publish all documentation from scratch, which should solve the problem without having to rebuild all the documentation from scratch all the time.

**Edit**

I've just rebuilt the gh-pages branch in the base repository and everything is updated now. This full-update should happen automatically when making a new release thanks to the new GA.