### PR TITLE
Add new axis to prior predictive to represent 1 chain in inference data

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -694,7 +694,7 @@ class Model:
 
         response_name = self.response.name
         if response_name in pps:
-            prior_predictive = {response_name: pps.pop(response_name)}
+            prior_predictive = {response_name: pps.pop(response_name)[np.newaxis]}
             observed_data = {response_name: self.response.data.squeeze()}
         else:
             prior_predictive = {}

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -460,7 +460,7 @@ def test_prior_predictive(crossed_data):
     for key, shape in zip(keys, shapes):
         assert pps.prior[key].shape == shape
 
-    assert pps.prior_predictive["count"].shape == (500, 120)
+    assert pps.prior_predictive["count"].shape == (1, 500, 120)
     assert pps.observed_data["count"].shape == (120,)
 
     pps = model.prior_predictive(draws=500, var_names=["count"])


### PR DESCRIPTION
Just a tiny change. Prior predictive used to have shape of (draws, n_obs), but ArviZ interprets first dimension as chains, so this is now (chains, draws, n_obs) where chains is 1.