### PR TITLE
Implement `censored()`

### DIFF
--- a/bambi/terms.py
+++ b/bambi/terms.py
@@ -4,6 +4,9 @@ from bambi.families.multivariate import Categorical, Multinomial
 from bambi.families.univariate import Bernoulli
 from bambi.utils import extract_argument_names, extra_namespace
 
+from formulae.terms.call import Call 
+from formulae.terms.call_resolver import get_function_from_module
+
 
 class ResponseTerm:
     """Representation of a single response model term.
@@ -340,3 +343,14 @@ def get_success_level(term):
         return intermediate_data._contrast.reference
 
     return levels[0]
+
+
+def is_single_call(term):
+    is_len_one = len(term.term.term.components) == 1
+    is_call = isinstance(term.term.term.components[0], Call)
+    return is_len_one and is_call
+
+
+def is_call_of_kind(call, kind):
+    function = get_function_from_module(call.call.callee, call.env)
+    return hasattr(function, "__metadata__") and function.__metadata__["kind"] == kind

--- a/bambi/terms.py
+++ b/bambi/terms.py
@@ -1,11 +1,11 @@
 import numpy as np
 
+from formulae.terms.call import Call
+from formulae.terms.call_resolver import get_function_from_module
+
 from bambi.families.multivariate import Categorical, Multinomial
 from bambi.families.univariate import Bernoulli
 from bambi.utils import extract_argument_names, extra_namespace
-
-from formulae.terms.call import Call 
-from formulae.terms.call_resolver import get_function_from_module
 
 
 class ResponseTerm:

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -405,3 +405,14 @@ def test_data_is_copied():
         assert all(model.data.dtypes[:3] == "category")
 
     assert all(adults.dtypes[:3] == "object")
+
+
+def test_response_is_censored():
+    df = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4, 5],
+            "status": ["none", "right", "interval", "left", "none"],
+        }
+    )
+    dm = Model("censored(x, status) ~ 1", df)
+    assert dm.response.is_censored

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -118,6 +118,7 @@ def censored(*args):
     if right is not None:
         right = np.asarray(right)
         assert len(left) == len(right)
+        assert (right > left).all(), "Upper bound must be larger than lower bound"
 
     assert all(s in status_mapping for s in status), f"Statuses must be in {list(status_mapping)}"
     status = np.asarray([status_mapping[s] for s in status])

--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -78,15 +78,15 @@ def extract_argument_names(expr, accepted_funcs):
 def censored(*args):
     """Construct array for censored response
 
-    The `args` argument must be of length 2 or 3. 
-    If it is of length 2, the first value has the values of the variable and the second value 
+    The `args` argument must be of length 2 or 3.
+    If it is of length 2, the first value has the values of the variable and the second value
     contains the censoring statuses.
 
     If it is of length 3, the first value represents either the value of the variable or the lower
     bound (depending on whether it's interval censoring or not). The second value represents the
     upper bound, only if it's interval censoring, and the third argument contains the censoring
     statuses.
-    
+
     Valid censoring statuses are
 
     * "left": left censoring
@@ -100,10 +100,10 @@ def censored(*args):
     Returns
     -------
     np.ndarray
-        Array of shape (n, 2) or (n, 3). The first case applies when a single value argument is 
+        Array of shape (n, 2) or (n, 3). The first case applies when a single value argument is
         passed, and the second case applies when two values are passed.
     """
-    STATUS_MAPPING = {"left": -1, "none": 0, "right": 1, "interval": 2}
+    status_mapping = {"left": -1, "none": 0, "right": 1, "interval": 2}
 
     if len(args) == 2:
         left, status = args
@@ -111,23 +111,24 @@ def censored(*args):
     elif len(args) == 3:
         left, right, status = args
     else:
-        raise
-    
+        raise ValueError("'censored' needs 2 or 3 argument values.")
+
     assert len(left) == len(status)
 
     if right is not None:
         right = np.asarray(right)
         assert len(left) == len(right)
 
-    assert all(s in STATUS_MAPPING for s in status), f"Statuses must be in {list(STATUS_MAPPING)}"
-    status = np.asarray([STATUS_MAPPING[s] for s in status])
-    
+    assert all(s in status_mapping for s in status), f"Statuses must be in {list(status_mapping)}"
+    status = np.asarray([status_mapping[s] for s in status])
+
     if right is not None:
         result = np.column_stack([left, right, status])
     else:
         result = np.column_stack([left, status])
-    
+
     return result
+
 
 censored.__metadata__ = {"kind": "censored"}
 


### PR DESCRIPTION
Closes #577

This only implements the `censored()` function to be accessible within the formula interface in Bambi.
This **does not** implement censored families yet. That will come in another PR.
