### PR TITLE
Make imports compatible with PyTensor/PyMC v5

### DIFF
--- a/bambi/backend/links.py
+++ b/bambi/backend/links.py
@@ -1,13 +1,17 @@
 import numpy as np
-import aesara.tensor as at
+
+try:
+    import pytensor.tensor as pt
+except ModuleNotFoundError:
+    import aesara.tensor as pt
 
 
 def probit(x):
     """Probit function that ensures result is in (0, 1)"""
     eps = np.finfo(float).eps
-    result = 0.5 + 0.5 * at.erf(x / at.sqrt(2))
-    result = at.switch(at.eq(result, 0), eps, result)
-    result = at.switch(at.eq(result, 1), 1 - eps, result)
+    result = 0.5 + 0.5 * pt.erf(x / pt.sqrt(2))
+    result = pt.switch(pt.eq(result, 0), eps, result)
+    result = pt.switch(pt.eq(result, 1), 1 - eps, result)
 
     return result
 
@@ -15,9 +19,9 @@ def probit(x):
 def cloglog(x):
     """Cloglog function that ensures result is in (0, 1)"""
     eps = np.finfo(float).eps
-    result = 1 - at.exp(-at.exp(x))
-    result = at.switch(at.eq(result, 0), eps, result)
-    result = at.switch(at.eq(result, 1), 1 - eps, result)
+    result = 1 - pt.exp(-pt.exp(x))
+    result = pt.switch(pt.eq(result, 0), eps, result)
+    result = pt.switch(pt.eq(result, 1), 1 - eps, result)
 
     return result
 
@@ -25,9 +29,9 @@ def cloglog(x):
 def logit(x):
     """Logit function that ensures result is in (0, 1)"""
     eps = np.finfo(float).eps
-    result = at.sigmoid(x)
-    result = at.switch(at.eq(result, 0), eps, result)
-    result = at.switch(at.eq(result, 1), 1 - eps, result)
+    result = pt.sigmoid(x)
+    result = pt.switch(pt.eq(result, 0), eps, result)
+    result = pt.switch(pt.eq(result, 1), 1 - eps, result)
     return result
 
 
@@ -36,8 +40,8 @@ def identity(x):
 
 
 def inverse_squared(x):
-    return at.reciprocal(at.sqrt(x))
+    return pt.reciprocal(pt.sqrt(x))
 
 
 def arctan_2(x):
-    return 2 * at.arctan(x)
+    return 2 * pt.arctan(x)

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pymc as pm
-import aesara.tensor as at
+
+try:
+    import pytensor.tensor as pt
+except ModuleNotFoundError:
+    import aesara.tensor as pt
 
 from bambi.backend.utils import has_hyperprior, get_distribution
 from bambi.families.multivariate import MultivariateFamily
@@ -57,7 +61,7 @@ class CommonTerm:
             else:
                 shape = data.shape[1]
             coef = distribution(label, shape=shape, **args)
-            coef = at.atleast_1d(coef)  # If only a single numeric column it won't be 1D
+            coef = pt.atleast_1d(coef)  # If only a single numeric column it won't be 1D
 
         # Prepends one dimension if response is multivariate and the predictor is 1D
         if response_dims and len(dims) == 1:
@@ -204,11 +208,11 @@ class ResponseTerm:
     def build(self, nu, invlinks):
         """Create and return the response distribution for the PyMC model.
 
-        nu : aesara.tensor.var.TensorVariable
+        nu : pytensor.tensor.var.TensorVariable
             The linear predictor in the PyMC model.
         invlinks : dict
             A dictionary where names are names of inverse link functions and values are functions
-            that can operate with Aesara tensors.
+            that can operate with PyTensor tensors.
         """
         data = np.squeeze(self.term.data)
 

--- a/bambi/backend/utils.py
+++ b/bambi/backend/utils.py
@@ -1,4 +1,7 @@
-import aesara.tensor as at
+try:
+    import pytensor.tensor as pt
+except ModuleNotFoundError:
+    import aesara.tensor as pt
 import pymc as pm
 
 
