### PR TITLE
Fix typos

### DIFF
--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -270,7 +270,7 @@ class PyMC3Model:
         # Coordinates that end with "_dim_0" are added automatically.
         # These represents unidimensional coordinates that are added for numerical variables.
         # These variables have a shape of 1 so we can concatenate the coefficients and multiply
-        # the resulting vector withe the design matrix.
+        # the resulting vector with the design matrix.
         # But having a unidimensional coordinate for a numeric variable does not make sense.
         # So we drop them.
         coords_to_drop = [dim for dim in idata.posterior.dims if dim.endswith("_dim_0")]

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -9,7 +9,7 @@ from bambi.priors import Prior
 
 
 class CommonTerm:
-    """Represetation of a common effects term in PyMC3
+    """Representation of a common effects term in PyMC3
 
     An object that builds the PyMC3 distribution for a common effects term. It also contains the
     coordinates that we then add to the model.
@@ -75,7 +75,7 @@ class CommonTerm:
 
 
 class GroupSpecificTerm:
-    """Represetation of a group specific effects term in PyMC3
+    """Representation of a group specific effects term in PyMC3
 
     Creates an object that builds the PyMC3 distribution for a group specific effect. It also
     contains the coordinates that we then add to the model.

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -9,10 +9,10 @@ class Family:
     name: str
         The name of the family. It can be any string.
     likelihood: Likelihood
-        A ``bambi.families.Likelihood`` instace specifying the model likelihood function.
+        A ``bambi.families.Likelihood`` instance specifying the model likelihood function.
     link: str or Link
         The name of the link function or a ``bambi.families.Link`` instance. The link function
-        transforms the linear model prediction to the mean parameter of the likelihood funtion.
+        transforms the linear model prediction to the mean parameter of the likelihood function.
 
     Examples
     --------

--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -121,7 +121,7 @@ class Multinomial(MultivariateFamily):
         n = model.response.data.sum(1)
 
         # random.multinomial only accepts
-        # * n : interger
+        # * n : integer
         # * p : vector
         for i in range(obs_n):
             for j in range(draws_n):

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -891,7 +891,7 @@ class Model:
                     transpose_dims = ["samples"] + expr_dims
                     values = (
                         term_posterior.stack(samples=("chain", "draw"))
-                        .traspose(*transpose_dims)
+                        .transpose(*transpose_dims)
                         .values
                     )
                 # 2 dimensional predictors

--- a/bambi/terms.py
+++ b/bambi/terms.py
@@ -223,7 +223,7 @@ class GroupSpecificTerm:
         # Determine if the term represents cell-means encoding.
         self.is_cell_means = self.categorical and (self.data.sum(1) == 1).all()
 
-        # Used in pymc model coords to label coordinates appropiately
+        # Used in pymc model coords to label coordinates appropriately
         self.coords = {}
 
         # Group is always a coordinate added to the model.

--- a/bambi/tests/test_priors.py
+++ b/bambi/tests/test_priors.py
@@ -70,7 +70,7 @@ def test_likelihood_bad_priors():
     with pytest.raises(ValueError):
         Likelihood("Normal", parent="mu", sigma="HalfNormal")
 
-    # Passing unnecesary priors
+    # Passing unnecessary priors
     with pytest.raises(ValueError):
         Likelihood("Bernoulli", sigma=sigma)
 

--- a/docs/notebooks/beta_regression.ipynb
+++ b/docs/notebooks/beta_regression.ipynb
@@ -779,7 +779,7 @@
    "id": "486440b2-a090-481f-a3e8-a59819369370",
    "metadata": {},
    "source": [
-    "In the [Hierarchical Logistic regression with Binomial family](https://bambinos.github.io/bambi/main/notebooks/hierarchical_binomial_bambi.html) notebook, we modeled baseball batting averages (times a player reached first via a hit per times at bat) via a Hierarchical Logisitic regression model. If we're interested in league-wide effects, we could look at a Beta regression. We work off the assumption that the league-wide batting average follows a Beta distribution, and that individual player's batting averages are samples from that distribtuion.\n",
+    "In the [Hierarchical Logistic regression with Binomial family](https://bambinos.github.io/bambi/main/notebooks/hierarchical_binomial_bambi.html) notebook, we modeled baseball batting averages (times a player reached first via a hit per times at bat) via a Hierarchical Logisitic regression model. If we're interested in league-wide effects, we could look at a Beta regression. We work off the assumption that the league-wide batting average follows a Beta distribution, and that individual player's batting averages are samples from that distribution.\n",
     "\n",
     "First, load the Batting dataset again, and re-calculate batting average as hits/at-bat. In order to make sure that we have a sufficient sample, we'll require at least 100 at-bats in order consider a batter. Last, we'll focus on 1990-2018."
    ]

