### PR TITLE
Remove check to convert prior parameter values into arrays

### DIFF
--- a/bambi/priors/prior.py
+++ b/bambi/priors/prior.py
@@ -29,7 +29,6 @@ class Prior:
         kwargs : dict
             Optional keyword arguments to add to prior args.
         """
-        # The backend expect numpy arrays, so make sure all numeric values are represented as such.
         kwargs_ = {}
         for key, val in kwargs.items():
             if isinstance(val, np.ndarray):

--- a/bambi/priors/prior.py
+++ b/bambi/priors/prior.py
@@ -32,9 +32,7 @@ class Prior:
         # The backend expect numpy arrays, so make sure all numeric values are represented as such.
         kwargs_ = {}
         for key, val in kwargs.items():
-            if isinstance(val, (int, float)):
-                val = np.array(val)
-            elif isinstance(val, np.ndarray):
+            if isinstance(val, np.ndarray):
                 val = val.squeeze()
             kwargs_[key] = val
         self.args.update(kwargs_)


### PR DESCRIPTION
I don't know why, but we had a check that made sure the values of the prior parameters were all numpy arrays. This was problematic when one tried to use configs such as `aesara.config.floatX = 'float32'` because `np.array()` would convert to int64 or float64 by default (this just happened to me).

I'm opening this mainly to see if our test suit still works. If that's the case, it means we don't need to convert single values to numpy arrays