### PR TITLE
Add compound families

### DIFF
--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -11,7 +11,7 @@ from bambi.backend.utils import (
     get_linkinv,
     GP_KERNELS,
 )
-from bambi.families.multivariate import MultivariateFamily, Multinomial
+from bambi.families.multivariate import MultivariateFamily, Multinomial, DirichletMultinomial
 from bambi.families.univariate import Categorical
 from bambi.priors import Prior
 from bambi.utils import get_aliased_name
@@ -289,8 +289,8 @@ class ResponseTerm:
         # In this case, we add extra dimensions to avoid having shape mismatch between the data
         # and the shape implied by the `dims` we pass.
 
-        # Don't do it for the Multinomial family (it's an exception)
-        if isinstance(self.family, Multinomial):
+        # Don't do it for the Multinomial families (it's an exception)
+        if isinstance(self.family, (Multinomial, DirichletMultinomial)):
             return kwargs
 
         dims, data = kwargs["dims"], kwargs["observed"]

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -11,7 +11,7 @@ from bambi.backend.utils import (
     get_linkinv,
     GP_KERNELS,
 )
-from bambi.families.multivariate import MultivariateFamily
+from bambi.families.multivariate import MultivariateFamily, Multinomial
 from bambi.families.univariate import Categorical
 from bambi.priors import Prior
 from bambi.utils import get_aliased_name
@@ -288,6 +288,11 @@ class ResponseTerm:
         # linear predictor because the family is not multivariate.
         # In this case, we add extra dimensions to avoid having shape mismatch between the data
         # and the shape implied by the `dims` we pass.
+
+        # Don't do it for the Multinomial family (it's an exception)
+        if isinstance(self.family, Multinomial):
+            return kwargs
+
         dims, data = kwargs["dims"], kwargs["observed"]
         dims_n = len(dims)
         ndim_diff = data.ndim - dims_n

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -126,7 +126,7 @@ class GroupSpecificTerm:
         new_coords = {}
         for key, value in coords.items():
             _, kind = key.split("__")
-            new_coords[self.term.alias + kind] = value
+            new_coords[self.term.alias + "__" + kind] = value
         return new_coords
 
     def build_distribution(self, prior, label, **kwargs):

--- a/bambi/defaults/families.py
+++ b/bambi/defaults/families.py
@@ -18,7 +18,7 @@ from bambi.families.univariate import (
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
 )
-from bambi.families.multivariate import Multinomial
+from bambi.families.multivariate import Multinomial, DirichletMultinomial
 
 
 # fmt: off
@@ -80,6 +80,15 @@ BUILTIN_FAMILIES = {
         },
         "link": {"p": "softmax"},
         "family": Categorical,
