### PR TITLE
Add panel covariates to `plot_cap()` and make it more flexible

### DIFF
--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -113,7 +113,9 @@ def create_cap_data(model, covariates, grid_n=200, groups_n=5):
     return cap_data
 
 
-def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True, ax=None):
+def plot_cap(
+    model, idata, covariates, use_hdi=True, hdi_prob=None, transforms=None, legend=True, ax=None
+):
     """Plot Conditional Adjusted Predictions
 
     Parameters
@@ -133,6 +135,9 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
         Changing the global variable ``az.rcParam["stats.hdi_prob"]`` affects this default.
     legend : bool, optional
         Whether to automatically include a legend in the plot. Defaults to ``True``.
+    transforms : dict, optional
+        Transformations that are applied to each of the variables being plotted. The keys are the
+        name of the variables, and the values are functions to be applied. Defaults to ``None``.
     ax : matplotlib.axes._subplots.AxesSubplot, optional
         A matplotlib axes object. If None, this function instantiates a new axes object.
         Defaults to ``None``.
@@ -161,7 +166,13 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
     if not 0 < hdi_prob < 1:
         raise ValueError(f"'hdi_prob' must be greater than 0 and smaller than 1. It is {hdi_prob}.")
 
-    y_hat = idata.posterior[f"{model.response.name}_mean"]
+    if transforms is None:
+        transforms = {}
+
+    # If passed, use transformation
+    response_transform = transforms.get(model.response.name, identity)
+
+    y_hat = response_transform(idata.posterior[f"{model.response.name}_mean"])
     y_hat_mean = y_hat.mean(("chain", "draw"))
 
     if use_hdi:
@@ -178,7 +189,9 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
 
     main = covariates[0]
     if is_numeric_dtype(cap_data[main]):
-        ax = _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, ax)
+        ax = _plot_cap_numeric(
+            covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, ax
+        )
     elif is_categorical_dtype(cap_data[main]) or is_string_dtype(cap_data[main]):
         ax = _plot_cap_categoric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, ax)
     else:
@@ -188,20 +201,24 @@ def plot_cap(model, idata, covariates, use_hdi=True, hdi_prob=None, legend=True,
     return fig, ax
 
 
-def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, ax):
+def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, ax):
+    main = covariates[0]
+    # Extract transform
+    transform_main = transforms.get(main, identity)
     if len(covariates) == 1:
-        main = covariates[0]
-        ax.plot(cap_data[main], y_hat_mean, solid_capstyle="butt")
-        ax.fill_between(cap_data[main], y_hat_bounds[0], y_hat_bounds[1], alpha=0.5)
+        values_main = transform_main(cap_data[main])
+        ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
+        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.5)
     else:
-        main, group = covariates
+        group = covariates[1]
         groups = get_unique_levels(cap_data[group])
 
         for i, grp in enumerate(groups):
             idx = (cap_data[group] == grp).values
-            ax.plot(cap_data.loc[idx, main], y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
+            values_main = transform_main(cap_data.loc[idx, main])
+            ax.plot(values_main, y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
             ax.fill_between(
-                cap_data.loc[idx, main],
+                values_main,
                 y_hat_bounds[0][idx],
                 y_hat_bounds[1][idx],
                 alpha=0.3,
@@ -261,3 +278,7 @@ def _plot_cap_categoric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, 
     ax.set_xticks(idxs_main)
     ax.set_xticklabels(main_levels)
     return ax
+
+
+def identity(x):
+    return x

--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -238,7 +238,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
         ax = axes[0]
         values_main = transform_main(cap_data[main])
         ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
-        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.8)
+        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.5)
     elif "color" in covariates and not "panel" in covariates:
         ax = axes[0]
         color = covariates.get("color")
@@ -251,7 +251,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
                 values_main,
                 y_hat_bounds[0][idx],
                 y_hat_bounds[1][idx],
-                alpha=0.3,
+                alpha=0.5,
                 color=f"C{i}",
             )
     elif not "color" in covariates and "panel" in covariates:
@@ -261,7 +261,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
             idx = (cap_data[panel] == pnl).to_numpy()
             values_main = transform_main(cap_data.loc[idx, main])
             ax.plot(values_main, y_hat_mean[idx], solid_capstyle="butt")
-            ax.fill_between(values_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx], alpha=0.3)
+            ax.fill_between(values_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx], alpha=0.5)
             ax.set(title=f"{panel} = {pnl}")
     elif "color" in covariates and "panel" in covariates:
         color = covariates.get("color")
@@ -277,7 +277,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
                     values_main,
                     y_hat_bounds[0][idx],
                     y_hat_bounds[1][idx],
-                    alpha=0.3,
+                    alpha=0.5,
                     color=f"C{i}",
                 )
                 ax.set(title=f"{panel} = {pnl}")
@@ -291,7 +291,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
                         values_main,
                         y_hat_bounds[0][idx],
                         y_hat_bounds[1][idx],
-                        alpha=0.3,
+                        alpha=0.5,
                         color=f"C{i}",
                     )
                     ax.set(title=f"{panel} = {pnl}")
@@ -300,7 +300,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
         handles = [
             (
                 Line2D([], [], color=f"C{i}", solid_capstyle="butt"),
-                Patch(color=f"C{i}", alpha=0.3, lw=1),
+                Patch(color=f"C{i}", alpha=0.5, lw=1),
             )
             for i in range(len(colors))
         ]


### PR DESCRIPTION
~~This is still WIP, but I'm excited about this PR since it makes `plot_cap()` much more flexible~~

Now we can do something like 

```python
data = pd.read_csv("https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f23f993cd87c283ce766e7ac6b329ee7cc2e1d1/mtcars.csv")
data["cyl"] = data["cyl"].replace({4: "low", 6: "medium", 8: "high"})
data["cyl"] = pd.Categorical(data["cyl"], categories=["low", "medium", "high"], ordered=True)
data["gear"] = data["gear"].replace({3: "A", 4: "B", 5: "C"})
model = bmb.Model("mpg ~ 0 + hp * wt + cyl + gear", data)
idata = model.fit(draws=500, target_accept=0.9, random_seed=1234)

fig, axes = plot_cap(
    model, 
    idata, 
    {"horizontal": "hp", "color": "cyl","panel": "gear"},
    use_hdi=False, 
    fig_kwargs={"figsize": (15, 5), "dpi": 120, "sharey": True}
);
```

![image](https://user-images.githubusercontent.com/25507629/204097226-63ba31f9-4783-4243-a15c-3fb435af3d07.png)


~~All the previous examples still work. I still need to update the the internal function `_plot_cap_categoric()` and clean some details in `_plot_cap_numeric()`. In particular I need to handle legends using the figure and not the axes.~~

**Edit:** This is done. I decided to create a notebook to show the new features of `plot_cap()`. Basically, it still works for all the cases it used to work, but now it's more flexible. We can map groups to panels.

https://gist.github.com/tomicapretto/1388437357d8520ff5ff2fcee39b7d1b

