### PR TITLE
Fix bug in custom link definition

### DIFF
--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -84,7 +84,7 @@ class Family:
             self._link = Link(x)
             self.smlink = STATSMODELS_LINKS.get(x, None)
         elif isinstance(x, Link):
-            self.link = x
+            self._link = x
         else:
             raise ValueError(".link must be set to a string or a Link instance.")
 


### PR DESCRIPTION
While trying to reproduce the custom link example in the getting started notebook I got a `segmentation fault` error. This fix it and add a test.