+    },
+    "dirichlet_multinomial": {
+        "likelihood": {
+            "name": "DirichletMultinomial",
+            "params": ["a"],
+            "parent": "a",
+        },
+        "link": {"a": "log"},
+        "family": DirichletMultinomial,
     },
     "gamma": {
         "likelihood": {

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -176,15 +176,9 @@ class Family:
         output_array = pm.draw(response_dist.dist(**kwargs))
         output_coords_all = xr.merge(output_dataset_list).coords
 
+        coord_names = ["chain", "draw", response_aliased_name + "_obs"]
         if hasattr(model.family, "KIND") and model.family.KIND == "Multivariate":
-            coord_names = (
-                "chain",
-                "draw",
-                response_aliased_name + "_obs",
-                response_aliased_name + "_mean_dim",
-            )
-        else:  # Assume it's univariate family
-            coord_names = ("chain", "draw", response_aliased_name + "_obs")
+            coord_names.append(response_aliased_name + "_dim")
 
         output_coords = {}
         for coord_name in coord_names:

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -122,8 +122,9 @@ class Family:
             It must contain the parameters that are needed in the distribution of the response, or
             the parameters that allow to derive them.
         kwargs :
-            Parameters that are used to get draws but do not appear in the posterior object.
-            For instance, the 'n' in binomial models.
+            Parameters that are used to get draws but do not appear in the posterior object or
+            other configuration parameters.
+            For instance, the 'n' in binomial models and multinomial models.
 
         Returns
         -------
@@ -135,10 +136,11 @@ class Family:
         response_aliased_name = get_aliased_name(model.response_component.response_term)
 
         kwargs.pop("data", None)  # Remove the 'data' kwarg
+        dont_reshape = kwargs.pop("dont_reshape", [])
         output_dataset_list = []
 
-        # In the posterior xr.Dataset we need to consider aliases.
-        # But we don't use aliases when passing kwargs to the PyMC distribution
+        # In the posterior xr.Dataset we need to consider aliases,
+        # but we don't use aliases when passing kwargs to the PyMC distribution.
         for param in params:
             # Extract posterior draws for the parent parameter
             if param == model.family.likelihood.parent:
@@ -161,11 +163,13 @@ class Family:
         ndims_max = max(x.ndim for x in kwargs.values())
 
         # Append a dimension when needed. Required to make `pm.draw()` work.
+        # However, some distributions like Multinomial, require some parameters to be of a smaller
+        # dimension than others (n.ndim <= p.ndim - 1) so we don't reshape those.
         for key, values in kwargs.items():
+            if key in dont_reshape:
+                continue
             kwargs[key] = expand_array(values, ndims_max)
 
-        # NOTE: Wouldn't it be better to always use parametrizations compatible with PyMC?
-        # The current approach allows more flexibility, but it's more painful.
         if hasattr(model.family, "transform_backend_kwargs"):
             kwargs = model.family.transform_backend_kwargs(kwargs)
 

--- a/bambi/families/likelihood.py
+++ b/bambi/families/likelihood.py
@@ -11,6 +11,7 @@ DISTRIBUTIONS = {
     "BetaBinomial": DistSettings(params=("mu", "kappa"), parent="mu"),
     "Binomial": DistSettings(params=("p",), parent="p"),
     "Categorical": DistSettings(params=("p",), parent="p"),
+    "DirichletMultinomial": DistSettings(params=("a",), parent="a"),
     "Gamma": DistSettings(params=("mu", "alpha"), parent="mu"),
     "Multinomial": DistSettings(params=("p",), parent="p"),
     "Normal": DistSettings(params=("mu", "sigma"), parent="mu"),

--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -13,7 +13,7 @@ class MultivariateFamily(Family):
 
 class Multinomial(MultivariateFamily):
     SUPPORTED_LINKS = {"p": ["softmax"]}
-    UFUNC_KWARGS = {"axis": -1}
+    INVLINK_KWARGS = {"axis": -1}
 
     def transform_linear_predictor(self, model, linear_predictor):
         response_name = get_aliased_name(model.response_component.response_term)

--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -73,7 +73,7 @@ class Multinomial(MultivariateFamily):
 
     def get_coords(self, response):
         # For the moment, it always uses the first column as reference.
-        name = response.name + "_dim"
+        name = get_aliased_name(response) + "_dim"
         labels = self.get_levels(response)
         return {name: labels[1:]}
 

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -55,6 +55,11 @@ class Bernoulli(UnivariateFamily):
 
 
 class Beta(UnivariateFamily):
+    """Beta Family
+
+    It uses the mean (mu) and sample size (kappa) parametrization of the Beta distribution.
+    """
+
     SUPPORTED_LINKS = {"mu": ["logit", "probit", "cloglog"], "kappa": ["log"]}
 
     @staticmethod
@@ -67,16 +72,21 @@ class Beta(UnivariateFamily):
 
 
 class BetaBinomial(BinomialBaseFamily):
-    # We use the 'mu' and 'kappa' parametrization of the Beta
+    """BetaBinomial family
+
+    It uses the mean (mu) and sample size (kappa) parametrization of the Beta distribution.
+    """
+
     SUPPORTED_LINKS = {"mu": ["logit", "probit", "cloglog"], "kappa": ["log"]}
 
     @staticmethod
     def transform_backend_kwargs(kwargs):
-        # Beta specific parameters
+        # First, transform the parameters of the beta component
         mu = kwargs.pop("mu")
         kappa = kwargs.pop("kappa")
         kwargs["alpha"] = mu * kappa
         kwargs["beta"] = (1 - mu) * kappa
+        # Then transform the parameters of the binomial component
         return BinomialBaseFamily.transform_backend_kwargs(kwargs)
 
 

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -93,7 +93,7 @@ class Categorical(UnivariateFamily):
         return np.nonzero(response.term.data)[1]
 
     def get_coords(self, response):
-        name = response.name + "_dim"
+        name = get_aliased_name(response) + "_dim"
         return {name: [level for level in response.levels if level != response.reference]}
 
     def get_reference(self, response):

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -96,19 +96,19 @@ class Binomial(BinomialBaseFamily):
 
 class Categorical(UnivariateFamily):
     SUPPORTED_LINKS = {"p": ["softmax"]}
-    UFUNC_KWARGS = {"axis": -1}
+    INVLINK_KWARGS = {"axis": -1}
 
     def transform_linear_predictor(self, model, linear_predictor):
         response_name = get_aliased_name(model.response_component.response_term)
-        response_levels_dim = response_name + "_dim"
+        response_levels_dim = response_name + "_reduced_dim"
         linear_predictor = linear_predictor.pad({response_levels_dim: (1, 0)}, constant_values=0)
         return linear_predictor
 
     def transform_coords(self, model, mean):
         # The mean has the reference level in the dimension, a new name is needed
         response_name = get_aliased_name(model.response_component.response_term)
-        response_levels_dim = response_name + "_dim"
-        response_levels_dim_complete = response_name + "_mean_dim"
+        response_levels_dim = response_name + "_reduced_dim"
+        response_levels_dim_complete = response_name + "_dim"
         levels_complete = model.response_component.response_term.levels
         mean = mean.rename({response_levels_dim: response_levels_dim_complete})
         mean = mean.assign_coords({response_levels_dim_complete: levels_complete})
@@ -118,7 +118,7 @@ class Categorical(UnivariateFamily):
         return np.nonzero(response.term.data)[1]
 
     def get_coords(self, response):
-        name = get_aliased_name(response) + "_dim"
+        name = get_aliased_name(response) + "_reduced_dim"
         return {name: [level for level in response.levels if level != response.reference]}
 
     def get_reference(self, response):

--- a/bambi/model_components.py
+++ b/bambi/model_components.py
@@ -166,12 +166,18 @@ class DistributionalComponent:
         # Prepare dims objects
         response_name = get_aliased_name(self.spec.response_component.response_term)
         response_dim = response_name + "_obs"
-        response_levels_dim = response_name + "_dim"
         linear_predictor_dims = ("chain", "draw", response_dim)
         to_stack_dims = ("chain", "draw")
         design_matrix_dims = (response_dim, "__variables__")
 
-        if isinstance(self.spec.family, (multivariate.MultivariateFamily, univariate.Categorical)):
+        # These families drop a level in the response
+        if isinstance(self.spec.family, (multivariate.Multinomial, univariate.Categorical)):
+            response_levels_dim = response_name + "_reduced_dim"
+            to_stack_dims = to_stack_dims + (response_levels_dim,)
+            linear_predictor_dims = linear_predictor_dims + (response_levels_dim,)
+        # These families DON'T drop any level in the response
+        elif isinstance(self.spec.family, multivariate.MultivariateFamily):
+            response_levels_dim = response_name + "_dim"
             to_stack_dims = to_stack_dims + (response_levels_dim,)
             linear_predictor_dims = linear_predictor_dims + (response_levels_dim,)
 

--- a/bambi/model_components.py
+++ b/bambi/model_components.py
@@ -282,17 +282,13 @@ class DistributionalComponent:
         if hasattr(family, "transform_linear_predictor"):
             linear_predictor = family.transform_linear_predictor(self.spec, linear_predictor)
 
-        if hasattr(family, "UFUNC_KWARGS"):
-            ufunc_kwargs = family.UFUNC_KWARGS
-        else:
-            ufunc_kwargs = {}
-
         if self.response_kind == "data":
             linkinv = family.link[family.likelihood.parent].linkinv
         else:
             linkinv = family.link[self.response_name].linkinv
 
-        response = xr.apply_ufunc(linkinv, linear_predictor, kwargs=ufunc_kwargs)
+        invlink_kwargs = getattr(family, "INVLINK_KWARGS", {})
+        response = xr.apply_ufunc(linkinv, linear_predictor, kwargs=invlink_kwargs)
 
         if hasattr(family, "transform_coords"):
             response = family.transform_coords(self.spec, response)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,10 +6,18 @@
 
 * Add support for Gaussian Processes via the HSGP approximation (#632) 
 * Add new families: `"zero_inflated_poisson"`, `"zero_inflated_binomial"`, and `"zero_inflated_negativebinomial"` (#654)
+* Add new families: `"beta_binomial"` and `"dirichlet_multinomial"` (#659)
 
 ### Maintenance and fixes
 
+* Modify how HSGP is built in PyMC when there are groups (#661)
+* Modify how Bambi is imported in the tests (#662)
+* Prevent underscores from being removed in dim names (#664)
+
 ### Documentation
+
+* Document how to use custom priors (#656)
+* Fix name of arviz traceplot function in the docs (#666)
 
 ### Deprecation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "graphviz",
     "numpy>1.22",
     "pandas>=1.0.0",
-    "pymc @ git+https://git@github.com/pymc-devs/pymc",
+    "pymc >= 5.2.0",
     "scipy>=1.7.0",
 ]
 


### PR DESCRIPTION
This adds two new families

* [x] The `"beta_binomial"` family which uses the `BetaBinomial` distribution from PyMC.
* [x] The `"dirichlet_multinomial"` family which uses the `DirichletMultinomial` distribution from PyMC.

Also, I'm adding a `BinomialBaseFamily` which implements the common transformations needed for posterior predictive sampling and the transformation of backend kwargs.

~~For the dirichlet_multinomial I first need to improve the implementation of posterior predictive of the multinomial family~~ Done!