### PR TITLE
add  include_group_specific argument to predict

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### New features
 
 - Add VonMises (`"vonmises"`) built-in family (#453)
+- `Model.predict()` gains a new argument `include_group_specific` to determine if group-specific effects are considered when making predictions (#470)
 
 ### Maintenance and fixes
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -754,7 +754,9 @@ class Model:
         return idata
 
     # pylint: disable=protected-access
-    def predict(self, idata, kind="mean", data=None, draws=None, inplace=True, with_group_specific=True):
+    def predict(
+        self, idata, kind="mean", data=None, draws=None, inplace=True, include_group_specific=True
+    ):
         """Predict method for Bambi models
 
         Obtains in-sample and out-of-sample predictions from a fitted Bambi model.
@@ -772,7 +774,7 @@ class Model:
         data: pandas.DataFrame or None
             An optional data frame with values for the predictors that are used to obtain
             out-of-sample predictions. If omitted, the original dataset is used.
-        with_group_specific: bool
+        include_group_specific: bool
             If ``True`` make predictions including the group specific effects. Otherwise,
             predictions are made with common effects only (i.e. group specific are set
             to zero).
@@ -815,7 +817,7 @@ class Model:
             else:
                 X = self._design.common._evaluate_new_data(data).design_matrix
 
-        if self._design.group and with_group_specific:
+        if self._design.group and include_group_specific:
             if in_sample:
                 Z = self._design.group.design_matrix
             else:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -754,7 +754,7 @@ class Model:
         return idata
 
     # pylint: disable=protected-access
-    def predict(self, idata, kind="mean", data=None, with_group_specific=True, draws=None, inplace=True):
+    def predict(self, idata, kind="mean", data=None, draws=None, inplace=True, with_group_specific=True):
         """Predict method for Bambi models
 
         Obtains in-sample and out-of-sample predictions from a fitted Bambi model.
@@ -815,7 +815,7 @@ class Model:
             else:
                 X = self._design.common._evaluate_new_data(data).design_matrix
 
-        if self._design.group anf with_group_specific:
+        if self._design.group and with_group_specific:
             if in_sample:
                 Z = self._design.group.design_matrix
             else:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -754,7 +754,7 @@ class Model:
         return idata
 
     # pylint: disable=protected-access
-    def predict(self, idata, kind="mean", data=None, draws=None, inplace=True):
+    def predict(self, idata, kind="mean", data=None, with_group_specific=True, draws=None, inplace=True):
         """Predict method for Bambi models
 
         Obtains in-sample and out-of-sample predictions from a fitted Bambi model.
@@ -772,6 +772,10 @@ class Model:
         data: pandas.DataFrame or None
             An optional data frame with values for the predictors that are used to obtain
             out-of-sample predictions. If omitted, the original dataset is used.
+        with_group_specific: bool
+            If ``True`` make predictions including the group specific effects. Otherwise,
+            predictions are made with common effects only (i.e. group specific are set
+            to zero).
         draws: None
             The number of random draws per chain. Only used if ``kind="pps"``. Not recommended
             unless more than ndraws times nchains posterior predictive samples are needed.
@@ -811,7 +815,7 @@ class Model:
             else:
                 X = self._design.common._evaluate_new_data(data).design_matrix
 
-        if self._design.group:
+        if self._design.group anf with_group_specific:
             if in_sample:
                 Z = self._design.group.design_matrix
             else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 git+https://github.com/dls-controls/sphinx-multiversion.git@only-arg
 ipython>=5.8.0
 nbsphinx>=0.4.2


### PR DESCRIPTION
Add new argument ~`with_group_specific`~  `include_group_specific` to `model.predict()` that allows prediction without group-specific effects.

Currently when calling `model.predict()` with a hierarchical model on new data, the `data` argument must contain variables with valid group-specific labels from the original data. There is occasional need to make predictions without including group-specific effects, i.e. set them to zero. The proposed extra argument allows bypassing of the group-specific predictions to do this. 