### PR TITLE
add vi_kwargs to fit

### DIFF
--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -84,6 +84,7 @@ class PyMCModel:
         chains=None,
         cores=None,
         random_seed=None,
+        vi_kwargs=None,
         **kwargs,
     ):
         """Run PyMC sampler."""
@@ -104,7 +105,9 @@ class PyMCModel:
                 **kwargs,
             )
         elif method.lower() == "vi":
-            result = self._run_vi(**kwargs)
+            if vi_kwargs is None:
+                vi_kwargs = {}
+            result = self._run_vi(**vi_kwargs)
         else:
             result = self._run_laplace()
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -180,6 +180,7 @@ class Model:
         chains=None,
         cores=None,
         random_seed=None,
+        vi_kwargs=None,
         **kwargs,
     ):
         """Fit the model using PyMC.
@@ -242,8 +243,10 @@ class Model:
             in the system unless there are more than 4 CPUs, in which case it is set to 4.
         random_seed : int or list of ints
             A list is accepted if cores is greater than one.
+        vi_kwargs : dict
+            kwargs passed to ``pymc.fit``. Only works when ``method="vi".
         **kwargs:
-            For other kwargs see the documentation for ``PyMC.sample()``.
+            For other kwargs see the documentation for ``pymc.sample()``.
 
         Returns
         -------

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -277,6 +277,7 @@ class Model:
             chains=chains,
             cores=cores,
             random_seed=random_seed,
+            vi_kwargs=vi_kwargs,
             **kwargs,
         )
 


### PR DESCRIPTION
`model.fit` has an argument called  `method` as well as `pymc.fit` to avoid those name clashing, this PR introduces a `vi_kwargs`argument that is passed to `pymc.fit`. As `method="mcmc"` is the most common method, we allow passing arguments as kwargs, instead of adding a `mcmc_kwargs argument`. This also add a missing test.