### PR TITLE
Remove string option for data input

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -32,9 +32,9 @@ class Model:
     ----------
     formula : str
         A model description written using the formula syntax from the ``formulae`` library.
-    data : pandas.DataFrame or str
-        The dataset to use. Either a pandas ``DataFrame``, or the name of the file containing
-        the data, which will be passed to ``pd.read_csv()``.
+    data : pandas.DataFrame
+        A pandas dataframe containing the data on which the model will be fit, with column
+        names matching variables defined in the formula.
     family : str or bambi.families.Family
         A specification of the model family (analogous to the family object in R). Either
         a string, or an instance of class ``bambi.families.Family``. If a string is passed, a
@@ -121,10 +121,8 @@ class Model:
         self.potentials = potentials
 
         # Read and clean data
-        if isinstance(data, str):
-            data = pd.read_csv(data, sep=None, engine="python")
-        elif not isinstance(data, pd.DataFrame):
-            raise ValueError("'data' must be a string with a path to a .csv or a pandas DataFrame.")
+        if not isinstance(data, pd.DataFrame):
+            raise ValueError("'data' must be a pandas DataFrame.")
 
         # Convert 'object' and explicitly asked columns to categorical.
         object_cols = list(data.select_dtypes("object").columns)

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -98,15 +98,6 @@ def test_distribute_group_specific_effect_over(diabetes_data):
     assert model.terms["C(age_grp)|BMI"].data.shape == (442, 489)
 
 
-def test_model_init_from_filename():
-    data_dir = join(dirname(__file__), "data")
-    filename = join(data_dir, "diabetes.txt")
-    model = Model("BP ~ BMI", filename)
-    assert isinstance(model.data, pd.DataFrame)
-    assert model.data.shape == (442, 11)
-    assert "BMI" in model.data.columns
-
-
 def test_model_init_bad_data():
     with pytest.raises(ValueError):
         Model("y ~ x", {"x": 1})


### PR DESCRIPTION
Closes issue #601 by removing the string option for data. 

The type check is left in (line 124), since I think it's better feedback to the user rather than failing on a later TypeError trying to run pandas operations on a string.

The docstring is updated, I added a note that the column names must match the formula just so there's some explanation on expected format.

Code coverage will likely decrease since the associated test is also removed.