### PR TITLE
Add 'transforms' argument to plot_cap

### DIFF
--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -113,7 +113,9 @@ def create_cap_data(model, covariates, grid_n=200, groups_n=5):
     return cap_data
 
 
-def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True, ax=None):
+def plot_cap(
+    model, idata, covariates, use_hdi=True, hdi_prob=None, transforms=None, legend=True, ax=None
+):
     """Plot Conditional Adjusted Predictions
 
     Parameters
@@ -133,6 +135,9 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
         Changing the global variable ``az.rcParam["stats.hdi_prob"]`` affects this default.
     legend : bool, optional
         Whether to automatically include a legend in the plot. Defaults to ``True``.
+    transforms : dict, optional
+        Transformations that are applied to each of the variables being plotted. The keys are the
+        name of the variables, and the values are functions to be applied. Defaults to ``None``.
     ax : matplotlib.axes._subplots.AxesSubplot, optional
         A matplotlib axes object. If None, this function instantiates a new axes object.
         Defaults to ``None``.
@@ -161,7 +166,13 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
     if not 0 < hdi_prob < 1:
         raise ValueError(f"'hdi_prob' must be greater than 0 and smaller than 1. It is {hdi_prob}.")
 
-    y_hat = idata.posterior[f"{model.response.name}_mean"]
+    if transforms is None:
+        transforms = {}
+
+    # If passed, use transformation
+    response_transform = transforms.get(model.response.name, identity)
+
+    y_hat = response_transform(idata.posterior[f"{model.response.name}_mean"])
     y_hat_mean = y_hat.mean(("chain", "draw"))
 
     if use_hdi:
@@ -178,7 +189,9 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
 
     main = covariates[0]
     if is_numeric_dtype(cap_data[main]):
-        ax = _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, ax)
+        ax = _plot_cap_numeric(
+            covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, ax
+        )
     elif is_categorical_dtype(cap_data[main]) or is_string_dtype(cap_data[main]):
         ax = _plot_cap_categoric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, ax)
     else:
@@ -188,20 +201,24 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
     return fig, ax
 
 
-def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, ax):
+def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, ax):
+    main = covariates[0]
+    # Extract transform
+    transform_main = transforms.get(main, identity)
     if len(covariates) == 1:
-        main = covariates[0]
-        ax.plot(cap_data[main], y_hat_mean, solid_capstyle="butt")
-        ax.fill_between(cap_data[main], y_hat_bounds[0], y_hat_bounds[1], alpha=0.5)
+        values_main = transform_main(cap_data[main])
+        ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
+        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.5)
     else:
-        main, group = covariates
+        group = covariates[1]
         groups = get_unique_levels(cap_data[group])
 
         for i, grp in enumerate(groups):
             idx = (cap_data[group] == grp).values
-            ax.plot(cap_data.loc[idx, main], y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
+            values_main = transform_main(cap_data.loc[idx, main])
+            ax.plot(values_main, y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
             ax.fill_between(
-                cap_data.loc[idx, main],
+                values_main,
                 y_hat_bounds[0][idx],
                 y_hat_bounds[1][idx],
                 alpha=0.3,
@@ -261,3 +278,7 @@ def _plot_cap_categoric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, 
     ax.set_xticks(idxs_main)
     ax.set_xticklabels(main_levels)
     return ax
+
+
+def identity(x):
+    return x


### PR DESCRIPTION
This PR adds an optional argument called `transforms` to `plot_cap()`. This is useful when the model is fitted on transformed data and we want the visualization in the original scale. See the example

```python
import bambi as bmb
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

from bambi.plots import plot_cap

rng = np.random.default_rng(1234)
x = np.abs(rng.normal(size=100, scale=5)) + 5
y = np.exp(2 + 0.3 * x + rng.normal(size=100, scale=0.5))

data = pd.DataFrame({"x": x, "y": y})
data["log_x"] = np.log(x)
data["log_y"] = np.log(y)
model = bmb.Model("log_y ~ 1 + log_x", data)
idata = model.fit()

# Plot CAP on transformed scale. Result is a straight line
fig, ax = plt.subplots()
ax.scatter(data["log_x"], data["log_y"], color="C4", alpha=0.6);
plot_cap(model, idata, "log_x", ax=ax);
```

![image](https://user-images.githubusercontent.com/25507629/204011619-0c5ab1cf-cdd4-4f5c-9260-88458c00d9b9.png)

```python
# Plot CAP on the original scale, not necessarily a straight line
transforms = {"log_y": np.exp, "log_x": np.exp}
fig, ax = plt.subplots()
ax.scatter(data["x"], data["y"], color="C4", alpha=0.6);
plot_cap(model, idata, "log_x", transforms=transforms, ax=ax);
```
![image](https://user-images.githubusercontent.com/25507629/204011705-9e9d9cbd-ab6c-45f4-ba61-db925582098d.png)


**Update** We can also use models that contain inline transformations. Notice the plot is created in the untransformed space. If we want the transformed space, we need to ask for it. While it may look counter-intuitive in the beginning, this is the most sensible approach I think because it works well when the predictor on the horizontal scale is included in more than a single term.

```python
fig, ax = plt.subplots()
ax.scatter(np.log(data["x"]), np.log(data["y"]), color="C4", alpha=0.6);
plot_cap(model, idata, "x", transforms={"x": np.log}, ax=ax);
```
![image](https://user-images.githubusercontent.com/25507629/204029193-f104889d-8d05-4a1f-8a0b-2ceadeb35aaa.png)


```python
transforms = {"log(y)": np.exp}
fig, ax = plt.subplots()
ax.scatter(data["x"], data["y"], color="C4", alpha=0.6);
plot_cap(model, idata, "x", transforms=transforms, ax=ax);
```
![image](https://user-images.githubusercontent.com/25507629/204029236-9000ed69-b566-4d43-a79a-39c21e93f19b.png)


Closes #588 and #590