### PR TITLE
Don't pass `dims` to the likelihood distribution

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 ### Maintenance and fixes
 
 * Moved the `tests` directory to the root of the repository (#607)
+* Don't pass `dims` to the response of the likelihood distribution anymore (#629)
 
 ### Documentation
 

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -254,6 +254,19 @@ class ResponseTerm:
         # Add parent parameter and observed data
         kwargs[parent] = linkinv(nu)
         kwargs["observed"] = data
+
+        # The response has multiple variables, but a single linear predictor
+        dims_n = len(dims)
+        ndim_diff = data.ndim - dims_n
+
+        if ndim_diff > 0:
+            for i in range(ndim_diff):
+                axis = dims_n + i
+                name = f"{response_aliased_name}_extra_dim_{i}"
+                values = np.arange(np.size(data, axis=axis))
+                pymc_backend.model.add_coords({name: values})
+                dims.append(name)
+
         kwargs["dims"] = dims
 
         # Build the response distribution

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -255,10 +255,10 @@ class ResponseTerm:
         kwargs[parent] = linkinv(nu)
         kwargs["observed"] = data
 
-        # The response has multiple variables, but a single linear predictor
         dims_n = len(dims)
         ndim_diff = data.ndim - dims_n
 
+        # The response has multiple variables, but a single linear predictor
         if ndim_diff > 0:
             for i in range(ndim_diff):
                 axis = dims_n + i

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -235,7 +235,9 @@ class ResponseTerm:
 
         # Distributional parameters. A link funciton is used.
         response_aliased_name = get_aliased_name(self.term)
-        dims = (response_aliased_name + "_obs",)
+        dims = [
+            response_aliased_name + "_obs",
+        ]
         for name, component in pymc_backend.distributional_components.items():
             bmb_component = bmb_model.components[name]
             if bmb_component.response_term:  # The response is added later

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -162,11 +162,10 @@ def test_multiple_outputs():
     y = rng.gamma(shape, np.exp(a + b * x) / shape, N)
     data_gamma = pd.DataFrame({"x": x, "y": y})
 
-
     formula = Formula("y ~ x", "alpha ~ x")
     model = Model(formula, data_gamma, family="gamma")
     idata = model.fit(tune=100, draws=100, random_seed=1234)
-    # Test default target 
+    # Test default target
     plot_cap(model, idata, "x")
     # Test user supplied target argument
     plot_cap(model, idata, "x", "alpha")


### PR DESCRIPTION
We are passing `dims` to the likelihood distribution. Internally, there's something like what follows happening

```python
with model:
    ...
    pm.Distribution(name, **params, observed=observed, dims=dims)
```

However, the `dims` aren't used and they can bring more problems in special cases. PyMC can determine the shape of the distribution from the shape of the  `observed` data. 

For more context, I figured this out because of a collaboration with people developing a library on top of Bambi. They have a custom likelihood function where `observed.ndim` is 2, but Bambi was passing a single dimension. My first attempt was to add a function that added as many dimensions as needed (https://github.com/bambinos/bambi/pull/629/commits/a4e3646e5bb414a0f264d7c1215a3092b5a60797) but it turns we can actually make it work without passing dimensions and just letting PyMC use the shape from `observed`.