### PR TITLE
Add T regression notebook

### DIFF
--- a/docs/notebooks/t_regression.ipynb
+++ b/docs/notebooks/t_regression.ipynb
@@ -21,11 +21,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import arviz as az\n",
+    "import bambi as bmb\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "import bambi as bmb\n",
-    "import pandas as pd\n",
-    "import arviz as az"
+    "import pandas as pd"
    ]
   },
   {
@@ -886,7 +886,7 @@
    "id": "2b62d1df",
    "metadata": {},
    "source": [
-    "Here it is quite obvious that the Student T model is much better, due to having a LOO value far closer to 0."
+    "Here it is quite obvious that the Student T model is much better, due to having a clearly larger value of LOO."
    ]
   },
   {


### PR DESCRIPTION
Issue #370 suggested that a t regression example notebook is needed. I recreated the example from the [pymc](https://docs.pymc.io/notebooks/GLM-robust.html) docs, and adapted it using bambi, and included it in the notebook in this commit. 

The text was largely changed and were a few minor and stylistic changes but nothing too major. I additionally added a couple of code blocks comparing the recovered parameters and evaluating LOO of the normal regression model vs the T regression.