### PR TITLE
Implement `include_mean` argument

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,19 +4,19 @@
 
 ### New features
 
-- Added the new "categorical" built-in family (#426)
-- Added the `include_mean` argument to the method `Model.fit()` (#434)
+- Add "categorical" built-in family (#426)
+- Add `include_mean` argument to the method `Model.fit()` (#434)
 
 ### Maintenance and fixes
 
 - Codebase for the PyMC backend has been refactored (#408)
-- Fixed examples that averaged posterior values across chains (#429)
-- Fixed issue #427 with automatic priors for the intercept term (#430)
+- Fix examples that averaged posterior values across chains (#429)
+- Fix issue #427 with automatic priors for the intercept term (#430)
 
 ### Documentation
 
 - Add StudentT regression example, thanks to @tjburch (#414)
-- Added a B-Spline regression example with the cherry blossoms dataset (#416)
+- Add B-Spline regression example with cherry blossoms dataset (#416)
 - Add hirarchical linear regression example with sleepstudy dataset (#424)
 
 ### Deprecation

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### New features
 
 - Added the new "categorical" built-in family (#426)
+- Added the `include_mean` argument to the method `Model.fit()` (#434)
 
 ### Maintenance and fixes
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -191,6 +191,7 @@ class Model:
         tune=1000,
         discard_tuned_samples=True,
         omit_offsets=True,
+        include_mean=False,
         method="mcmc",
         init="auto",
         n_init=50000,
@@ -215,6 +216,8 @@ class Model:
         omit_offsets: bool
             Omits offset terms in the ``InferenceData`` object returned when the model includes
             group specific effects. Defaults to ``True``.
+        include_mean: bool
+            Compute the posterior of the mean response? Defaults to ``False``.
         method: str
             The method to use for fitting the model. By default, ``"mcmc"``. This automatically
             assigns a MCMC method best suited for each kind of variables, like NUTS for continuous
@@ -256,6 +259,7 @@ class Model:
             A list is accepted if cores is greater than one.
         **kwargs:
             For other kwargs see the documentation for ``pymc3.sample()``.
+
         Returns
         -------
         An ArviZ ``InferenceData`` instance.
@@ -277,6 +281,7 @@ class Model:
             tune=tune,
             discard_tuned_samples=discard_tuned_samples,
             omit_offsets=omit_offsets,
+            include_mean=include_mean,
             method=method,
             init=init,
             n_init=n_init,

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -217,7 +217,7 @@ class Model:
             Omits offset terms in the ``InferenceData`` object returned when the model includes
             group specific effects. Defaults to ``True``.
         include_mean: bool
-            Compute the posterior of the mean response? Defaults to ``False``.
+            Compute the posterior of the mean response. Defaults to ``False``.
         method: str
             The method to use for fitting the model. By default, ``"mcmc"``. This automatically
             assigns a MCMC method best suited for each kind of variables, like NUTS for continuous

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -533,7 +533,7 @@ def test_binomial_regression():
 def test_init_fallback(init_data, caplog):
     model = Model("od ~ temp + (1|source) + 0", init_data)
     with caplog.at_level(logging.INFO):
-        results = model.fit(draws=100, init="auto")
+        model.fit(draws=100, init="auto")
         assert "Initializing NUTS using jitter+adapt_diag..." in caplog.text
         assert "The default initialization" in caplog.text
         assert "Initializing NUTS using adapt_diag..." in caplog.text
@@ -547,3 +547,17 @@ def test_categorical_family(inhaler):
 def test_categorical_family_varying_intercept(inhaler):
     model = Model("rating ~ period + carry + treat + (1|subject)", inhaler, family="categorical")
     model.fit()
+
+
+def test_fit_include_mean(crossed_data):
+    model = Model("Y ~ continuous*threecats", crossed_data)
+    idata = model.fit(tune=400, draws=400, include_mean=True)
+    assert idata.posterior["Y_mean"].shape[1:] == (400, 120)
+
+    # Compare with the mean obtained with `model.predict()`
+    mean = idata.posterior["Y_mean"].stack(sample=("chain", "draw")).values.mean(1)
+
+    model.predict(idata)
+    predicted_mean = idata.posterior["Y_mean"].stack(sample=("chain", "draw")).values.mean(1)
+
+    assert np.array_equal(mean, predicted_mean)


### PR DESCRIPTION
This PR adds the `include_mean` argument to `Model.fit()` method. When `include_mean=True`, the resulting InferenceData contains the posterior distribution of the mean.

Under the hood, this is simply a call to `Model.predict(idata)` without arguments, which just computes the mean prediction of the response.

This PR closes #422