### PR TITLE
Move families to their own module, improve many docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -64,7 +64,6 @@ disable=missing-docstring,
         no-self-use,
         too-few-public-methods,
         bad-continuation
-        unspecified-encoding
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc
+++ b/.pylintrc
@@ -64,6 +64,7 @@ disable=missing-docstring,
         no-self-use,
         too-few-public-methods,
         bad-continuation
+        unspecified-encoding
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/bambi/__init__.py
+++ b/bambi/__init__.py
@@ -3,11 +3,11 @@ import logging
 from pymc3 import math
 
 from .data import clear_data_home, load_data
+from .families import Family, Likelihood, Link
 from .models import Model
-from .priors import Prior, Family, Likelihood, Link
+from .priors import Prior
 from .backends import PyMC3BackEnd
 from .version import __version__
-
 
 __all__ = ["Model", "Prior", "Family", "Likelihood", "Link", "PyMC3BackEnd"]
 

--- a/bambi/data/datasets.py
+++ b/bambi/data/datasets.py
@@ -64,8 +64,8 @@ def get_data_home(data_home=None):
     This folder is used to avoid downloading the data several times.
 
     By default the data dir is set to a folder named 'bambi_data' in the user home folder.
-    Alternatively, it can be set by the 'BAMBI_DATA' environment variable or programmatically by
-    giving an explicit folder path. The '~' symbol is expanded to the user home folder. If the
+    Alternatively, it can be set by the ``"BAMBI_DATA"`` environment variable or programmatically by
+    giving an explicit folder path. The ``"~"`` symbol is expanded to the user home folder. If the
     folder does not already exist, it is automatically created.
 
     Parameters
@@ -87,7 +87,8 @@ def clear_data_home(data_home=None):
     Parameters
     ----------
     data_home : str
-        The path to Bambi data dir. By default a folder named 'bambi_data' in the user home folder.
+        The path to Bambi data dir. By default a folder named ``"bambi_data"`` in the user home
+        folder.
     """
     data_home = get_data_home(data_home)
     shutil.rmtree(data_home)
@@ -111,11 +112,11 @@ def _sha256(path):
 def load_data(dataset=None, data_home=None):
     """Load a dataset.
 
-    Run with no parameters to get a list of all available models.
+    Run with no parameters to get a list of all available data sets.
 
-    The directory to save can also be set with the environment variable `BAMBI_HOME`.
+    The directory to save can also be set with the environment variable ``BAMBI_HOME``.
     The checksum of the dataset is checked against a hardcoded value to watch for data corruption.
-    Run `bmb.clear_data_home` to clear the data directory.
+    Run ``bmb.clear_data_home()`` to clear the data directory.
 
     Parameters
     ----------

--- a/bambi/defaults/__init__.py
+++ b/bambi/defaults/__init__.py
@@ -1,3 +1,4 @@
+"""Settings for default priors, families, etc. in Bambi."""
 from .defaults import get_default_prior, get_builtin_family
 
 __all__ = ["get_default_prior", "get_builtin_family"]

--- a/bambi/defaults/defaults.py
+++ b/bambi/defaults/defaults.py
@@ -1,7 +1,8 @@
-from . import pps
-from ..priors import Family, Likelihood, Prior
+from bambi.defaults import pps
+from bambi.families import Family, Likelihood
+from bambi.priors import Prior
 
