### PR TITLE
Remove seed argument

### DIFF
--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -499,7 +499,7 @@ def _posterior_samples_to_idata(samples, model):
     -------
     An ArviZ's InferenceData object.
     """
-    initial_point = model.initial_point(seed=None)
+    initial_point = model.initial_point()
     variables = model.value_vars
 
     var_info = {}


### PR DESCRIPTION
Looks like I was wrong in saying we need to restrict to PyMC >= 4.4.0. We can simply remove the argument name and that's it. By default the `.initial_point()` method has `seed=None` or `random_seed=None`
