### PR TITLE
Modify how HSGP is built in PyMC when there are groups

### DIFF
--- a/bambi/model_components.py
+++ b/bambi/model_components.py
@@ -207,6 +207,11 @@ class DistributionalComponent:
                 else:
                     maximum_distance = 1
 
+                # NOTE:
+                # The approach here differs from the one in the PyMC implementation.
+                # Here we have a single dot product with many zeros, while there we have many
+                # smaller dot products.
+                # It is subject to change here, but I don't want to mess up dims and coords.
                 if term.by_levels is not None:
                     by_values = x_slice[:, -1].astype(int)
                     x_slice = x_slice[:, :-1]
@@ -222,7 +227,7 @@ class DistributionalComponent:
                     x_slice_centered = (x_slice - term.mean) / maximum_distance
                     phi = term.hsgp.prior_linearized(x_slice_centered)[0].eval()
 
-                # Convert 'phi' and 'sqrt_psd' to xarray.DataArrays for easier math
+                # Convert 'phi' to xarray.DataArray for easier math
                 # Notice the extra '_' in the dim name for the weights
                 phi = xr.DataArray(phi, dims=(response_dim, f"{term_aliased_name}__weights_dim"))
                 weights = posterior[f"{term_aliased_name}_weights"]


### PR DESCRIPTION
In the first implementation of HSGP, we used to perform a single dot product between `phi` and the vector of coefficients `coeffs`. When there were groups, `phi` used to have many zeros. And the number of zeros would increase with the number of groups.

**Some details for posterity**

`phi` used to be of shape `(n_observations, n_basis_functions * n_groups)`. For every row, there were `n_basis_functions * (n_groups - 1)` columns of structural zeros. So this grew with both the number of basis functions `m` and the number of groups `n_groups`, making it less performant. Albeit not being implemented as such, we can imagine `phi` as a block diagonal matrix where each block corresponds to a group.

We could exploit the sparse structure using the support of PyTensor. However the coverage is not yet the best, and it would prevent users from using JAX-based samplers that don't do sparse stuff yet. 

The alternative implemented in this PR is to manually do as many dot products as groups in the HSGP, using the blocks of the block diagonal matrix. The advantage is that we no longer multiply things that are structurally zero and we don't need to store the structural zero values either.

**There are no user-visible changes**