-
+## NOTE: Check docs/api_reference.rst links the right lines from this document
 # Default parameters for PyMC3 distributions
 SETTINGS_DISTRIBUTIONS = {
     "Bernoulli": {"p": 0.5},
@@ -158,10 +159,11 @@ def get_default_prior(term_type):
 
 
 def get_builtin_family(name):
-    """Generate a built-in ``Family`` instance
+    """Generate a built-in ``bambi.families.Family`` instance
 
-    Given the name of a built-in family, this function returns a ``Family`` instance that is
-    constructed by calling other utility functions that construct the ``Likelihood`` and the
-    ``Prior``s that are needed to build the family.
+    Given the name of a built-in family, this function returns a ``bambi.families.Family`` instance
+    that is constructed by calling other utility functions that construct the
+    ``bambi.families.Likelihood`` and the ``bambi.priors.Prior`` instances that are needed to build
+    the family.
     """
     return generate_family(name, **SETTINGS_FAMILIES[name])

--- a/bambi/families/__init__.py
+++ b/bambi/families/__init__.py
@@ -1,0 +1,11 @@
+"""Classes to construct model families."""
+from .family import Family, _extract_family_prior
+from .likelihood import Likelihood
+from .link import Link
+
+__all__ = [
+    "_extract_family_prior",
+    "Family",
+    "Likelihood",
+    "Link",
+]

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -37,22 +37,21 @@ class Family:
 
     Examples
     --------
-    Some imports
 
-    >>> from bambi import Family, Likelihood, Prior
+    >>> import bambi as bmb
 
     Replicate the Gaussian built-in family.
 
-    >>> sigma_prior = Prior("HalfNormal", sigma=1)
-    >>> likelihood = Likelihood("Gaussian", parent="mu", sigma=sigma_prior)
-    >>> family = Family("gaussian", likelihood, "identity")
+    >>> sigma_prior = bmb.Prior("HalfNormal", sigma=1)
+    >>> likelihood = bmb.Likelihood("Gaussian", parent="mu", sigma=sigma_prior)
+    >>> family = bmb.Family("my_gaussian", likelihood, "identity")
     >>> # Then you can do
-    >>> # Model("y ~ x", data, family=family)
+    >>> # bmb.Model("y ~ x", data, family=family)
 
     Replicate the Bernoulli built-in family.
 
-    >>> likelihood = Likelihood("Bernoulli", parent="p")
-    >>> family = Family("bernoulli", likelihood, "logit")
+    >>> likelihood = bmb.Likelihood("Bernoulli", parent="p")
+    >>> family = bmb.Family("bernoulli2", likelihood, "logit")
     """
 
     def __init__(self, name, likelihood, link):

--- a/bambi/families/likelihood.py
+++ b/bambi/families/likelihood.py
@@ -1,6 +1,5 @@
-from .prior import Prior
-
-from ..utils import multilinify, spacify
+from bambi.priors import Prior
+from bambi.utils import multilinify, spacify
 
 DISTRIBUTIONS = {
     "Normal": {"params": ("mu", "sigma"), "parent": "mu", "args": ("sigma",)},
@@ -18,7 +17,9 @@ DISTRIBUTIONS = {
 class Likelihood:
     """Representation of a Likelihood function for a Bambi model.
 
-    'parent' must not be in 'kwargs'. 'parent' is inferred from the 'name' if it is a known name
+    Notes:
+    * ``parent`` must not be in ``kwargs``.
+    * ``parent`` is inferred from the ``name`` if it is a known name
 
     Parameters
     ----------
@@ -27,7 +28,7 @@ class Likelihood:
     parent: str
         Optional specification of the name of the mean parameter in the likelihood.
         This is the parameter whose transformation is modeled by the linear predictor.
-    kwargs
+    kwargs:
         Keyword arguments that indicate prior distributions for auxiliary parameters in the
         likelihood.
     """

--- a/bambi/families/link.py
+++ b/bambi/families/link.py
@@ -118,7 +118,7 @@ class Link:
         function in GLM jargon. Does not need to be specified when ``name`` is a known name.
     linkinv_backend: function
         Same than ``linkinv`` but must be something that works with PyMC3 backend (i.e. it must
-        work with Theano/Aesara tensors). Does not need to be specified when ``name`` is a known
+        work with Theano tensors). Does not need to be specified when ``name`` is a known
         name.
 
     """

--- a/bambi/families/link.py
+++ b/bambi/families/link.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from scipy import special
 
-from ..utils import multilinify, spacify
+from bambi.utils import multilinify, spacify
 
 
 def force_within_unit_interval(x):
@@ -96,7 +96,7 @@ LINKS = {
 class Link:
     """Representation of link function.
 
-    This object actually contains two main functions. One is the link function itself, the function
+    This object contains two main functions. One is the link function itself, the function
     that maps values in the response scale to the linear predictor, and the other is the inverse
     of the link function, that maps values of the linear predictor to the response scale.
 
@@ -111,14 +111,15 @@ class Link:
         other arguments because functions are already defined internally. If not known, all of
         ``link``, ``linkinv`` and ``linkinv_backend`` must be specified.
     link: function
-        A function that maps the response to the linear predictor. Known as 'g()' in GLM jargon.
-        Does not need to be specified when ``name`` is a known name.
+        A function that maps the response to the linear predictor. Known as the :math:`g` function
+        in GLM jargon. Does not need to be specified when ``name`` is a known name.
     linkinv: function
-        A function that maps the linear predictor to the response. Known as 'g()^-1' in GLM jargon.
-        Does not need to be specified when ``name`` is a known name.
+        A function that maps the linear predictor to the response. Known as the :math:`g^{-1}`
+        function in GLM jargon. Does not need to be specified when ``name`` is a known name.
     linkinv_backend: function
         Same than ``linkinv`` but must be something that works with PyMC3 backend (i.e. it must
-        work with Aesara tensors). Does not need to be specified when ``name`` is a known name.
+        work with Theano/Aesara tensors). Does not need to be specified when ``name`` is a known
+        name.
 
     """
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -14,7 +14,8 @@ from formulae import design_matrices
 
 from .backends import PyMC3BackEnd
 from .defaults import get_default_prior, get_builtin_family
-from .priors import Family, Prior, PriorScaler, PriorScalerMLE, extract_family_prior
+from .families import Family, _extract_family_prior
+from .priors import Prior, PriorScaler, PriorScalerMLE
 from .terms import ResponseTerm, Term, GroupSpecificTerm
 from .utils import listify, link_match_family
 from .version import __version__
@@ -28,31 +29,30 @@ class Model:
     Parameters
     ----------
     formula : str
-        A model description written in model formula language.
-    data : DataFrame or str
+        A model description written using the formula syntax from the ``formulae`` library.
+    data : pandas.DataFrame or str
         The dataset to use. Either a pandas ``DataFrame``, or the name of the file containing
         the data, which will be passed to ``pd.read_csv()``.
-    family : str or Family
+    family : str or bambi.families.Family
         A specification of the model family (analogous to the family object in R). Either
-        a string, or an instance of class ``priors.Family``. If a string is passed, a family
-        with the corresponding name must be defined in the defaults loaded at ``Model``
-        initialization. Valid pre-defined families are ``'gaussian'``, ``'bernoulli'``, ``'beta'``,
-        ``'binomial'``, ``'poisson'``, ``'gamma'``, ``'wald'``, and ``'negativebinomial'``.
-        Defaults to ``'gaussian'``.
+        a string, or an instance of class ``bambi.families.Family``. If a string is passed, a
+        family with the corresponding name must be defined in the defaults loaded at ``Model``
+        initialization. Valid pre-defined families are ``"bernoulli"``, ``"beta"``,
+        ``"binomial"``, ``"gamma"``, ``"gaussian"``, ``"negativebinomial"``, ``"poisson"``, ``"t"``,
+        and ``"wald"``. Defaults to ``"gaussian"``.
     priors : dict
         Optional specification of priors for one or more terms. A dictionary where the keys are
-        the names of terms in the model, 'common' or 'group_specific' and the values are either
-        instances of class ``Prior`` or ``int``, ``float``, or ``str`` that specify the
-        width of the priors on a standardized scale.
+        the names of terms in the model, "common" or "group_specific" and the values are
+        instances of class ``Prior`` when ``automatic_priors`` is ``"default"``, or either
+        ``Prior``, ``int``, ``float``, or ``str`` when ``automatic_priors`` is ``"mle"``.
     link : str
-        The model link function to use. Can be either a string (must be one of the options
-        defined in the current backend; typically this will include at least ``'identity'``,
-        ``'logit'``, ``'inverse'``, and ``'log'``), or a callable that takes a 1D ndarray or
-        theano tensor as the sole argument and returns one with the same shape.
+        The name of the link function to use. Valid names are ``"cloglog"``, ``"identity"``,
+        ``"inverse_squared"``, ``"inverse"``, ``"log"``, ``"logit"``, and ``"probit"``. Not all
+        the link functions can be used with all the families. See TODO.
     categorical : str or list
         The names of any variables to treat as categorical. Can be either a single variable
         name, or a list of names. If categorical is ``None``, the data type of the columns in
-        the ``DataFrame`` will be used to infer handling. In cases where numeric columns are
+        the ``data`` will be used to infer handling. In cases where numeric columns are
         to be treated as categoricals (e.g., group specific factors coded as numerical IDs),
         explicitly passing variable names via this argument is recommended.
     potentials : A list of 2-tuples.
@@ -77,15 +77,18 @@ class Model:
     noncentered : bool
         If ``True`` (default), uses a non-centered parameterization for normal hyperpriors on
         grouped parameters. If ``False``, naive (centered) parameterization is used.
-    priors_cor = dict
-        The value of eta in the prior for the correlation matrix of group-specific terms.
-        Keys in the dictionary indicate the groups, and values indicate the value of eta.
+    priors_cor : dict
+        An optional value for eta in the LKJ prior for the correlation matrix of group-specific
+        terms. Keys in the dictionary indicate the groups, and values indicate the value of eta.
+        This is a very experimental feature. Defaults to ``None``, which means priors for the
+        group-specific terms are independent.
     taylor : int
         Order of Taylor expansion to use in approximate variance when constructing the default
-        priors. Should be between 1 and 13. Lower values are less accurate, tending to undershoot
-        the correct prior width, but are faster to compute and more stable. Odd-numbered values
-        tend to work better. Defaults to 5 for Normal models and 1 for non-Normal models. Values
-        higher than the defaults are generally not recommended as they can be unstable.
+        priors when ``automatic_priors`` is ``"mle"``. Should be between 1 and 13. Lower values are
+        less accurate, tending to undershoot the correct prior width, but are faster to compute and
+        more stable. Odd-numbered values tend to work better. Defaults to 5 for Normal models and
+        1 for non-Normal models. Values higher than the defaults are generally not recommended as
+        they can be unstable.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -130,7 +133,7 @@ class Model:
         if isinstance(data, str):
             data = pd.read_csv(data, sep=None, engine="python")
         elif not isinstance(data, pd.DataFrame):
-            raise ValueError("data must be a string with a path to a .csv or a pandas DataFrame.")
+            raise ValueError("'data' must be a string with a path to a .csv or a pandas DataFrame.")
 
         # To avoid SettingWithCopyWarning when converting object columns to category
         data._is_copy = False
@@ -157,29 +160,27 @@ class Model:
         self.automatic_priors = automatic_priors
 
         # Obtain design matrices and related objects.
-        na_action = "drop" if dropna else "error"
-        if formula is not None:
-            self.formula = formula
-            self._design = design_matrices(formula, data, na_action, eval_env=1)
-        else:
+        if formula is None:
             raise ValueError("Can't instantiate a model without a model formula.")
+        na_action = "drop" if dropna else "error"
+        self.formula = formula
+        self._design = design_matrices(formula, data, na_action, eval_env=1)
 
-        if self._design.response is not None:
-            family_prior = extract_family_prior(family, priors)
-            if family_prior and self._design.common:
-                conflict = [name for name in family_prior if name in self._design.common.terms_info]
-                if conflict:
-                    raise ValueError(
-                        f"The prior name for {', '.join(conflict)} conflicts with the name of a "
-                        "parameter in the response distribution.\n"
-                        "Please rename the term(s) to prevent an unexpected behaviour."
-                    )
-            self._add_response(self._design.response, family, link, family_prior)
-        else:
+        if self._design.response is None:
             raise ValueError(
                 "No outcome variable is set! "
                 "Please specify an outcome variable using the formula interface."
             )
+        family_prior = _extract_family_prior(family, priors)
+        if family_prior and self._design.common:
+            conflicts = [name for name in family_prior if name in self._design.common.terms_info]
+            if conflicts:
+                raise ValueError(
+                    f"The prior name for {', '.join(conflicts)} conflicts with the name of a "
+                    "parameter in the response distribution.\n"
+                    "Please rename the term(s) to prevent an unexpected behaviour."
+                )
+        self._add_response(self._design.response, family, link, family_prior)
 
         if self._design.common:
             self._add_common(self._design.common, priors)
@@ -212,59 +213,58 @@ class Model:
         Parameters
         ----------
         draws: int
-            The number of samples to draw. Defaults to 1000.
-            The number of tuned samples are discarded by default. See discard_tuned_samples.
+            The number of samples to draw from the posterior distribution. Defaults to 1000.
         tune : int
-            Number of iterations to tune, defaults to 1000. Samplers adjust the step sizes,
-            scalings or similar during tuning.
-            Tuning samples will be drawn in addition to the number specified in the draws argument,
-            and will be discarded unless discard_tuned_samples is set to False.
+            Number of iterations to tune. Defaults to 1000. Samplers adjust the step sizes,
+            scalings or similar during tuning. These tuning samples are be drawn in addition to the
+            number specified in the ``draws`` argument, and will be discarded unless
+            ``discard_tuned_samples`` is set to ``False``.
         discard_tuned_samples : bool
-            Whether to discard posterior samples of the tune interval. Defaults to True.
+            Whether to discard posterior samples of the tune interval. Defaults to ``True``.
         omit_offsets: bool
             Omits offset terms in the ``InferenceData`` object when the model includes
             group specific effects. Defaults to ``True``.
         method: str
-            The method to use for fitting the model. By default, ``'mcmc'``. This will automatically
+            The method to use for fitting the model. By default, ``"mcmc"``. This automatically
             assigns a MCMC method best suited for each kind of variables, like NUTS for continuous
-            variables and Metropolis for non-binary discrete ones. Alternatively, ``'advi'``, in
+            variables and Metropolis for non-binary discrete ones. Alternatively, ``"advi"``, in
             which case the model will be fitted using  automatic differentiation variational
             inference as implemented in PyMC3.
-            Finally, ``'laplace'``, in which case a Laplace approximation is used, ``'laplace'`` is
-            not recommended other than for pedagogical use.
+            Finally, ``"laplace"``, in which case a Laplace approximation is used and is not
+            recommended other than for pedagogical use.
         init: str
-            Initialization method. Defaults to ``'auto'``. The available methods are:
-            * auto: Use ``'jitter+adapt_diag'`` and if this method fails it uses ``'adapt_diag'``.
+            Initialization method. Defaults to ``"auto"``. The available methods are:
+            * auto: Use ``"jitter+adapt_diag"`` and if this method fails it uses ``"adapt_diag"``.
             * adapt_diag: Start with a identity mass matrix and then adapt a diagonal based on the
-              variance of the tuning samples. All chains use the test value (usually the prior mean)
-              as starting point.
-            * jitter+adapt_diag: Same as ``adapt_diag``, but use test value plus a uniform jitter in
-              [-1, 1] as starting point in each chain.
+            variance of the tuning samples. All chains use the test value (usually the prior mean)
+            as starting point.
+            * jitter+adapt_diag: Same as ``"adapt_diag"``, but use test value plus a uniform jitter
+            in [-1, 1] as starting point in each chain.
             * advi+adapt_diag: Run ADVI and then adapt the resulting diagonal mass matrix based on
-              the sample variance of the tuning samples.
+            the sample variance of the tuning samples.
             * advi+adapt_diag_grad: Run ADVI and then adapt the resulting diagonal mass matrix based
-              on the variance of the gradients during tuning. This is **experimental** and might be
-              removed in a future release.
+            on the variance of the gradients during tuning. This is **experimental** and might be
+            removed in a future release.
             * advi: Run ADVI to estimate posterior mean and diagonal mass matrix.
             * advi_map: Initialize ADVI with MAP and use MAP as starting point.
             * map: Use the MAP as starting point. This is strongly discouraged.
             * adapt_full: Adapt a dense mass matrix using the sample covariances. All chains use the
-              test value (usually the prior mean) as starting point.
-            * jitter+adapt_full: Same as ``adapt_full``, but use test value plus a uniform jitter in
-              [-1, 1] as starting point in each chain.
+            test value (usually the prior mean) as starting point.
+            * jitter+adapt_full: Same as ``"adapt_full"``, but use test value plus a uniform jitter
+            in [-1, 1] as starting point in each chain.
         n_init: int
-            Number of initialization iterations. Only works for 'advi' init methods.
+            Number of initialization iterations. Only works for ``"advi"`` init methods.
         chains: int
             The number of chains to sample. Running independent chains is important for some
-            convergence statistics and can also reveal multiple modes in the posterior. If None,
-            then set to either cores or 2, whichever is larger.
+            convergence statistics and can also reveal multiple modes in the posterior. If ``None``,
+            then set to either ``cores`` or 2, whichever is larger.
         cores : int
-            The number of chains to run in parallel. If None, set to the number of CPUs in the
-            system, but at most 4.
+            The number of chains to run in parallel. If ``None``, it is equal to the number of CPUs
+            in the system unless there are more than 4 CPUs, in which case it is set to 4.
         random_seed : int or list of ints
             A list is accepted if cores is greater than one.
-        kwargs
-            For other kwargs see the documentation for ``pm.sample()``
+        **kwargs:
+            For other kwargs see the documentation for ``pymc3.sample()``.
         Returns
         -------
         An ArviZ ``InferenceData`` instance.
@@ -378,7 +378,7 @@ class Model:
 
         if priors is not None:
             # Prepare priors for response auxiliary parameters
-            family_prior = extract_family_prior(self.family, priors)
+            family_prior = _extract_family_prior(self.family, priors)
             if family_prior:
                 for prior in family_prior.values():
                     prior.auto_scale = False
@@ -403,7 +403,7 @@ class Model:
         ----------
         prior : Prior, float, or None.
         type_ : string
-            Accepted values are: ``'intercept'``, ``'common'``, or ``'group_specific'``.
+            Accepted values are: ``"intercept"``, ``"common"``, or ``"group_specific"``.
         """
 
         if prior is None and not self.auto_scale:
@@ -424,26 +424,26 @@ class Model:
         response : formulae.ResponseVector
             An instance of ``formulae.ResponseVector`` as returned by
             ``formulae.design_matrices()``.
-        family : str or Family
+        family : str or bambi.families.Family
             A specification of the model family (analogous to the family object in R). Either a
-            string, or an instance of class ``priors.Family``. If a string is passed, a family with
-            the corresponding name must be defined in the defaults loaded at Model initialization.
-            Valid pre-defined families are ``'gaussian'``, ``'bernoulli'``, ``'beta'``,
-            ``'binomial'``, ``'poisson'``, ``'gamma'``, ``'wald'``, and ``'negativebinomial'``.
-            Defaults to ``'gaussian'``.
+            string, or an instance of class ``families.Family``. If a string is passed, a family
+            with the corresponding name must be defined in the defaults loaded at model
+            initialization. Valid pre-defined families are ``"bernoulli"``, ``"beta"``,
+            ``"binomial"``, ``"gamma"``, ``"gaussian"``, ``"negativebinomial"``, ``"poisson"``,
+            ``"t"``, and ``"wald"``. Defaults to ``"gaussian"``.
         link : str
-            The model link function to use. Can be either a string (must be one of the options
-            defined in the current backend; typically this will include at least ``'identity'``,
-            ``'logit'``, ``'inverse'``, and ``'log'``), or a callable that takes a 1D ndarray or
-            theano tensor as the sole argument and returns one with the same shape.
+            The name of the link function to use. Valid names are ``"cloglog"``, ``"identity"``,
+            ``"inverse_squared"``, ``"inverse"``, ``"log"``, ``"logit"``, and ``"probit"``. Not all
+            the link functions can be used with all the families. See TODO.
         priors : dict
             Optional dictionary with specification of priors for the parameters in the family of
             the response. Keys are names of other parameters than the mean in the family
-            (i.e. they cannot be equal to family.parent) and values can be an instance of class
+            (i.e. they cannot be equal to ``family.parent``) and values can be an instance of class
             ``Prior``, a numeric value, or a string describing the width. In the numeric case,
             the distribution specified in the defaults will be used, and the passed value will be
-            used to scale the appropriate variance parameter. For strings (e.g., ``'wide'``,
-            ``'narrow'``, ``'medium'``, or ``'superwide'``), predefined values will be used.
+            used to scale the appropriate variance parameter. Strings, which are only available when
+            ``automatic_priors`` is ``"mle"``and can be one of ``"wide"``, ``"narrow"``,
+            ``"medium"``, or ``"superwide"``), predefined values will be used.
         """
         if isinstance(family, str):
             family = get_builtin_family(family)
@@ -472,7 +472,7 @@ class Model:
         self.built = False
 
     def _add_common(self, common, priors):
-        """Add common (or fixed) terms to the model.
+        """Add common (a.k.a. fixed) terms to the model.
 
         Parameters
         ----------
@@ -482,9 +482,9 @@ class Model:
             term in the model.
         priors : dict
             Optional specification of priors for one or more terms. A dictionary where the keys are
-            any of the names of the common terms in the model or 'common' and the values are either
-            instances of class ``Prior`` or ``int``, ``float``, or ``str`` that specify the width
-            of the priors on a standardized scale.
+            any of the names of the common terms in the model or ``"common"`` and the values are
+            either instances of class ``Prior`` or ``int``, ``float``, or ``str`` that specify the
+            width of the priors on a standardized scale.
         """
         if matrix_rank(common.design_matrix) < common.design_matrix.shape[1]:
             raise ValueError(
@@ -515,8 +515,8 @@ class Model:
             associated with each group-specific term in the model.
         priors : dict
             Optional specification of priors for one or more terms. A dictionary where the keys are
-            any of the names of the group-specific terms in the model or 'group_specific' and the
-            values are either instances of class ``Prior`` or ``int``, ``float``, or ``str``
+            any of the names of the group-specific terms in the model or ``"group_specific"`` and
+            the values are either instances of class ``Prior`` or ``int``, ``float``, or ``str``
             that specify the width of the priors on a standardized scale.
         """
         for name, term in group.terms_info.items():
@@ -558,7 +558,8 @@ class Model:
             Number of draws to sample from the prior predictive distribution. Defaults to 5000.
         var_names : str or list
             A list of names of variables for which to compute the posterior predictive
-            distribution. Defaults to both observed and unobserved RVs.
+            distribution. Defaults to ``None`` which means to include both observed and
+            unobserved RVs.
         random_seed : int
             Seed for the random number generator.
         figsize: tuple
@@ -566,22 +567,22 @@ class Model:
         textsize: float
             Text size scaling factor for labels, titles and lines. If ``None`` it will be
             autoscaled based on ``figsize``.
-        hdi_prob: float
+        hdi_prob: float or str
             Plots highest density interval for chosen percentage of density.
-            Use ``'hide'`` to hide the highest density interval. Defaults to 0.94.
+            Use ``"hide"`` to hide the highest density interval. Defaults to 0.94.
         round_to: int
             Controls formatting of floats. Defaults to 2 or the integer part, whichever is bigger.
         point_estimate: str
-            Plot point estimate per variable. Values should be ``'mean'``, ``'median'``, ``'mode'``
-             or ``None``. Defaults to ``'auto'`` i.e. it falls back to default set in
-             ArviZ's rcParams.
+            Plot point estimate per variable. Values should be ``"mean"``, ``"median"``, ``"mode"``
+            or ``None``. Defaults to ``"auto"`` i.e. it falls back to default set in
+            ArviZ's rcParams.
         kind: str
-            Type of plot to display (``'kde'`` or ``'hist'``) For discrete variables this argument
+            Type of plot to display (``"kde"`` or ``"hist"``) For discrete variables this argument
             is ignored and a histogram is always used.
-        bins: integer or sequence or 'auto'
-            Controls the number of bins, accepts the same keywords ``matplotlib.hist()`` does.
-            Only works if ``kind == hist``. If ``None`` (default) it will use ``auto`` for
-            continuous variables and ``range(xmin, xmax + 1)`` for discrete variables.
+        bins: integer or sequence or "auto"
+            Controls the number of bins, accepts the same keywords ``matplotlib.pyplot.hist()``
+            does. Only works if ``kind == "hist"``. If ``None`` (default) it will use ``"auto"``
+            for continuous variables and ``range(xmin, xmax + 1)`` for discrete variables.
         omit_offsets: bool
             Whether to omit offset terms in the plot. Defaults to ``True``.
         omit_group_specific: bool
@@ -590,12 +591,12 @@ class Model:
             A 2D array of locations into which to plot the densities. If not supplied, ArviZ will
             create its own array of plot areas (and return it).
         **kwargs
-            Passed as-is to ``plt.hist()`` or ``plt.plot()`` function depending on the value of
-            ``kind``.
+            Passed as-is to ``matplotlib.pyplot.hist()`` or ``matplotlib.pyplot.plot()`` function
+            depending on the value of ``kind``.
 
         Returns
         -------
-        axes: matplotlib axes or bokeh figures
+        axes: matplotlib axes
         """
         if not self.built:
             raise ValueError(
@@ -660,15 +661,15 @@ class Model:
         draws : int
             Number of draws to sample from the prior predictive distribution. Defaults to 500.
         var_names : str or list
-            A list of names of variables for which to compute the posterior predictive
-            distribution. Defaults to both observed and unobserved RVs.
+            A list of names of variables for which to compute the prior predictive distribution.
+            Defaults to ``None`` which means both observed and unobserved RVs.
         random_seed : int
             Seed for the random number generator.
 
         Returns
         -------
         InferenceData
-            ``InferenceData`` object with the groups `prior`, ``prior_predictive`` and
+            ``InferenceData`` object with the groups ``prior``, ``prior_predictive`` and
             ``observed_data``.
         """
         if var_names is None:
@@ -729,33 +730,35 @@ class Model:
     def predict(self, idata, kind="mean", data=None, draws=None, inplace=True):
         """Predict method for Bambi models
 
-        Obtains in-sample and out-sample predictions from a fitted Bambi model.
+        Obtains in-sample and out-of-sample predictions from a fitted Bambi model.
 
         Parameters
         ----------
         idata : InferenceData
-            ``InferenceData`` with samples from the posterior distribution.
+            The ``InferenceData`` instance returned by ``.fit()``.
         kind: str
             Indicates the type of prediction required. Can be ``"mean"`` or ``"pps"``. The
-            first returns posterior distribution of the mean, while the latter returns the posterior
-            predictive distribution (i.e. the posterior probability distribution for a new
-            observation). Defaults to ``"mean"``.
-        data: pd.DataFrame or None
-            An optional data frame in which to look for variables with which to predict.
-            If omitted, the fitted linear predictors are used.
+            first returns draws from the posterior distribution of the mean, while the latter
+            returns the draws from the posterior predictive distribution
+            (i.e. the posterior probability distribution for a new observation).
+            Defaults to ``"mean"``.
+        data: pandas.DataFrame or None
+            An optional data frame with values for the predictors that are used to obtain
+            out-of-sample predictions. If omitted, the original dataset is used.
         draws: None
             The number of random draws per chain. Only used if ``kind="pps"``. Not recommended
             unless more than ndraws times nchains posterior predictive samples are needed.
-            Defaults to ``None`` which means ndraws times nchains.
+            Defaults to ``None`` which means ndraws times nchains draws are obtained.
         inplace: bool
-            If ``True`` it will add a ``posterior_predictive`` group to idata, otherwise it will
-            return a copy of idata with the added group. If ``True`` and idata already have a
-            ``posterior_predictive`` group it will be overwritten.
+            If ``True`` it will modify ``idata`` in-place. Otherwise, it will return a copy of
+            ``idata`` with the predictions added. If ``kind="mean"``, a new variable ending in
+            ``"_mean"`` is added to the ``posterior`` group. If ``kind="pps"``, it appends a
+            ``posterior_predictive`` group to ``idata``. If any of these already exist, it will be
+            overwritten.
 
         Returns
         -------
-        np.ndarray
-            A NumPy array with predictions.
+        InferenceData or None
         """
 
         if kind not in ["mean", "pps"]:
@@ -858,28 +861,28 @@ class Model:
         Parameters
         ----------
         formatting : str
-            One of ``'plain'`` or ``'plain_with_params'``. Defaults to ``'plain'``.
+            One of ``"plain"`` or ``"plain_with_params"``. Defaults to ``"plain"``.
         name : str
-            Name of the figure to save. Defaults to None, no figure is saved.
+            Name of the figure to save. Defaults to ``None``, no figure is saved.
         figsize : tuple
-            Maximum width and height of figure in inches. Defaults to None, the figure size is set
-            automatically. If defined and the drawing is larger than the given size, the drawing is
-            uniformly scaled down so that it fits within the given size.  Only works if ``name``
-            is not None.
+            Maximum width and height of figure in inches. Defaults to ``None``, the figure size is
+            set automatically. If defined and the drawing is larger than the given size, the drawing
+            is uniformly scaled down so that it fits within the given size.  Only works if ``name``
+            is not ``None``.
         dpi : int
             Point per inch of the figure to save.
-            Defaults to 300. Only works if ``name`` is not None.
+            Defaults to 300. Only works if ``name`` is not ``None``.
         fmt : str
             Format of the figure to save.
-            Defaults to ``'png'``. Only works if ``name`` is not None.
+            Defaults to ``"png"``. Only works if ``name`` is not ``None``.
 
         Example
         --------
-        >>> model = Model('y ~ x + (1|z)')
+        >>> model = Model("y ~ x + (1|z)")
         >>> model.build()
         >>> model.graph()
 
-        >>> model = Model('y ~ x + (1|z)')
+        >>> model = Model("y ~ x + (1|z)")
         >>> model.fit()
         >>> model.graph()
 

--- a/bambi/priors/__init__.py
+++ b/bambi/priors/__init__.py
@@ -1,16 +1,10 @@
-from .family import Family, extract_family_prior
-from .likelihood import Likelihood
-from .link import Link
+"""Classes to represent prior distributions and methods to set automatic priors"""
 from .prior import Prior
 from .scaler_mle import PriorScalerMLE
 from .scaler_default import PriorScaler
 
 __all__ = [
-    "Family",
-    "Likelihood",
     "Prior",
-    "Link",
     "PriorScaler",
     "PriorScalerMLE",
-    "extract_family_prior",
 ]

--- a/bambi/priors/prior.py
+++ b/bambi/priors/prior.py
@@ -8,10 +8,13 @@ class Prior:
     ----------
     name : str
         Name of prior distribution. Must be the name of a PyMC3 distribution
-        (e.g., ``'Normal'``, ``'Bernoulli'``, etc.)
+        (e.g., ``"Normal"``, ``"Bernoulli"``, etc.)
     auto_scale: bool
         Whether to adjust the parameters of the prior or use them as passed. Default to ``True``.
     scale: num or str
+        How to scale the prior. If a number, must be within 0 and 1. If a string, must be one of
+        ``"narrow"``, ``"medium"``, ``"wide"``, or ``"superwide"``. Only used when the model was
+        created with ``automatic_priors="mle"``.
     kwargs : dict
         Optional keywords specifying the parameters of the named distribution.
     """
@@ -24,7 +27,7 @@ class Prior:
         self.update(**kwargs)
 
     def update(self, **kwargs):
-        """Update the model arguments with additional arguments.
+        """Update the arguments of the prior with additional arguments.
 
         Parameters
         ----------

--- a/bambi/priors/scaler_mle.py
+++ b/bambi/priors/scaler_mle.py
@@ -39,6 +39,7 @@ class PriorScalerMLE:
         self.priors = {}
         self.mle = None
         self.taylor = taylor
+        # pylint: disable=unspecified-encoding
         with open(join(dirname(__file__), "config", "derivs.txt"), "r") as file:
             self.deriv = [next(file).strip("\n") for x in range(taylor + 1)]
 

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -6,8 +6,9 @@ import pytest
 
 from statsmodels.tools.sm_exceptions import PerfectSeparationError
 
+from bambi.families import Family, Likelihood
 from bambi.models import Model
-from bambi.priors import Family, Likelihood, Prior
+from bambi.priors import Prior
 
 
 @pytest.fixture(scope="module")
@@ -155,6 +156,7 @@ def test_family_bad_type():
         Model("y ~ x", data, family={"family": "gaussian"})
 
 
+@pytest.mark.skip(reason="This case is actually handled by formulae")
 def test_family_unsupported_index_notation():
     data = pd.DataFrame({"x": [1], "y": [1]})
     with pytest.raises(ValueError):

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -10,14 +10,27 @@ methods in the current release of Bambi.
 
 
 :mod:`bambi.models`
-===========================
+===================
 
 .. automodule:: bambi.models
-   :members:
+   :members: Model
 
 
 :mod:`bambi.priors`
-===========================
+===================
 
 .. automodule:: bambi.priors
+    :members:
+
+
+:mod:`bambi.families`
+=====================
+
+.. automodule:: bambi.families
+    :members:
+
+:mod:`bambi.data`
+=====================
+
+.. automodule:: bambi.data
     :members:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 ipython>=5.8.0
-pylint>=2.3.1
+pylint==2.10.2
 pytest>=4.4.0
 pytest-cov>=2.6.1
 seaborn>=0.9.0


### PR DESCRIPTION
Fixes and improvements to our docs. I was working on the paper and figured out that some docstrings weren't right or accurate. 

Some things I would like to agree with you before merging cc @aloctavodia @canyon289 

* I'm double-quotes, like `"string"`, in all the docstrings because that is what Black, our formatter, does. I'm not opposed to using single quotes, but we should be consistent. Any strong opinion in favor or against any of these alternatives?
* I'm referencing classes as `bambi.families.Likelihood` instead of just `Likelihood`. I've seen it in another repo and I think it is a good practice because it reduces ambiguity. But I would like to know if this is too much redundancy.
* I'm completely in favor of promoting Aesara. However, we're not using Aesara/Theano names consistently. We are using Aesara in the paper and in some parts of our docs, but Bambi actually uses Theano (e.g. see the link inv functions in the PyMC3 backend). I have two ideas:
  + Use the name Theano everywhere, but be very explicit we're going to use Aesara when PyMC3 v4 is ready.
  + Try to use Aesara as it is? I'm not following its development, so I'm not sure if it supports the things we currently use from Theano. If that's the case, I would drop Theano and use Aesara from now.

Finally, I think we should launch a new patch release that includes all these last-minute changes before we finish reviewing the paper. At the moment, the great majority of the paper is consistent with Bambi 0.6.0, but docstrings are not. I would like to be 100% consistent and reproducible so we can share with reviewers and users the code and the version of Bambi to reproduce everything.