### PR TITLE
Fix shape issue in some group specific effects

### DIFF
--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -104,7 +104,9 @@ class GroupSpecificTerm:
             response_dims = list(spec.response.pymc_coords)
 
         dims = list(self.coords) + response_dims
-        coef = self.build_distribution(dist, label, dims=dims, **kwargs)
+        # Squeeze ensures we don't have a shape of (n, 1) when we mean (n, )
+        # This happens with categorical predictors with two levels and intercept.
+        coef = self.build_distribution(dist, label, dims=dims, **kwargs).squeeze()
         coef = coef[self.term.group_index]
 
         return coef, predictor


### PR DESCRIPTION
If we have a group-specific effect where the predictor is categorical with two levels, and there's a group-specific intercept for the same grouping variable, the underlying PyMC distribution is going to be of shape `(n, 1)`. 

The problem is that all the other distributions we add up are of shape `(n, )`.  Adding something of shape `(n, )` and something of shape `(n, 1)` results in something of shape `(n, n)`, which is not what we want.

This PR fixes that problem by squeezing the distribution after being created.

For more motivation see https://github.com/bambinos/bambi/pull/440#issuecomment-1013529907