### PR TITLE
Add build check function, on prior predictive and plot prior

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -546,6 +546,14 @@ class Model:
             else:
                 raise KeyError(f"The name {group} is not a group in any group-specific term.")
 
+    def _check_built(self):
+        # Checks if model is built, raises ValueError if not
+        if not self.built:
+            raise ValueError(
+                "Model is not built yet! "
+                "Call .build() to build the model or .fit() to build and sample from the posterior."
+            )
+
     def plot_priors(
         self,
         draws=5000,
@@ -611,11 +619,7 @@ class Model:
         -------
         axes: matplotlib axes
         """
-        if not self.built:
-            raise ValueError(
-                "Cannot plot priors until model is built!! "
-                "Call .build() to build the model or .fit() to build and sample from the posterior."
-            )
+        self._check_built()
 
         unobserved_rvs_names = []
         flat_rvs = []
@@ -683,6 +687,8 @@ class Model:
             ``InferenceData`` object with the groups ``prior``, ``prior_predictive`` and
             ``observed_data``.
         """
+        self._check_built()
+
         if var_names is None:
             variables = self.backend.model.unobserved_RVs + self.backend.model.observed_RVs
             variables_names = [v.name for v in variables]

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -880,11 +880,7 @@ class Model:
         >>> model.graph()
 
         """
-        if self.backend is None:
-            raise ValueError(
-                "The model is empty. "
-                "Are you forgetting to first call .build() or .fit() on the Bambi model?"
-            )
+        self._check_built()
 
         graphviz = pm.model_to_graphviz(model=self.backend.model, formatting=formatting)
 

--- a/bambi/tests/test_model_construction.py
+++ b/bambi/tests/test_model_construction.py
@@ -103,6 +103,12 @@ def test_model_init_bad_data():
         Model("y ~ x", {"x": 1})
 
 
+def test_unbuilt_model(diabetes_data):
+    model = Model("Y ~ AGE", data=diabetes_data)
+    with pytest.raises(ValueError):
+        model._check_built()
+
+
 def test_model_categorical_argument():
     data = pd.DataFrame(
         {


### PR DESCRIPTION
Added a check that the model has been built in order to call `prior_predictive`. Since the same check is being called for this and `plot_priors`, I moved it out to a function that raises a `ValueError` if unbuilt.

Also added a single test that creates an unbuilt model and looks for that `ValueError`. 

Closes #595.