--- a/docs/notebooks/categorical_regression.ipynb
+++ b/docs/notebooks/categorical_regression.ipynb
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, we can notice that the probability phases betweeen classes from left to right. At all points across $x$, sum of the class probabilities is 1, since in our generative model, it must be one of these three outcomes.  "
+    "Here, we can notice that the probability phases between classes from left to right. At all points across $x$, sum of the class probabilities is 1, since in our generative model, it must be one of these three outcomes.  "
    ]
   },
   {

--- a/docs/notebooks/getting_started.ipynb
+++ b/docs/notebooks/getting_started.ipynb
@@ -354,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We pass ``dropna=True`` to tell Bambi to drop rows containing missing values. The number of rows dropped is different from the numer of rows with missing values because Bambi only considers columns involved in the model."
+    "We pass ``dropna=True`` to tell Bambi to drop rows containing missing values. The number of rows dropped is different from the number of rows with missing values because Bambi only considers columns involved in the model."
    ]
   },
   {

--- a/docs/notebooks/logistic_regression.ipynb
+++ b/docs/notebooks/logistic_regression.ipynb
@@ -981,7 +981,7 @@
    "source": [
     "This observation corresponds to a 95 year old Republican party member that voted for Trump. \n",
     "\n",
-    "<!-- If this observation doesn't appear unusual to you right now, the model's difficulty in prediciting with that observation will definetly make sense in the next section. -->\n",
+    "<!-- If this observation doesn't appear unusual to you right now, the model's difficulty in prediciting with that observation will definitely make sense in the next section. -->\n",
     "\n",
     "Let us take a look at six observations with the highest $\\hat \\kappa$ values."
    ]

--- a/docs/notebooks/model_comparison.ipynb
+++ b/docs/notebooks/model_comparison.ipynb
@@ -1341,7 +1341,7 @@
    "source": [
     "## Model comparison\n",
     "\n",
-    "We can perform a Bayesian model comparison very easily with `az.compare()`. Here we pass a dictionary with the InferenceData objects that `Model.fit()` returned and `az.compare()` returns a data frame that is ordered from best to worst according to the criteria used. By default, ArviZ uses *loo*,  which is an estimation of leave one out cross validation. Another option is the widely applicable information criterion (WAIC). For more information about the information criterias available and other options within the function [see the docs](https://arviz-devs.github.io/arviz/api/generated/arviz.compare.html)."
+    "We can perform a Bayesian model comparison very easily with `az.compare()`. Here we pass a dictionary with the InferenceData objects that `Model.fit()` returned and `az.compare()` returns a data frame that is ordered from best to worst according to the criteria used. By default, ArviZ uses *loo*,  which is an estimation of leave one out cross validation. Another option is the widely applicable information criterion (WAIC). For more information about the information criteria available and other options within the function [see the docs](https://arviz-devs.github.io/arviz/api/generated/arviz.compare.html)."
    ]
   },
   {
@@ -1566,7 +1566,7 @@
    "source": [
     "### Final remarks\n",
     "\n",
-    "In this notebook we've seen how easy it is to incorporate ArviZ into a Bambi workflow to perform model comparison based on information criterias such as **LOO** and **WAIC**. However, an attentive reader might have seen that the highest density interval plot never shows a predicted probability greater than 0.5 (which is not good if we expect to predict that at least some people working 40hrs/wk make more than \\\\$50k/yr). You can increase the hours of work per week for the profiles we've used and the HDIs will show larger values. But we won't be seeing the whole picture.  \n",
+    "In this notebook we've seen how easy it is to incorporate ArviZ into a Bambi workflow to perform model comparison based on information criteria such as **LOO** and **WAIC**. However, an attentive reader might have seen that the highest density interval plot never shows a predicted probability greater than 0.5 (which is not good if we expect to predict that at least some people working 40hrs/wk make more than \\\\$50k/yr). You can increase the hours of work per week for the profiles we've used and the HDIs will show larger values. But we won't be seeing the whole picture.  \n",
     "\n",
     "Although we're using some demographic variables such as **sex** and **race**, the cells resulting from the combinations of their levels are still very heterogeneous. For example, we are mixing individuals of all educational levels. A possible next step is to **incorporate education** into the different models we compared. If any of the readers (yes, you!) is interested in doing so, here there are some notes that may help \n",
     "\n",

--- a/docs/notebooks/multi-level_regression.ipynb
+++ b/docs/notebooks/multi-level_regression.ipynb
@@ -665,7 +665,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also plot the posterior overlayed with a region of practical equivalence (ROPE). This region indicates a range of parameter values that are considered to be practically equivalent to some reference value of interest to the particular application, for example 0. In the following plot we can see that all our posterior distributions fall outside of this range."
+    "We can also plot the posterior overlaid with a region of practical equivalence (ROPE). This region indicates a range of parameter values that are considered to be practically equivalent to some reference value of interest to the particular application, for example 0. In the following plot we can see that all our posterior distributions fall outside of this range."
    ]
   },
   {

--- a/docs/notebooks/negative_binomial.ipynb
+++ b/docs/notebooks/negative_binomial.ipynb
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In SciPy, the definition of the negative binomial distribution differs a little from the one in our introduction. They define $Y$ = Number of failures until k sucesses and then $y$ starts at 0. In the following plot, we have  the probability of observing $y$ failures before we see $k=3$ successes. "
+    "In SciPy, the definition of the negative binomial distribution differs a little from the one in our introduction. They define $Y$ = Number of failures until k successes and then $y$ starts at 0. In the following plot, we have  the probability of observing $y$ failures before we see $k=3$ successes. "
    ]
   },
   {
@@ -228,7 +228,7 @@
     "\n",
     "The variables of insterest in the dataset are\n",
     "\n",
-    "* daysabs: The number of days of abscence. It is our response variable.\n",
+    "* daysabs: The number of days of absence. It is our response variable.\n",
     "* progr: The type of program. Can be one of 'General', 'Academic', or 'Vocational'.\n",
     "* math: Score in a standardized math test."
    ]

