### PR TITLE
Allow to use custom priors

### DIFF
--- a/bambi/backend/model_components.py
+++ b/bambi/backend/model_components.py
@@ -3,7 +3,7 @@ import numpy as np
 from pytensor import tensor as pt
 
 from bambi.backend.terms import CommonTerm, GroupSpecificTerm, InterceptTerm, ResponseTerm
-from bambi.backend.utils import get_distribution
+from bambi.backend.utils import get_distribution_from_prior
 from bambi.families.multivariate import MultivariateFamily
 from bambi.families.univariate import Categorical
 from bambi.utils import get_aliased_name
@@ -25,7 +25,7 @@ class ConstantComponent:
                 self.output = self.component.prior
             # Set to a distribution
             else:
-                dist = get_distribution(self.component.prior.name)
+                dist = get_distribution_from_prior(self.component.prior)
                 self.output = dist(label, **self.component.prior.args)
 
 

--- a/bambi/backend/utils.py
+++ b/bambi/backend/utils.py
@@ -19,3 +19,18 @@ def has_hyperprior(kwargs):
         and "observed" not in kwargs
         and isinstance(kwargs["sigma"], pt.TensorVariable)
     )
+
+
+def get_distribution_from_prior(prior):
+    if prior.dist is not None:
+        distribution = prior.dist
+    else:
+        distribution = get_distribution(prior.name)
+    return distribution
+
+
+def get_distribution_from_likelihood(likelihood):
+    """
+    It works because both `Prior` and `Likelihood` instances have a `name` and a `dist` argument.
+    """
+    return get_distribution_from_prior(likelihood)

--- a/bambi/families/likelihood.py
+++ b/bambi/families/likelihood.py
@@ -38,7 +38,7 @@ class Likelihood:
     parent : str
         Optional specification of the name of the mean parameter in the likelihood.
         This is the parameter whose transformation is modeled by the linear predictor.
-    dist : pymc.distributions.distribution.DistributionMeta
+    dist : pymc.distributions.distribution.DistributionMeta or callable
         Optional custom PyMC distribution that will be used to compute the likelihood.
     """
 
@@ -83,7 +83,12 @@ class Likelihood:
         self._parent = value
 
     def __str__(self):
-        args = [("name", self.name), ("params", self.params), ("parent", self.parent)]
+        args = [
+            ("name", self.name),
+            ("params", self.params),
+            ("parent", self.parent),
+            ("dist", self.dist),
+        ]
         args = [f"{arg[0]}: {arg[1]}" for arg in args]
         return f"{self.__class__.__name__}({indentify(multilinify(args))}\n)"
 

--- a/bambi/priors/prior.py
+++ b/bambi/priors/prior.py
@@ -14,13 +14,17 @@ class Prior:
         Whether to adjust the parameters of the prior or use them as passed. Default to ``True``.
     kwargs : dict
         Optional keywords specifying the parameters of the named distribution.
+    dist : pymc.distributions.distribution.DistributionMeta or callable
+        A callable that returns a valid PyMC distribution. The signature must contain ``name``,
+        ``dims``, and ``shape``, as well as its own keyworded arguments.
     """
 
-    def __init__(self, name, auto_scale=True, **kwargs):
+    def __init__(self, name, auto_scale=True, dist=None, **kwargs):
         self.name = name
         self.auto_scale = auto_scale
         self.args = {}
         self.update(**kwargs)
+        self.dist = dist
 
     def update(self, **kwargs):
         """Update the arguments of the prior with additional arguments.


### PR DESCRIPTION
This PR adds a new optional `dist` argument to `bmb.Prior`. It's a callable that returns a valid PyMC distribution. This may be useful when users want to use a distribution that is not implemented in PyMC.

Closes #630