### PR TITLE
Add common numpy transforms to extra_namespace

### DIFF
--- a/bambi/utils.py
+++ b/bambi/utils.py
@@ -133,4 +133,13 @@ def censored(*args):
 
 censored.__metadata__ = {"kind": "censored"}
 
-extra_namespace = {"c": c, "censored": censored}
+extra_namespace = {
+    "c": c,
+    "censored": censored,
+    "log": np.log,
+    "log2": np.log2,
+    "log10": np.log10,
+    "exp": np.exp,
+    "exp2": np.exp2,
+    "abs": np.abs,
+}


### PR DESCRIPTION
Adds the following transformations

* `log()`
* `log2()`
* `log10()`
* `exp()`
* `exp2()`
* `abs()`

Previously

```python
import numpy as np
model = bmb.Model("y ~ np.log(x)", data)
```

Now

```python
model = bmb.Model("y ~ log(x)", data)
```


Closes #587
