### PR TITLE
Remove retry logic in mcmc as pymc already does this

### DIFF
--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -215,40 +215,17 @@ class PyMCModel:
     ):
         with self.model:
             if sampler_backend == "mcmc":
-                try:
-                    idata = pm.sample(
-                        draws=draws,
-                        tune=tune,
-                        discard_tuned_samples=discard_tuned_samples,
-                        init=init,
-                        n_init=n_init,
-                        chains=chains,
-                        cores=cores,
-                        random_seed=random_seed,
-                        **kwargs,
-                    )
-                except (RuntimeError, ValueError):
-                    if (
-                        "ValueError: Mass matrix contains" in traceback.format_exc()
-                        and init == "auto"
-                    ):
-                        _log.info(
-                            "\nThe default initialization using init='auto' has failed, trying to "
-                            "recover by switching to init='adapt_diag'",
-                        )
-                        idata = pm.sample(
-                            draws=draws,
-                            tune=tune,
-                            discard_tuned_samples=discard_tuned_samples,
-                            init="adapt_diag",
-                            n_init=n_init,
-                            chains=chains,
-                            cores=cores,
-                            random_seed=random_seed,
-                            **kwargs,
-                        )
-                    else:
-                        raise
+                idata = pm.sample(
+                    draws=draws,
+                    tune=tune,
+                    discard_tuned_samples=discard_tuned_samples,
+                    init=init,
+                    n_init=n_init,
+                    chains=chains,
+                    cores=cores,
+                    random_seed=random_seed,
+                    **kwargs,
+                )
             elif sampler_backend == "nuts_numpyro":
                 # Lazy import to not force users to install Jax
                 import pymc.sampling_jax  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
This came up in a recent PR (https://github.com/bambinos/bambi/pull/526#discussion_r893729628) but I think PyMC already handles this retry logic so bambi doesn't need to any more (I'm having trouble finding the exact code in pymc, although I've definitely seen it happen in my non-bambi pymc models!) 