### PR TITLE
Change how reshape is performed for categorical group specific terms.

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -869,17 +869,23 @@ class Model:
                 # 1-dimensional expr (the great majority: a single slope or intercept)
                 if len(shape) == 3:
                     shape = (shape[0] * shape[1], shape[2])
+                    values = values.reshape(shape)
                 # 2-dimensional predictors (e.g. spline basis and multivariate models)
                 else:
                     if isinstance(self.family, multivariate.Categorical):
                         response_n = len(self.response.levels) - 1
                         p = np.prod(shape[2:]) // response_n
                         shape = (shape[0] * shape[1], p, response_n)
+                        values = values.reshape(shape)
                     # Group specific effect with categorical expr
                     else:
-                        shape = (shape[0] * shape[1], shape[2] * shape[3])
+                        # Needs to be reshaped in two steps.
+                        # Second stage uses order="F", see issue #477.
+                        shape_1 = (shape[0] * shape[1], shape[2], shape[3])
+                        shape_2 = (shape[0] * shape[1], shape[2] * shape[3])
+                        values = values.reshape(shape_1).reshape(shape_2, order="F")
 
-                beta_z_list.append(values.reshape(shape))
+                beta_z_list.append(values)
 
             # 'beta_z' is of shape:
             # * (chain_n * draw_n, p) for univariate

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 git+https://github.com/dls-controls/sphinx-multiversion.git@only-arg
 ipython>=5.8.0
 nbsphinx>=0.4.2


### PR DESCRIPTION
In #477 we discuss a problem associated with how we reshape draws from the posterior of categorical group-specific effects. These are group-specific effects where the expression part (LHS of `|`) is a categorical variable.

This PR fixes that issue by performing a two-step reshape for the mentioned type of terms. The second step uses `order="F"` so the reshape varies first through the `expr` part of the term and then through the `factor` part.

In NumPy's terms, the `expr` values vary along the first index and the `factor` values vary along the second index. With `order="F"` we have that the first index (`expr`) changes fastest and the last index (`factor`) changes slowest.

**Note** This does not affect predictions for models not involving categorical group-specific terms, but I still need to double-check if this is the right approach.