@@ -17,5 +20,5 @@ def has_hyperprior(kwargs):
     return (
         "sigma" in kwargs
         and "observed" not in kwargs
-        and isinstance(kwargs["sigma"], at.TensorVariable)
+        and isinstance(kwargs["sigma"], pt.TensorVariable)
     )

--- a/bambi/families/link.py
+++ b/bambi/families/link.py
@@ -139,7 +139,7 @@ class Link:
         function in GLM jargon. Does not need to be specified when ``name`` is a known name.
     linkinv_backend: function
         Same than ``linkinv`` but must be something that works with PyMC backend (i.e. it must
-        work with Aesara tensors). Does not need to be specified when ``name`` is a known
+        work with PyTensor tensors). Does not need to be specified when ``name`` is a known
         name.
     """
 

--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -1,5 +1,5 @@
 # pylint: disable=unused-argument
-import aesara.tensor as pt
+import pytensor.tensor as pt
 import numpy as np
 import xarray as xr
 

--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -1,5 +1,5 @@
 # pylint: disable=unused-argument
-import aesara.tensor as at
+import aesara.tensor as pt
 import numpy as np
 import xarray as xr
 
@@ -106,7 +106,7 @@ class Categorical(MultivariateFamily):
 
         # The first line makes sure the intercept-only models work
         nu = np.ones(shape) * nu  # (response_levels, ) -> (n, response_levels)
-        nu = at.concatenate([np.zeros(shape), nu], axis=1)
+        nu = pt.concatenate([np.zeros(shape), nu], axis=1)
         return nu
 
 
@@ -198,7 +198,7 @@ class Multinomial(MultivariateFamily):
 
         # The first line makes sure the intercept-only models work
         nu = np.ones(shape) * nu  # (response_levels, ) -> (n, response_levels)
-        nu = at.concatenate([np.zeros(shape), nu], axis=1)
+        nu = pt.concatenate([np.zeros(shape), nu], axis=1)
         return nu
 
 

--- a/docs/notebooks/getting_started.ipynb
+++ b/docs/notebooks/getting_started.ipynb
@@ -983,8 +983,8 @@
     "# link: A function that maps the response to the linear predictor\n",
     "# linkinv: A function that maps the linear predictor to the response\n",
     "# linkinv_backend: A function that maps the linear predictor to the response\n",
-    "#                  that works with Aesara tensors.\n",
-    "#                  bmb.math.sigmoid is a Aesara tensor function wrapped by PyMC and Bambi \n",
+    "#                  that works with PyTensor tensors.\n",
+    "#                  bmb.math.sigmoid is a PyTensor tensor function wrapped by PyMC and Bambi \n",
     "link = bmb.Link(\n",
     "    \"my_logit\", \n",
     "    link=special.expit,\n",
@@ -1007,7 +1007,7 @@
    "source": [
     "The above example produces results identical to simply setting ``family='bernoulli'``.\n",
     "\n",
-    "One complication in specifying a custom ``Family`` is that one must pass both a link function and an inverse link function which must be able to operate over Aesara tensors rather than numpy arrays, so you'll probably need to rely on tensor operations provided in ``aesara.tensor`` (many of which are also wrapped by PyMC) when defining a new link."
+    "One complication in specifying a custom ``Family`` is that one must pass both a link function and an inverse link function which must be able to operate over PyTensor tensors rather than numpy arrays, so you'll probably need to rely on tensor operations provided in ``aesara.tensor`` (many of which are also wrapped by PyMC) when defining a new link."
    ]
   },
   {


### PR DESCRIPTION
I changed the `aesara` imports to `try` PyTensor first, and fall back to `aesara` otherwise.

Mentions of `Aesara` were changed to `PyTensor`, and in `pymc.py` I had to change where `softmax` comes from because `aesara.tensor.nnet` was removed.

Closes #611