### PR TITLE
add AsymmetricLaplace family (Quantile Regression)

### DIFF
--- a/bambi/defaults/defaults.py
+++ b/bambi/defaults/defaults.py
@@ -2,6 +2,7 @@ from bambi.families import Likelihood
 from bambi.priors import Prior
 
 from bambi.families.univariate import (
+    AsymmetricLaplace,
     Bernoulli,
     Beta,
     Binomial,
@@ -19,6 +20,7 @@ from bambi.families.multivariate import Categorical, Multinomial
 
 # Default parameters for PyMC distributions
 SETTINGS_DISTRIBUTIONS = {
+    "AsymmetricLaplace": {"mu": 0, "b": 1, "kappa": 1},
     "Bernoulli": {"p": 0.5},
     "Beta": {"alpha": 1, "beta": 1},
     "Binomial": {"n": 1, "p": 0.5},
@@ -39,6 +41,19 @@ SETTINGS_DISTRIBUTIONS = {
 
 # fmt: off
 BUILTIN_FAMILIES = {
+    "asymmetriclaplace": {
+        "likelihood": {
+            "name": "AsymmetricLaplace",
+            "args": {
+                "b": "HalfNormal",
+                "kappa" : "HalfNormal",
+            },
+            "parent": "mu",
+        },
+        "link": "identity",
+        "family": AsymmetricLaplace,
+    },
+
     "bernoulli": {
         "likelihood": {
             "name": "Bernoulli",

--- a/bambi/families/likelihood.py
+++ b/bambi/families/likelihood.py
@@ -7,6 +7,7 @@ from bambi.utils import multilinify, spacify
 DistSettings = namedtuple("DistSettings", ["params", "parent", "args"])
 
 DISTRIBUTIONS = {
+    "AsymetricLaplace": DistSettings(params=("mu", "b"), parent="mu", args=("b", "kappa")),
     "Bernoulli": DistSettings(params=("p",), parent="p", args=None),
     "Beta": DistSettings(params=("mu", "kappa"), parent="mu", args=("kappa",)),
     "Binomial": DistSettings(params=("p",), parent="p", args=None),

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -23,6 +23,17 @@ class UnivariateFamily(Family):
         return posterior
 
 
+class AsymmetricLaplace(UnivariateFamily):
+    SUPPORTED_LINKS = ["identity", "log", "inverse"]
+
+    def posterior_predictive(self, model, posterior, linear_predictor):
+        "Sample from posterior predictive distribution"
+        mean = xr.apply_ufunc(self.link.linkinv, linear_predictor)
+        b = posterior[model.response.name + "_b"]
+        kappa = posterior[model.response.name + "_kappa"]
+        return xr.apply_ufunc(stats.laplace_asymmetric, kappa=kappa, loc=mean, scale=b)
+
+
 class Bernoulli(UnivariateFamily):
     SUPPORTED_LINKS = ["identity", "logit", "probit", "cloglog"]
 

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -31,7 +31,7 @@ class AsymmetricLaplace(UnivariateFamily):
         mean = xr.apply_ufunc(self.link.linkinv, linear_predictor)
         b = posterior[model.response.name + "_b"]
         kappa = posterior[model.response.name + "_kappa"]
-        return xr.apply_ufunc(stats.laplace_asymmetric, kappa=kappa, loc=mean, scale=b)
+        return xr.apply_ufunc(stats.laplace_asymmetric, kappa, mean, b)
 
 
 class Bernoulli(UnivariateFamily):

--- a/bambi/tests/test_built_models.py
+++ b/bambi/tests/test_built_models.py
@@ -544,6 +544,24 @@ def test_vonmises_regression():
     Model("y ~ x", data, family="vonmises").fit(draws=10, tune=10)
 
 
+def test_quantile_regression():
+    x = np.random.uniform(2, 10, 100)
+    y = 2 * x + np.random.normal(0, 0.6 * x**0.75)
+    data = pd.DataFrame({"x": x, "y": y})
+    bmb_model0 = Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa": 9})
+    idata0 = bmb_model0.fit()
+    bmb_model0.predict(idata0)
+
+    bmb_model1 = Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa": 0.1})
+    idata1 = bmb_model1.fit()
+    bmb_model1.predict(idata1)
+
+    assert np.all(
+        idata0.posterior["y_mean"].mean(("chain", "draw"))
+        > idata1.posterior["y_mean"].mean(("chain", "draw"))
+    )
+
+
 def test_plot_priors(crossed_data):
     model = Model("Y ~ 0 + threecats", crossed_data)
     # Priors cannot be plotted until model is built.

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -290,6 +290,7 @@ def test_hyperprior_on_common_effect():
 @pytest.mark.parametrize(
     "family",
     [
+        "asymmetriclaplace",
         "gaussian",
         "negativebinomial",
         "bernoulli",
@@ -315,6 +316,7 @@ def test_links():
     )
 
     FAMILIES = {
+        "asymmetriclaplace": ["identity", "log", "inverse"],
         "bernoulli": ["identity", "logit", "probit", "cloglog"],
         "beta": ["identity", "logit", "probit", "cloglog"],
         "gamma": ["identity", "inverse", "log"],


### PR DESCRIPTION
This is useful for performing quantile regression. To do so we have to fix the value of the kappa parameter to a suitable value. For example, to fit the 0.1 quantile we do the following:

```python
q = 0.1
κ = (q/(1-q))**0.5
Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa":κ})
```

The following figure shows the fit to the 0.1 and 0.9 quantiles

![quantile_regression](https://user-images.githubusercontent.com/1338958/203848533-b6504ce1-74dd-461e-8e95-4dc022e00d3c.png)

Having to transform from q to κ can be annoying, So I will add an alternative parametrization to the AssymetricLaplace in PyMC, so we can directly set the quantiles.