### PR TITLE
Change default priors for the 't' family

### DIFF
--- a/bambi/defaults/defaults.py
+++ b/bambi/defaults/defaults.py
@@ -10,7 +10,7 @@ SETTINGS_DISTRIBUTIONS = {
     "Binomial": {"n": 1, "p": 0.5},
     "Cauchy": {"alpha": 0, "beta": 1},
     "Flat": {},
-    "Gamma": {"alpha": 2, "beta": 2},
+    "Gamma": {"alpha": 2, "beta": 0.1},
     "HalfCauchy": {"beta": 1},
     "HalfFlat": {},
     "HalfNormal": {"sigma": 1},

--- a/bambi/defaults/defaults.py
+++ b/bambi/defaults/defaults.py
@@ -99,8 +99,8 @@ SETTINGS_FAMILIES = {
         "likelihood": {
             "name": "StudentT",
             "args": {
-                "lam": "HalfCauchy",
-                "nu": 2
+                "sigma": "HalfNormal",
+                "nu": "Gamma"
             },
             "parent": "mu",
             "pps": pps.pps_t

--- a/bambi/defaults/pps.py
+++ b/bambi/defaults/pps.py
@@ -90,8 +90,7 @@ def pps_t(model, posterior, mu, draws, draw_n):
     else:
         nu = posterior[model.response.name + "_nu"].values[:, idxs, np.newaxis]
 
-    lam = posterior[model.response.name + "_lam"].values[:, idxs, np.newaxis]
-    sigma = lam ** -0.5
+    sigma = posterior[model.response.name + "_sigma"].values[:, idxs, np.newaxis]
     return stats.t.rvs(nu, mu, sigma)
 
 

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -104,7 +104,7 @@ FAMILY_PARAMS = {
     "gamma": ("alpha",),
     "gaussian": ("sigma",),
     "negativebinomial": ("alpha",),
-    "t": ("lam", "nu"),
+    "t": ("sigma", "nu"),
     "wald": ("lam",),
 }
 

--- a/bambi/families/likelihood.py
+++ b/bambi/families/likelihood.py
@@ -7,7 +7,7 @@ DISTRIBUTIONS = {
     "Beta": {"params": ("mu", "kappa"), "parent": "mu", "args": ("kappa",)},
     "Binomial": {"params": ("p",), "parent": "p", "args": None},
     "Poisson": {"params": ("mu",), "parent": "mu", "args": None},
-    "StudentT": {"params": ("mu", "lam"), "args": ("lam", "nu")},
+    "StudentT": {"params": ("mu", "sigma"), "args": ("sigma", "nu")},
     "NegativeBinomial": {"params": ("mu", "alpha"), "parent": "mu", "args": ("alpha",)},
     "Gamma": {"params": ("mu", "alpha"), "parent": "mu", "args": ("alpha",)},
     "Wald": {"params": ("mu", "lam"), "parent": "mu", "args": ("lam",)},

--- a/bambi/priors/scaler_default.py
+++ b/bambi/priors/scaler_default.py
@@ -39,7 +39,7 @@ class PriorScaler:
     def scale_response(self):
         # Add cases for other families
         priors = self.model.response.family.likelihood.priors
-        if self.model.family.name == "gaussian":
+        if self.model.family.name in ["gaussian", "t"]:
             if priors["sigma"].auto_scale:
                 priors["sigma"] = Prior("HalfStudentT", nu=4, sigma=self.response_std)
 


### PR DESCRIPTION
At the moment, we're using `nu` and `lam` to parametrize the `StudentT` likelihood. I've realized we should use `sigma` instead of `lam`, and use the default prior we use for the `"gaussian"` family, i.e. sigma ~ HalfStudentT(nu=4, sigma=sd(y)).

I'm still not sure what we should use for `nu` (which is currently set to a constant value!!!). I've placed a Gamma(2, 2), but this isn't actually something I've thought deeply about. 