### PR TITLE
Add posterior predictive sampling method to categorical family

### DIFF
--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -14,7 +14,10 @@ class MultivariateFamily(Family):
 
         # Drop var/dim if already present
         if name in posterior.data_vars:
-            posterior = posterior.drop_vars(name).drop_dims(coord_name)
+            posterior = posterior.drop_vars(name)
+
+        if coord_name in posterior.dims:
+            posterior = posterior.drop_dims(coord_name)
 
         coords = ("chain", "draw", coord_name)
         posterior[name] = (coords, mean)
@@ -28,7 +31,7 @@ class Categorical(MultivariateFamily):
     def predict(self, model, posterior, linear_predictor):
         # This is only 'softmax' for now.
         # Second axis is the one where the response coord is inserted
-        # We need to append zeros for  the reference category
+        # We need to append zeros for the reference category
         shape = linear_predictor.shape
         linear_predictor = np.dstack(
             (np.zeros(shape=(shape[0], shape[1], 1, shape[3])), linear_predictor)
@@ -50,3 +53,32 @@ class Categorical(MultivariateFamily):
         posterior = posterior.assign_coords({response_coord_name: model.response.levels})
         posterior = posterior.assign_coords({coord_name: list(range(obs_n))})
         return posterior
+
+    def posterior_predictive(self, model, posterior, linear_predictor, draws, draw_n):
+        # https://stackoverflow.com/questions/34187130
+        def draw_categorical_samples(probability_matrix, items):
+            cumsum = probability_matrix.cumsum(axis=0)
+            idx = np.random.rand(probability_matrix.shape[1])
+            idx = (cumsum < idx).sum(axis=0)
+            return items[idx]
+
+        shape = linear_predictor.shape
+        linear_predictor = np.dstack(
+            (np.zeros(shape=(shape[0], shape[1], 1, shape[3])), linear_predictor)
+        )
+
+        mean = self.link.linkinv(linear_predictor, axis=2)
+        idxs = np.random.randint(low=0, high=draw_n, size=draws)
+        mean = mean[:, idxs, :, :]
+        shape = mean.shape
+
+        mean = mean.reshape((np.prod(mean.shape[:2]), mean.shape[2], mean.shape[3]))
+        draws_n = mean.shape[0]
+        obs_n = mean.shape[-1]
+
+        pps = np.empty((draws_n, obs_n), dtype=object)
+        response_levels = np.array([str(level) for level in model.response.levels])
+        for idx in range(obs_n):
+            pps[:, idx] = draw_categorical_samples(mean[..., idx].T, response_levels)
+
+        return pps.reshape((shape[0], shape[1], obs_n))

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -15,7 +15,10 @@ class UnivariateFamily(Family):
 
         # Drop var/dim if already present
         if name in posterior.data_vars:
-            posterior = posterior.drop_vars(name).drop_dims(coord_name)
+            posterior = posterior.drop_vars(name)
+
+        if coord_name in posterior.dims:
+            posterior = posterior.drop_dims(coord_name)
 
         coords = ("chain", "draw", coord_name)
         posterior[name] = (coords, mean)

--- a/bambi/tests/test_predict.py
+++ b/bambi/tests/test_predict.py
@@ -220,6 +220,16 @@ def test_predict_categorical(inhaler):
     model.predict(idata, data=inhaler.iloc[:20, :])
 
 
+def test_posterior_predictive_categorical(inhaler):
+    model = Model("rating ~ period", data=inhaler, family="categorical")
+    idata = model.fit()
+    model.predict(idata, kind="pps")
+    pps = idata.posterior_predictive["rating"].values
+
+    assert pps.shape[-1] == inhaler.shape[0]
+    assert (np.unique(pps) == ["1", "2", "3", "4"]).all()
+
+
 def test_predict_categorical_group_specific():
     # see https://github.com/bambinos/bambi/issues/447
     rng = np.random.default_rng(1234)


### PR DESCRIPTION
As reported in #456, in #426 we added support for the categorical family.

The problem is that we forgot to add the posterior predictive sampling method. This PR fixes that.

Let's see an example


```python
import arviz as az
import bambi as bmb
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

az.style.use("arviz-darkgrid")

inhaler = pd.read_csv("bambi/tests/data/inhaler.csv")
inhaler["rating"] = pd.Categorical(inhaler["rating"], categories=[1, 2, 3, 4])

model = bmb.Model("rating ~ period", data=inhaler, family="categorical")
idata = model.fit()
model.predict(idata, kind="pps")
````

```python
pps = idata.posterior_predictive["rating"].values.reshape(2000, 572)[::10]
print(pps.shape)
# (200, 572)


draws = pps.shape[0]
ratings = ["1", "2", "3", "4"]

y = np.zeros((draws, len(ratings)))
for i in range(draws):
    for j, value in enumerate(ratings):
        y[i, j] = np.sum(pps[i] == value)

y = y / y.sum(axis=1)[:, None]


fig, ax = plt.subplots(figsize=(8, 5))
x = np.arange(len(ratings))

for i in range(draws):
    ax.hlines(y[i], xmin=x - 0.5, xmax=x + 0.5, alpha=0.05)
ax.hlines(y.mean(0), xmin=x - 0.5, xmax=x + 0.5, color="C0", lw=2, ls="--")

true_counts = inhaler["rating"].value_counts().values
true_counts = true_counts / true_counts.sum()
ax.hlines(true_counts, xmin=x - 0.5, xmax=x + 0.5, color="black", lw=2)

ax.set_xticks(x)
ax.set_xticklabels(ratings)
ax.set_xlabel("Rating")
ax.set_ylabel("Probability");
```

![image](https://user-images.githubusercontent.com/25507629/155048115-fe5c20c6-3077-46d1-babc-897a0bc856a2.png)