--- a/docs/notebooks/radon_example.ipynb
+++ b/docs/notebooks/radon_example.ipynb
@@ -1539,7 +1539,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As expeced, the values strongly concentrated along the diagonal. In other words, for each county and floor level combination, the model uses their sample mean of radon level as prediction, plus smoothing due to the non-flat priors.\n",
+    "As expected, the values strongly concentrated along the diagonal. In other words, for each county and floor level combination, the model uses their sample mean of radon level as prediction, plus smoothing due to the non-flat priors.\n",
     "\n",
     "**What does _no pooling_ exactly mean here?**\n",
     "\n",

--- a/docs/notebooks/sleepstudy.ipynb
+++ b/docs/notebooks/sleepstudy.ipynb
@@ -490,7 +490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On average, people's average reaction time at the beginning of the study is between 235 and 265 miliseconds. With every extra day of sleep deprivation, the mean reaction times increase, on average, between 7.2 and 13.9 miliseconds.\n",
+    "On average, people's average reaction time at the beginning of the study is between 235 and 265 milliseconds. With every extra day of sleep deprivation, the mean reaction times increase, on average, between 7.2 and 13.9 milliseconds.\n",
     "\n",
     "So far so good with the interpretation of the common effects. It's quite straightforward and simple. But this analysis would be incomplete and misleading if we don't evaluate the subject-specific terms we added to the model. These terms are telling us how much subjects differ from each other in terms of the initial reaction time and the association between days of sleep deprivation and reaction times.\n",
     "\n",

--- a/docs/notebooks/t-test.ipynb
+++ b/docs/notebooks/t-test.ipynb
@@ -883,7 +883,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this summary we can observe the estimated distribution of means for each population. A simple way to compare them is substracting one to the other. In the next plot we can se that the entirety of the distribution of differences is higher than zero and that the mean of population 2 is higher than the mean of population 1 by a mean of 2."
+    "In this summary we can observe the estimated distribution of means for each population. A simple way to compare them is subtracting one to the other. In the next plot we can se that the entirety of the distribution of differences is higher than zero and that the mean of population 2 is higher than the mean of population 1 by a mean of 2."
    ]
   },
   {

--- a/docs/notebooks/wald_gamma_glm.ipynb
+++ b/docs/notebooks/wald_gamma_glm.ipynb
@@ -668,7 +668,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we look at the `agecat` variable, we can see the log mean of the claim amount tends to decrease when the age of the person increases, with the exception of the last category where we can see a slight increase in the mean of the coefficient (-0.307 vs -0.365 of the previous category). However, these differences only represent a slight tendency because of the large overlap between the marginal posteriors for these coefficients (see overlayed density plots for `C(agecat)`.\n",
+    "If we look at the `agecat` variable, we can see the log mean of the claim amount tends to decrease when the age of the person increases, with the exception of the last category where we can see a slight increase in the mean of the coefficient (-0.307 vs -0.365 of the previous category). However, these differences only represent a slight tendency because of the large overlap between the marginal posteriors for these coefficients (see overlaid density plots for `C(agecat)`.\n",
     "\n",
     "The posterior for `gender` tells us that the claim amount tends to be larger for males than for females, with the mean being 0.153 and the credible interval ranging from 0.054 to 0.246. \n",
     "\n",


### PR DESCRIPTION
Fix typos in some examples or documentation.

Not sure if there is an effect of the typo found in `models.py`. Let me know if that is not a typo.