### PR TITLE
import bambi as bmb in tests

### DIFF
--- a/docs/notebooks/getting_started.ipynb
+++ b/docs/notebooks/getting_started.ipynb
@@ -662,7 +662,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -788,6 +787,33 @@
    "metadata": {},
    "source": [
     "It's important to note that explicitly setting priors by passing in ``Prior`` objects will disable Bambi's default behavior of scaling priors to the data in order to ensure that they remain weakly informative. This means that if you specify your own prior, you have to be sure not only to specify the distribution you want, but also any relevant scale parameters. For example, the 0.5 in ``Prior(\"Normal\", mu=0, sd=0.5)`` will be specified on the scale of the data, not the bounded partial correlation scale that Bambi uses for default priors. This means that if your outcome variable has a mean value of 10,000 and a standard deviation of, say, 1,000, you could potentially have some problems getting the model to produce reasonable estimates, since from the perspective of the data, you're specifying an extremely strong prior."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom Prior\n",
+    "\n",
+    "Bambi's priors are a thin layer on top of [PyMC distributions](https://www.pymc.io/projects/docs/en/latest/api/distributions.html). If you want to ask for a prior distribution by name, it must be the name of a PyMC distribution. But sometimes we want to use more complex distributions as priors. For all those cases, Bambi's `Prior` class allow users to pass a function that returns a distribution that will be used as the prior. See the following example:\n",
+    "\n",
+    "```python\n",
+    "def CustomPrior(name, *args, dims=None, **kwargs):\n",
+    "    return pm.Normal(name, *args, dims=dims, **kwargs)\n",
+    "\n",
+    "priors = {\"x\": Prior(\"CustomPrior\", mu=0, sigma=5, dist=CustomPrior)}\n",
+    "model = Model(\"y ~ x\", data, priors=priors)\n",
+    "```\n",
+    "\n",
+    "The example above is trival because it's just a wrapper of the `pm.Normal` distribution. But we can use this pattern to construct more complex distributions, such as a Truncated Laplace distribution shown below.\n",
+    "\n",
+    "```python\n",
+    "def TruncatedLaplace(name, mu,b,lower,upper,*args, dims=None, **kwargs):\n",
+    "    lap_dist = pm.Laplace.dist(mu=mu, b=b)\n",
+    "    return pm.Truncated(name, lap_dist, lower=lower, upper=upper, *args, dims=dims, **kwargs)\n",
+    "```\n",
+    "\n",
+    "In summary, custom priors allow for greater flexibility by combining existing PyMC distributions in different ways. If you need to use a distribution that's not implemented in PyMC, please check the [link](https://www.pymc.io/projects/docs/en/latest/contributing/implementing_distribution.html) for further details."
    ]
   },
   {
@@ -1054,7 +1080,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1207,7 +1232,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1315,7 +1339,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.4 ('bambi')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,22 +1,22 @@
 import pytest
 
-from bambi import load_data, Formula, Model
+import bambi as bmb
 
 
 @pytest.fixture(scope="module")
 def my_data():
-    return load_data("my_data")
+    return bmb.load_data("my_data")
 
 
 @pytest.fixture(scope="module")
 def anes():
-    return load_data("ANES")
+    return bmb.load_data("ANES")
 
 
 def test_non_distributional_model(my_data):
     # Plain model
-    formula = Formula("y ~ x")
-    model = Model(formula, my_data)
+    formula = bmb.Formula("y ~ x")
+    model = bmb.Model(formula, my_data)
     idata = model.fit(tune=100, draws=100)
     model.predict(idata)
 
@@ -34,8 +34,8 @@ def test_non_distributional_model(my_data):
 
 
 def test_distributional_model(my_data):
-    formula = Formula("y ~ x", "sigma ~ x")
-    model = Model(formula, my_data)
+    formula = bmb.Formula("y ~ x", "sigma ~ x")
+    model = bmb.Model(formula, my_data)
     idata = model.fit(tune=100, draws=100)
     model.predict(idata)
 
@@ -74,7 +74,7 @@ def test_distributional_model(my_data):
 
 
 def test_non_distributional_model_with_categories(anes):
-    model = Model("vote[clinton] ~ age + age:party_id", anes, family="bernoulli")
+    model = bmb.Model("vote[clinton] ~ age + age:party_id", anes, family="bernoulli")
     idata = model.fit(tune=100, draws=100)
     model.predict(idata)
     assert list(idata.posterior.coords) == ["chain", "draw", "age:party_id_dim", "vote_obs"]

--- a/tests/test_built_models.py
+++ b/tests/test_built_models.py
@@ -10,11 +10,7 @@ import pymc as pm
 
 from scipy.special import expit
 
-from bambi import math
-from bambi.families import Family, Likelihood, Link
-from bambi.formula import Formula
-from bambi.models import Model
-from bambi.priors import Prior
+import bambi as bmb
 from bambi.terms import GroupSpecificTerm
 
 
@@ -120,22 +116,22 @@ def data_1000():
 
 
 def test_empty_model(crossed_data):
-    model0 = Model("Y ~ 0", crossed_data)
+    model0 = bmb.Model("Y ~ 0", crossed_data)
     model0.fit(tune=0, draws=1)
 
 
 def test_intercept_only_model(crossed_data):
-    model0 = Model("Y ~ 1", crossed_data)
+    model0 = bmb.Model("Y ~ 1", crossed_data)
     model0.fit(tune=0, draws=1)
 
 
 def test_slope_only_model(crossed_data):
-    model0 = Model("Y ~ 0 + continuous", crossed_data)
+    model0 = bmb.Model("Y ~ 0 + continuous", crossed_data)
     model0.fit(tune=0, draws=1)
 
 
 def test_cell_means_parameterization(crossed_data):
-    model0 = Model("Y ~ 0 + threecats", crossed_data)
+    model0 = bmb.Model("Y ~ 0 + threecats", crossed_data)
     model0.fit(tune=0, draws=1)
 
 
@@ -144,18 +140,18 @@ def test_3x4_common_anova(crossed_data):
     crossed_data["fourcats"] = sum([[x] * 10 for x in ["a", "b", "c", "d"]], list()) * 3
 
     # with intercept
-    model0 = Model("Y ~ threecats*fourcats", crossed_data)
+    model0 = bmb.Model("Y ~ threecats*fourcats", crossed_data)
     fitted0 = model0.fit(tune=0, draws=1)
     assert len(fitted0.posterior.data_vars) == 5
 
     # without intercept (i.e., 2-factor cell means model)
-    model1 = Model("Y ~ 0 + threecats*fourcats", crossed_data)
+    model1 = bmb.Model("Y ~ 0 + threecats*fourcats", crossed_data)
     fitted1 = model1.fit(tune=0, draws=1)
     assert len(fitted1.posterior.data_vars) == 4
 
 
 def test_cell_means_with_covariate(crossed_data):
-    model = Model("Y ~ 0 + threecats + continuous", crossed_data)
+    model = bmb.Model("Y ~ 0 + threecats + continuous", crossed_data)
     model.build()
     # check that threecats priors have finite variance
     assert not np.isinf(model.response_component.terms["threecats"].prior.args["sigma"]).all()
@@ -170,7 +166,7 @@ def test_many_common_many_group_specific(crossed_data):
     crossed_data_missing.loc[2, "threecats"] = np.nan
 
     # Here I'm comparing implicit/explicit intercepts for group specific effects work the same way.
-    model0 = Model(
+    model0 = bmb.Model(
         "Y ~ continuous + dummy + threecats + (threecats|subj) + (1|item) + (0+continuous|item) + (dummy|item) + (threecats|site)",
         crossed_data_missing,
         dropna=True,
@@ -181,7 +177,7 @@ def test_many_common_many_group_specific(crossed_data):
         chains=2,
     )
 
-    model1 = Model(
+    model1 = bmb.Model(
         "Y ~ continuous + dummy + threecats + (threecats|subj) + (continuous|item) + (dummy|item) + (threecats|site)",
         crossed_data_missing,
         dropna=True,
@@ -289,7 +285,7 @@ def test_cell_means_with_many_group_specific_effects(crossed_data):
             "(1|site)",
         ]
     )
-    model0 = Model(formula, crossed_data)
+    model0 = bmb.Model(formula, crossed_data)
     model0.fit(tune=0, draws=1)
 
     formula = "Y ~" + "+".join(
@@ -302,7 +298,7 @@ def test_cell_means_with_many_group_specific_effects(crossed_data):
             "(threecats|site)",
         ]
     )
-    model1 = Model(formula, crossed_data)
+    model1 = bmb.Model(formula, crossed_data)
     model1.fit(tune=0, draws=1)
 
     # check that the group specific effects design matrices have the same shape
@@ -379,17 +375,17 @@ def test_cell_means_with_many_group_specific_effects(crossed_data):
 
 def test_group_specific_categorical_interaction(crossed_data):
     crossed_data["fourcats"] = sum([[x] * 10 for x in ["a", "b", "c", "d"]], list()) * 3
-    model = Model("Y ~ continuous + (threecats:fourcats|site)", crossed_data)
+    model = bmb.Model("Y ~ continuous + (threecats:fourcats|site)", crossed_data)
     model.fit(tune=10, draws=10)
 
 
 def test_logistic_regression_empty_index(data_100):
-    model = Model("b1 ~ n1", data_100, family="bernoulli")
+    model = bmb.Model("b1 ~ n1", data_100, family="bernoulli")
     model.fit()
 
 
 def test_logistic_regression_good_numeric(data_100):
-    model = Model("b0 ~ n1", data_100, family="bernoulli")
+    model = bmb.Model("b0 ~ n1", data_100, family="bernoulli")
     model.fit()
 
 
@@ -398,7 +394,7 @@ def test_logistic_regression_bad_numeric():
     rng = np.random.default_rng(1234)
     data = pd.DataFrame({"y": rng.choice([1, 2], 50), "x": rng.normal(size=50)})
     with pytest.raises(ValueError, match=error_msg):
-        model = Model("y ~ x", data, family="bernoulli")
+        model = bmb.Model("y ~ x", data, family="bernoulli")
         model.fit()
 
 
@@ -411,7 +407,7 @@ def test_logistic_regression_bad_numeric():
     ],
 )
 def test_logistic_regression_categoric_alternative_samplers(data_100, args):
-    model = Model("b1 ~ n1", data_100, family="bernoulli")
+    model = bmb.Model("b1 ~ n1", data_100, family="bernoulli")
     model.fit(tune=50, draws=50, inference_method=args[0], **args[1])
 
 
@@ -424,23 +420,23 @@ def test_logistic_regression_categoric_alternative_samplers(data_100, args):
     ],
 )
 def test_regression_alternative_samplers(data_100, args):
-    model = Model("n1 ~ n2", data_100)
+    model = bmb.Model("n1 ~ n2", data_100)
     model.fit(tune=50, draws=50, inference_method=args[0], **args[1])
 
 
 def test_laplace_regression(data_100):
-    bmb_model = Model("n1 ~ n2", data_100, family="laplace")
+    bmb_model = bmb.Model("n1 ~ n2", data_100, family="laplace")
     bmb_model.fit()
 
 
 def test_poisson_regression(crossed_data):
     # build model using fit and pymc
     crossed_data["count"] = (crossed_data["Y"] - crossed_data["Y"].min()).round()
-    model0 = Model("count ~ dummy + continuous + threecats", crossed_data, family="poisson")
+    model0 = bmb.Model("count ~ dummy + continuous + threecats", crossed_data, family="poisson")
     model0.fit(tune=0, draws=1)
 
     # build model using add
-    model1 = Model("count ~ threecats + continuous + dummy", crossed_data, family="poisson")
+    model1 = bmb.Model("count ~ threecats + continuous + dummy", crossed_data, family="poisson")
     model1.fit(tune=0, draws=1)
 
     # check that term names agree
@@ -492,8 +488,8 @@ def test_poisson_regression(crossed_data):
 
 def test_laplace():
     data = pd.DataFrame(np.repeat((0, 1), (30, 60)), columns=["w"])
-    priors = {"Intercept": Prior("Uniform", lower=0, upper=1)}
-    model = Model("w ~ 1", data=data, family="bernoulli", priors=priors, link="identity")
+    priors = {"Intercept": bmb.Prior("Uniform", lower=0, upper=1)}
+    model = bmb.Model("w ~ 1", data=data, family="bernoulli", priors=priors, link="identity")
     results = model.fit(inference_method="laplace")
     mode_n = results.posterior["Intercept"].mean().item()
     std_n = results.posterior["Intercept"].std().item()
@@ -504,8 +500,8 @@ def test_laplace():
 
 def test_vi():
     data = pd.DataFrame(np.repeat((0, 1), (30, 60)), columns=["w"])
-    priors = {"Intercept": Prior("Uniform", lower=0, upper=1)}
-    model = Model("w ~ 1", data=data, family="bernoulli", priors=priors, link="identity")
+    priors = {"Intercept": bmb.Prior("Uniform", lower=0, upper=1)}
+    model = bmb.Model("w ~ 1", data=data, family="bernoulli", priors=priors, link="identity")
     results = model.fit(inference_method="vi", method="advi")
     samples = results.sample(1000).posterior["Intercept"]
     mode_n = samples.mean()
@@ -520,7 +516,7 @@ def test_vi():
 def test_prior_predictive(crossed_data):
     crossed_data["count"] = (crossed_data["Y"] - crossed_data["Y"].min()).round()
     # New default priors are too wide for this case... something to keep investigating
-    model = Model(
+    model = bmb.Model(
         "count ~ threecats + continuous + dummy",
         crossed_data,
         family="poisson",
@@ -546,7 +542,7 @@ def test_prior_predictive(crossed_data):
 
 def test_posterior_predictive(crossed_data):
     crossed_data["count"] = (crossed_data["Y"] - crossed_data["Y"].min()).round()
-    model = Model("count ~ threecats + continuous + dummy", crossed_data, family="poisson")
+    model = bmb.Model("count ~ threecats + continuous + dummy", crossed_data, family="poisson")
     fitted = model.fit(tune=0, draws=10, chains=2)
     pps = model.predict(fitted, kind="pps", inplace=False)
 
@@ -567,30 +563,30 @@ def test_gamma_regression(dm):
 
     y = rng.gamma(shape_true, y_true / shape_true, N)
     data = pd.DataFrame({"x": x, "y": y})
-    model = Model("y ~ x", data, family="gamma", link="log")
+    model = bmb.Model("y ~ x", data, family="gamma", link="log")
     model.fit(draws=10, tune=10)
 
     # Real data, categorical predictor.
     data = dm[["order", "ind_mg_dry"]]
-    model = Model("ind_mg_dry ~ order", data, family="gamma", link="log")
+    model = bmb.Model("ind_mg_dry ~ order", data, family="gamma", link="log")
     model.fit(draws=10, tune=10)
 
 
 def test_beta_regression():
     data_dir = join(dirname(__file__), "data")
     data = pd.read_csv(join(data_dir, "gasoline.csv"))
-    model = Model("yield ~  temp + batch", data, family="beta", categorical="batch")
+    model = bmb.Model("yield ~  temp + batch", data, family="beta", categorical="batch")
     model.fit(draws=10, tune=10, target_accept=0.9)
 
 
 def test_t_regression(data_100):
-    Model("n1 ~ n2", data_100, family="t").fit(draws=10, tune=10)
+    bmb.Model("n1 ~ n2", data_100, family="t").fit(draws=10, tune=10)
 
 
 def test_vonmises_regression():
     rng = np.random.default_rng(1234)
     data = pd.DataFrame({"y": rng.vonmises(0, 1, size=100), "x": rng.normal(size=100)})
-    Model("y ~ x", data, family="vonmises").fit(draws=10, tune=10)
+    bmb.Model("y ~ x", data, family="vonmises").fit(draws=10, tune=10)
 
 
 def test_quantile_regression():
@@ -598,11 +594,11 @@ def test_quantile_regression():
     x = rng.uniform(2, 10, 100)
     y = 2 * x + rng.normal(0, 0.6 * x**0.75)
     data = pd.DataFrame({"x": x, "y": y})
-    bmb_model0 = Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa": 9})
+    bmb_model0 = bmb.Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa": 9})
     idata0 = bmb_model0.fit()
     bmb_model0.predict(idata0)
 
-    bmb_model1 = Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa": 0.1})
+    bmb_model1 = bmb.Model("y ~ x", data, family="asymmetriclaplace", priors={"kappa": 0.1})
     idata1 = bmb_model1.fit()
     bmb_model1.predict(idata1)
 
@@ -613,16 +609,16 @@ def test_quantile_regression():
 
 
 def test_plot_priors(crossed_data):
-    model = Model("Y ~ 0 + threecats", crossed_data)
-    with pytest.raises(ValueError, match="Model is not built yet"):
+    model = bmb.Model("Y ~ 0 + threecats", crossed_data)
+    with pytest.raises(ValueError, match="bmb.Model is not built yet"):
         model.plot_priors()
     model.build()
     model.plot_priors()
 
 
 def test_model_graph(crossed_data):
-    model = Model("Y ~ 0 + threecats", crossed_data)
-    with pytest.raises(ValueError, match="Model is not built yet"):
+    model = bmb.Model("Y ~ 0 + threecats", crossed_data)
+    with pytest.raises(ValueError, match="bmb.Model is not built yet"):
         model.graph()
     model.build()
     model.graph()
@@ -630,14 +626,14 @@ def test_model_graph(crossed_data):
 
 def test_potentials():
     data = pd.DataFrame(np.repeat((0, 1), (18, 20)), columns=["w"])
-    priors = {"Intercept": Prior("Uniform", lower=0, upper=1)}
+    priors = {"Intercept": bmb.Prior("Uniform", lower=0, upper=1)}
 
     potentials = [
-        (("Intercept", "Intercept"), lambda x, y: math.switch(x < 0.45, y, -np.inf)),
-        ("Intercept", lambda x: math.switch(x > 0.55, 0, -np.inf)),
+        (("Intercept", "Intercept"), lambda x, y: bmb.math.switch(x < 0.45, y, -np.inf)),
+        ("Intercept", lambda x: bmb.math.switch(x > 0.55, 0, -np.inf)),
     ]
 
-    model = Model(
+    model = bmb.Model(
         "w ~ 1",
         data,
         family="bernoulli",
@@ -668,17 +664,17 @@ def test_binomial_regression():
         }
     )
 
-    model = Model("prop(y, n) ~ x", data, family="binomial")
+    model = bmb.Model("prop(y, n) ~ x", data, family="binomial")
     model.fit(draws=10, tune=10)
 
     # Using constant instead of variable in data frame
-    model = Model("prop(y, 62) ~ x", data, family="binomial")
+    model = bmb.Model("prop(y, 62) ~ x", data, family="binomial")
     model.fit(draws=10, tune=10)
 
 
 @pytest.mark.skip(reason="this example no longer trigger the fallback to adapt_diag")
 def test_init_fallback(init_data, caplog):
-    model = Model("od ~ temp + (1|source) + 0", init_data)
+    model = bmb.Model("od ~ temp + (1|source) + 0", init_data)
     with caplog.at_level(logging.INFO):
         model.fit(draws=100, init="auto")
         assert "Initializing NUTS using jitter+adapt_diag..." in caplog.text
@@ -687,23 +683,23 @@ def test_init_fallback(init_data, caplog):
 
 
 def test_categorical_family(inhaler):
-    model = Model("rating ~ period + carry + treat", inhaler, family="categorical")
+    model = bmb.Model("rating ~ period + carry + treat", inhaler, family="categorical")
     model.fit(draws=10, tune=10)
 
 
 def test_categorical_family_varying_intercept(inhaler):
-    model = Model("rating ~ period + carry + treat + (1|subject)", inhaler, family="categorical")
+    model = bmb.Model("rating ~ period + carry + treat + (1|subject)", inhaler, family="categorical")
     model.fit(draws=10, tune=10)
 
 
 def test_categorical_family_categorical_predictors(categorical_family_categorical_predictor):
     formula = "response ~ group + city"
-    model = Model(formula, categorical_family_categorical_predictor, family="categorical")
+    model = bmb.Model(formula, categorical_family_categorical_predictor, family="categorical")
     model.fit(draws=10, tune=10)
 
 
 def test_set_alias(data_100):
-    model = Model("n1 ~ n2 + (n2|cat1)", data_100)
+    model = bmb.Model("n1 ~ n2 + (n2|cat1)", data_100)
     aliases = {
         "Intercept": "α",
         "n2": "β",
@@ -719,7 +715,7 @@ def test_set_alias(data_100):
 
 def test_fit_include_mean(crossed_data):
     draws = 500
-    model = Model("Y ~ continuous * threecats", crossed_data)
+    model = bmb.Model("Y ~ continuous * threecats", crossed_data)
     idata = model.fit(tune=draws, draws=draws, include_mean=True)
     assert idata.posterior["Y_mean"].shape[1:] == (draws, 120)
 
@@ -772,7 +768,7 @@ def test_group_specific_splines():
     )
     knots = np.array([191.0, 297.0, 512.5])
 
-    model = Model("y ~ (bs(x, knots=knots, intercept=False, degree=1)|day)", data=x_check)
+    model = bmb.Model("y ~ (bs(x, knots=knots, intercept=False, degree=1)|day)", data=x_check)
     model.build()
 
 
@@ -791,9 +787,9 @@ def test_2d_response_no_shape():
         kwargs["dims"] = kwargs.get("dims")[0]
         return pm.Binomial(name, p=p, n=n, observed=y, **kwargs)
 
-    likelihood = Likelihood("CustomBinomial", params=["p"], parent="p", dist=fn)
-    link = Link("logit")
-    family = Family("custom-binomial", likelihood, link)
+    likelihood = bmb.Likelihood("CustomBinomial", params=["p"], parent="p", dist=fn)
+    link = bmb.Link("logit")
+    family = bmb.Family("custom-binomial", likelihood, link)
 
     data = pd.DataFrame(
         {
@@ -803,7 +799,7 @@ def test_2d_response_no_shape():
         }
     )
 
-    model = Model("prop(y, n) ~ x", data, family=family)
+    model = bmb.Model("prop(y, n) ~ x", data, family=family)
     model.fit(draws=10, tune=10)
 
 
@@ -814,7 +810,7 @@ def test_zero_inflated_poisson():
     x = np.concatenate([np.zeros(250), rng.poisson(lam=3, size=750)])
     df = pd.DataFrame({"response": x})
 
-    model = Model("response ~ 1", df, family="zero_inflated_poisson")
+    model = bmb.Model("response ~ 1", df, family="zero_inflated_poisson")
     idata = model.fit(chains=2, tune=200, draws=200, random_seed=121195)
     model.predict(idata, kind="pps")
 
@@ -829,8 +825,8 @@ def test_zero_inflated_poisson():
     y = pm.draw(pm.ZeroInflatedPoisson.dist(mu=mu, psi=psi))
     df = pd.DataFrame({"y": y, "x": x})
 
-    formula = Formula("y ~ x", "psi ~ x")
-    model = Model(formula, df, family="zero_inflated_poisson")
+    formula = bmb.Formula("y ~ x", "psi ~ x")
+    model = bmb.Model(formula, df, family="zero_inflated_poisson")
     idata = model.fit(chains=2, tune=200, draws=200, random_seed=121195)
     model.predict(idata, kind="pps")
 
@@ -841,7 +837,7 @@ def test_zero_inflated_binomial():
     # Basic intercept-only model
     y = pm.draw(pm.ZeroInflatedBinomial.dist(p=0.5, n=30, psi=0.7), draws=500, random_seed=1234)
     df = pd.DataFrame({"y": y})
-    model = Model("p(y, 30) ~ 1", df, family="zero_inflated_binomial")
+    model = bmb.Model("p(y, 30) ~ 1", df, family="zero_inflated_binomial")
     idata = model.fit(chains=2, tune=200, draws=200, random_seed=121195)
     model.predict(idata, kind="pps")
 
@@ -855,8 +851,8 @@ def test_zero_inflated_binomial():
     y = pm.draw(pm.ZeroInflatedBinomial.dist(p=p, psi=psi, n=30))
     df = pd.DataFrame({"y": y, "x": x})
 
-    formula = Formula("prop(y, 30) ~ x", "psi ~ x")
-    model = Model(formula, df, family="zero_inflated_binomial")
+    formula = bmb.Formula("prop(y, 30) ~ x", "psi ~ x")
+    model = bmb.Model(formula, df, family="zero_inflated_binomial")
     idata = model.fit(chains=2, tune=200, draws=200, random_seed=121195)
     model.predict(idata, kind="pps")
 
@@ -869,8 +865,8 @@ def test_zero_inflated_negativebinomial():
         pm.ZeroInflatedNegativeBinomial.dist(mu=5, alpha=30, psi=0.7), draws=500, random_seed=1234
     )
     df = pd.DataFrame({"y": y})
-    priors = {"alpha": Prior("HalfNormal", sigma=20)}
-    model = Model("y ~ 1", df, family="zero_inflated_negativebinomial", priors=priors)
+    priors = {"alpha": bmb.Prior("HalfNormal", sigma=20)}
+    model = bmb.Model("y ~ 1", df, family="zero_inflated_negativebinomial", priors=priors)
     idata = model.fit(chains=2, tune=200, draws=200, random_seed=121195)
     model.predict(idata, kind="pps")
 
@@ -884,8 +880,8 @@ def test_zero_inflated_negativebinomial():
     y = pm.draw(pm.ZeroInflatedNegativeBinomial.dist(mu=mu, alpha=30, psi=psi))
     df = pd.DataFrame({"y": y, "x": x})
 
-    priors = {"alpha": Prior("HalfNormal", sigma=20)}
-    formula = Formula("y ~ x", "psi ~ x")
-    model = Model(formula, df, family="zero_inflated_negativebinomial", priors=priors)
+    priors = {"alpha": bmb.Prior("HalfNormal", sigma=20)}
+    formula = bmb.Formula("y ~ x", "psi ~ x")
+    model = bmb.Model(formula, df, family="zero_inflated_negativebinomial", priors=priors)
     idata = model.fit(chains=2, tune=200, draws=200, random_seed=121195)
     model.predict(idata, kind="pps")

--- a/tests/test_built_models.py
+++ b/tests/test_built_models.py
@@ -610,7 +610,7 @@ def test_quantile_regression():
 
 def test_plot_priors(crossed_data):
     model = bmb.Model("Y ~ 0 + threecats", crossed_data)
-    with pytest.raises(ValueError, match="bmb.Model is not built yet"):
+    with pytest.raises(ValueError, match="Model is not built yet"):
         model.plot_priors()
     model.build()
     model.plot_priors()
@@ -618,7 +618,7 @@ def test_plot_priors(crossed_data):
 
 def test_model_graph(crossed_data):
     model = bmb.Model("Y ~ 0 + threecats", crossed_data)
-    with pytest.raises(ValueError, match="bmb.Model is not built yet"):
+    with pytest.raises(ValueError, match="Model is not built yet"):
         model.graph()
     model.build()
     model.graph()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,7 +5,7 @@ from urllib.parse import urlunsplit
 import pandas as pd
 import pytest
 
-from bambi import clear_data_home, load_data
+import bambi as bmb
 from bambi.data.datasets import DATASETS, FileMetadata
 
 
@@ -40,30 +40,30 @@ def no_remote_data(monkeypatch, tmpdir):
 def test_clear_data_home():
     resource = DATASETS["test_remote"]
     assert os.path.exists(resource.filename)
-    clear_data_home(data_home=os.path.dirname(resource.filename))
+    bmb.clear_data_home(data_home=os.path.dirname(resource.filename))
     assert not os.path.exists(resource.filename)
 
 
 def test_load_data():
-    df = load_data("test_remote")
+    df = bmb.load_data("test_remote")
     df_ = pd.DataFrame({"x": [0], "y": [1]})
     assert df.equals(df_)
 
 
 def test_bad_checksum():
     resource = DATASETS["test_remote"]
-    clear_data_home(data_home=os.path.dirname(resource.filename))
+    bmb.clear_data_home(data_home=os.path.dirname(resource.filename))
     with pytest.raises(IOError):
-        load_data("bad_checksum")
+        bmb.load_data("bad_checksum")
 
 
 def test_missing_dataset():
     with pytest.raises(ValueError):
-        load_data("does not exist")
+        bmb.load_data("does not exist")
 
 
 def test_list_datasets():
-    dataset_string = load_data()
+    dataset_string = bmb.load_data()
     # make sure all the names of the data sets are in the dataset description
     for key in ("my_data",):
         assert key in dataset_string

--- a/tests/test_glmlss.py
+++ b/tests/test_glmlss.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from bambi import Model, Formula, load_data
+import bambi as bmb
 
 
 @pytest.fixture(scope="module")
@@ -23,7 +23,7 @@ def data_new_gamma():
 
 @pytest.fixture(scope="module")
 def data_normal():
-    data = load_data("bikes")
+    data = bmb.load_data("bikes")
     data.sort_values(by="hour", inplace=True)
     data_cnt_om = data["count"].mean()
     data_cnt_os = data["count"].std()
@@ -41,37 +41,37 @@ def data_new_normal():
 def test_normal_with_splines(data_normal, data_new_normal):
     knots = np.linspace(0, 23, 8)[1:-1]
     knots_s = np.linspace(0, 23, 5)[1:-1]
-    formula = Formula(
+    formula = bmb.Formula(
         "count_normalized ~ 0 + bs(hour, knots=knots, intercept=True)",
         "sigma ~ 0 + bs(hour, knots=knots_s, intercept=True)",
     )
-    model = Model(formula, data_normal)
+    model = bmb.Model(formula, data_normal)
     idata = model.fit(tune=100, draws=100)
     model.predict(idata, kind="pps")
     model.predict(idata, kind="pps", data=data_new_normal)
 
 
 def test_gamma(data_gamma, data_new_gamma):
-    formula = Formula("y ~ x", "alpha ~ x")
+    formula = bmb.Formula("y ~ x", "alpha ~ x")
 
     # Default links
-    model = Model(formula, data_gamma, family="gamma")
+    model = bmb.Model(formula, data_gamma, family="gamma")
     idata = model.fit(tune=100, draws=100, random_seed=1234)
     model.predict(idata, kind="pps")
     model.predict(idata, kind="pps", data=data_new_gamma)
 
     # Custom links
-    model = Model(formula, data_gamma, family="gamma", link={"mu": "log", "alpha": "log"})
+    model = bmb.Model(formula, data_gamma, family="gamma", link={"mu": "log", "alpha": "log"})
     idata = model.fit(tune=100, draws=100, random_seed=1234)
     model.predict(idata, kind="pps")
     model.predict(idata, kind="pps", data=data_new_gamma)
 
 
 def test_gamma_with_splines(data_normal, data_new_normal):
-    formula = Formula(
+    formula = bmb.Formula(
         "count ~ 0 + bs(hour, 8, intercept=True)", "alpha ~ 0 + bs(hour, 8, intercept=True)"
     )
-    model = Model(formula, data_normal, family="gamma", link={"mu": "log", "alpha": "log"})
+    model = bmb.Model(formula, data_normal, family="gamma", link={"mu": "log", "alpha": "log"})
     idata = model.fit(tune=100, draws=100, random_seed=1234)
     model.predict(idata, kind="pps")
     model.predict(idata, kind="pps", data=data_new_normal)

--- a/tests/test_model_construction.py
+++ b/tests/test_model_construction.py
@@ -73,7 +73,7 @@ def test_term_init(diabetes_data):
 def test_distribute_group_specific_effect_over(diabetes_data):
     # 163 unique levels of BMI in diabetes_data
     # With intercept
-    model = bmb.bmb.Model("BP ~ (C(age_grp)|BMI)", diabetes_data)
+    model = bmb.Model("BP ~ (C(age_grp)|BMI)", diabetes_data)
 
     # Treatment encoding because of the intercept
     levels = sorted(list(diabetes_data["age_grp"].unique()))[1:]

--- a/tests/test_model_construction.py
+++ b/tests/test_model_construction.py
@@ -10,11 +10,8 @@ import pytest
 
 from formulae import design_matrices
 
-from bambi.data.datasets import load_data
-from bambi.models import Model
+import bambi as bmb
 from bambi.terms import CommonTerm, GroupSpecificTerm
-from bambi.priors import Prior
-from bambi.families import Family, Likelihood
 
 
 @pytest.fixture(scope="module")
@@ -76,7 +73,7 @@ def test_term_init(diabetes_data):
 def test_distribute_group_specific_effect_over(diabetes_data):
     # 163 unique levels of BMI in diabetes_data
     # With intercept
-    model = Model("BP ~ (C(age_grp)|BMI)", diabetes_data)
+    model = bmb.bmb.Model("BP ~ (C(age_grp)|BMI)", diabetes_data)
 
     # Treatment encoding because of the intercept
     levels = sorted(list(diabetes_data["age_grp"].unique()))[1:]
@@ -93,7 +90,7 @@ def test_distribute_group_specific_effect_over(diabetes_data):
     assert model.response_component.terms["C(age_grp)|BMI"].data.shape == (442, 326)
 
     # Without intercept. Reference level is not removed.
-    model = Model("BP ~ (0 + C(age_grp)|BMI)", diabetes_data)
+    model = bmb.Model("BP ~ (0 + C(age_grp)|BMI)", diabetes_data)
     assert "C(age_grp)|BMI" in model.response_component.terms
     assert not "1|BMI" in model.response_component.terms
     assert model.response_component.terms["C(age_grp)|BMI"].data.shape == (442, 489)
@@ -101,11 +98,11 @@ def test_distribute_group_specific_effect_over(diabetes_data):
 
 def test_model_init_bad_data():
     with pytest.raises(ValueError):
-        Model("y ~ x", {"x": 1})
+        bmb.Model("y ~ x", {"x": 1})
 
 
 def test_unbuilt_model(diabetes_data):
-    model = Model("Y ~ AGE", data=diabetes_data)
+    model = bmb.Model("Y ~ AGE", data=diabetes_data)
     with pytest.raises(ValueError):
         model._check_built()
 
@@ -119,10 +116,10 @@ def test_model_categorical_argument():
             "z": rng.integers(2, size=100),
         }
     )
-    model = Model("y ~ 0 + x", data, categorical="x")
+    model = bmb.Model("y ~ 0 + x", data, categorical="x")
     assert model.response_component.terms["x"].categorical
 
-    model = Model("y ~ 0 + x*z", data, categorical=["x", "z"])
+    model = bmb.Model("y ~ 0 + x*z", data, categorical=["x", "z"])
     assert model.response_component.terms["x"].categorical
     assert model.response_component.terms["z"].categorical
     assert model.response_component.terms["x:z"].categorical
@@ -130,18 +127,18 @@ def test_model_categorical_argument():
 
 def test_model_no_response():
     with pytest.raises(ValueError):
-        Model("x", pd.DataFrame({"x": [1]}))
+        bmb.Model("x", pd.DataFrame({"x": [1]}))
 
 
 def test_model_term_names_property(diabetes_data):
-    model = Model("BMI ~ age_grp + BP + S1", diabetes_data)
+    model = bmb.Model("BMI ~ age_grp + BP + S1", diabetes_data)
     assert model.response_component.intercept_term.name == "Intercept"
     assert set(model.response_component.common_terms) == {"age_grp", "BP", "S1"}
 
 
 def test_model_term_names_property_interaction(crossed_data):
     crossed_data["fourcats"] = sum([[x] * 10 for x in ["a", "b", "c", "d"]], list()) * 3
-    model = Model("Y ~ threecats*fourcats", crossed_data)
+    model = bmb.Model("Y ~ threecats*fourcats", crossed_data)
     assert model.response_component.intercept_term.name == "Intercept"
     assert set(model.response_component.common_terms) == {
         "threecats",
@@ -152,7 +149,7 @@ def test_model_term_names_property_interaction(crossed_data):
 
 def test_model_terms_levels_interaction(crossed_data):
     crossed_data["fourcats"] = sum([[x] * 10 for x in ["a", "b", "c", "d"]], list()) * 3
-    model = Model("Y ~ threecats*fourcats", crossed_data)
+    model = bmb.Model("Y ~ threecats*fourcats", crossed_data)
 
     assert model.response_component.terms["threecats:fourcats"].levels == [
         "b, b",
@@ -175,7 +172,7 @@ def test_model_terms_levels():
             "subject": reduce(add, [[f"Subject {x}"] * 10 for x in range(1, 6)]),
         }
     )
-    model = Model("y ~ x + z + time + (time|subject)", data)
+    model = bmb.Model("y ~ x + z + time + (time|subject)", data)
     assert model.response_component.terms["z"].levels == ["Group 2", "Group 3"]
     assert model.response_component.terms["1|subject"].groups == [
         f"Subject {x}" for x in range(1, 6)
@@ -196,7 +193,7 @@ def test_model_term_classes():
         }
     )
 
-    model = Model("y ~ x*g + (x|s)", data)
+    model = bmb.Model("y ~ x*g + (x|s)", data)
 
     assert isinstance(model.response_component.terms["x"], CommonTerm)
     assert isinstance(model.response_component.terms["g"], CommonTerm)
@@ -209,7 +206,7 @@ def test_model_term_classes():
 
 
 def test_one_shot_formula_fit(diabetes_data):
-    model = Model("S3 ~ S1 + S2", diabetes_data)
+    model = bmb.Model("S3 ~ S1 + S2", diabetes_data)
     model.fit(draws=50)
     named_vars = model.backend.model.named_vars
     targets = ["S3", "S1", "Intercept"]
@@ -227,7 +224,7 @@ def test_categorical_term():
             "g2": ["x", "x", "z", "z", "y", "y"],
         }
     )
-    model = Model("y ~ x1 + x2 + g1 + (g1|g2) + (x2|g2)", data)
+    model = bmb.Model("y ~ x1 + x2 + g1 + (g1|g2) + (x2|g2)", data)
     fitted = model.fit(tune=100, draws=100)
     df = az.summary(fitted)
     names = {
@@ -261,7 +258,7 @@ def test_omit_offsets_false():
             "g1": ["a"] * 50 + ["b"] * 50,
         }
     )
-    model = Model("y ~ x1 + (x1|g1)", data)
+    model = bmb.Model("y ~ x1 + (x1|g1)", data)
     fitted = model.fit(tune=100, draws=100, omit_offsets=False)
     offsets = [var for var in fitted.posterior.var() if var.endswith("_offset")]
     assert offsets == ["1|g1_offset", "x1|g1_offset"]
@@ -276,7 +273,7 @@ def test_omit_offsets_true():
             "g1": ["a"] * 50 + ["b"] * 50,
         }
     )
-    model = Model("y ~ x1 + (x1|g1)", data)
+    model = bmb.Model("y ~ x1 + (x1|g1)", data)
     fitted = model.fit(tune=100, draws=100, omit_offsets=True)
     offsets = [var for var in fitted.posterior.var() if var.endswith("_offset")]
     assert not offsets
@@ -291,15 +288,15 @@ def test_hyperprior_on_common_effect():
             "g1": ["a"] * 50 + ["b"] * 50,
         }
     )
-    slope = Prior("Normal", mu=0, sd=Prior("HalfCauchy", beta=2))
+    slope = bmb.Prior("Normal", mu=0, sd=bmb.Prior("HalfCauchy", beta=2))
 
     priors = {"x1": slope}
     with pytest.raises(ValueError):
-        Model("y ~ x1 + (x1|g1)", data, priors=priors)
+        bmb.Model("y ~ x1 + (x1|g1)", data, priors=priors)
 
     priors = {"common": slope}
     with pytest.raises(ValueError):
-        Model("y ~ x1 + (x1|g1)", data, priors=priors)
+        bmb.Model("y ~ x1 + (x1|g1)", data, priors=priors)
 
 
 @pytest.mark.parametrize(
@@ -318,7 +315,7 @@ def test_hyperprior_on_common_effect():
 def test_automatic_priors(family):
     """Test that automatic priors work correctly"""
     obs = pd.DataFrame([0], columns=["x"])
-    Model("x ~ 0", obs, family=family)
+    bmb.Model("x ~ 0", obs, family=family)
 
 
 def test_links():
@@ -345,9 +342,9 @@ def test_links():
     for family, links in FAMILIES.items():
         for link in links:
             if family == "bernoulli":
-                Model("g ~ x", data, family=family, link=link)
+                bmb.Model("g ~ x", data, family=family, link=link)
             else:
-                Model("y ~ x", data, family=family, link=link)
+                bmb.Model("y ~ x", data, family=family, link=link)
 
 
 def test_bad_links():
@@ -378,7 +375,7 @@ def test_bad_links():
                     formula = "g ~ x"
                 else:
                     formula = "y ~ x"
-                Model(formula, data, family=family, link=link)
+                bmb.Model(formula, data, family=family, link=link)
 
 
 def test_constant_terms():
@@ -392,10 +389,10 @@ def test_constant_terms():
     )
 
     with pytest.raises(ValueError):
-        Model("y ~ 0 + x", data)
+        bmb.Model("y ~ 0 + x", data)
 
     with pytest.raises(ValueError):
-        Model("y ~ 0 + z", data)
+        bmb.Model("y ~ 0 + z", data)
 
 
 def test_1d_group_specific():
@@ -411,16 +408,16 @@ def test_1d_group_specific():
     # We need to ensure x|g is of shape (40,) and not of shape (40, 1)
     # We do so by checking the mean is (40, ) because shape of x|g still returns (40, 1)
     # The difference is that we do .squeeze() on it after creation.
-    model = Model("y ~ (x|g)", data)
+    model = bmb.Model("y ~ (x|g)", data)
     model.build()
     assert model.backend.components["y"].output.shape.eval() == (40,)
 
 
 def test_data_is_copied():
-    adults = load_data("adults")
+    adults = bmb.load_data("adults")
 
-    model_1 = Model("age ~ sex * race", adults)
-    model_2 = Model("age ~ sex * race", adults, categorical=["age", "sex"])
+    model_1 = bmb.Model("age ~ sex * race", adults)
+    model_2 = bmb.Model("age ~ sex * race", adults, categorical=["age", "sex"])
 
     for model in [model_1, model_2]:
         assert id(adults) != id(model.data)
@@ -437,7 +434,7 @@ def test_response_is_censored():
             "status": ["none", "right", "interval", "left", "none"],
         }
     )
-    dm = Model("censored(x, status) ~ 1", df)
+    dm = bmb.Model("censored(x, status) ~ 1", df)
     assert dm.response.is_censored
 
 
@@ -447,21 +444,21 @@ def test_custom_likelihood_function():
     def CustomGaussian(*args, **kwargs):
         return pm.Normal(*args, **kwargs)
 
-    sigma_prior = Prior("HalfNormal", sigma=1)
-    likelihood = Likelihood(
+    sigma_prior = bmb.Prior("HalfNormal", sigma=1)
+    likelihood = bmb.Likelihood(
         "CustomGaussian", params=["mu", "sigma"], parent="mu", dist=CustomGaussian
     )
-    family = Family("custom_gaussian", likelihood, "identity")
-    model = Model("y ~ x", df, family=family, priors={"sigma": sigma_prior})
+    family = bmb.Family("custom_gaussian", likelihood, "identity")
+    model = bmb.Model("y ~ x", df, family=family, priors={"sigma": sigma_prior})
     _ = model.fit(tune=100, draws=100)
     assert model.backend.model.observed_RVs[0].str_repr() == "y ~ N(f(Intercept, x), y_sigma)"
 
 
 def test_extra_namespace():
     """Tests the formula can access an additional namespace"""
-    data = load_data("carclaims")
+    data = bmb.load_data("carclaims")
     extra_namespace = {"levels": data["veh_body"].unique()}
     formula = "numclaims ~ 0 + C(veh_body, levels=levels)"
-    model = Model(formula, data, family="poisson", link="log", extra_namespace=extra_namespace)
+    model = bmb.Model(formula, data, family="poisson", link="log", extra_namespace=extra_namespace)
     term = model.response_component.terms["C(veh_body, levels=levels)"]
     assert (np.asarray(term.levels) == data["veh_body"].unique()).all()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -5,7 +5,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import pytest
 
-from bambi.models import Model, Formula
+import bambi as bmb
 from bambi.plots import plot_cap
 
 
@@ -15,7 +15,7 @@ def mtcars():
     data["cyl"] = data["cyl"].replace({4: "low", 6: "medium", 8: "high"})
     data["cyl"] = pd.Categorical(data["cyl"], categories=["low", "medium", "high"], ordered=True)
     data["gear"] = data["gear"].replace({3: "A", 4: "B", 5: "C"})
-    model = Model("mpg ~ 0 + hp * wt + cyl + gear", data)
+    model = bmb.Model("mpg ~ 0 + hp * wt + cyl + gear", data)
     idata = model.fit(tune=500, draws=500, random_seed=1234)
     return model, idata
 
@@ -162,8 +162,8 @@ def test_multiple_outputs():
     y = rng.gamma(shape, np.exp(a + b * x) / shape, N)
     data_gamma = pd.DataFrame({"x": x, "y": y})
 
-    formula = Formula("y ~ x", "alpha ~ x")
-    model = Model(formula, data_gamma, family="gamma")
+    formula = bmb.Formula("y ~ x", "alpha ~ x")
+    model = bmb.Model(formula, data_gamma, family="gamma")
     idata = model.fit(tune=100, draws=100, random_seed=1234)
     # Test default target
     plot_cap(model, idata, "x")

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -4,8 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from bambi.models import Model
-from bambi import load_data
+import bambi as bmb
 
 
 @pytest.fixture(scope="module")
@@ -68,7 +67,7 @@ def inhaler():
 
 def test_predict_bernoulli(data_bernoulli):
     data = data_bernoulli
-    model = Model("y ~ x1*x2", data, family="bernoulli")
+    model = bmb.Model("y ~ x1*x2", data, family="bernoulli")
     idata = model.fit(tune=100, draws=100, target_accept=0.9)
 
     # In sample prediction
@@ -89,7 +88,7 @@ def test_predict_bernoulli(data_bernoulli):
 def test_predict_beta(data_beta):
     data = data_beta
     data["batch"] = pd.Categorical(data["batch"], [10, 1, 2, 3, 4, 5, 6, 7, 8, 9], ordered=True)
-    model = Model("yield ~ temp + batch", data, family="beta")
+    model = bmb.Model("yield ~ temp + batch", data, family="beta")
     idata = model.fit(tune=100, draws=100, target_accept=0.90)
 
     model.predict(idata, kind="mean")
@@ -112,7 +111,7 @@ def test_predict_beta(data_beta):
 def test_predict_gamma(data_gamma):
     data = data_gamma
 
-    model = Model("y ~ x", data, family="gamma", link="log")
+    model = bmb.Model("y ~ x", data, family="gamma", link="log")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -130,7 +129,7 @@ def test_predict_gamma(data_gamma):
 
 def test_predict_gaussian(data_numeric_xy):
     data = data_numeric_xy
-    model = Model("y ~ x", data, family="gaussian")
+    model = bmb.Model("y ~ x", data, family="gaussian")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -143,7 +142,7 @@ def test_predict_gaussian(data_numeric_xy):
 def test_predict_negativebinomial(data_count):
     data = data_count
 
-    model = Model("y ~ x", data, family="negativebinomial")
+    model = bmb.Model("y ~ x", data, family="negativebinomial")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -162,7 +161,7 @@ def test_predict_negativebinomial(data_count):
 def test_predict_poisson(data_count):
     data = data_count
 
-    model = Model("y ~ x", data, family="negativebinomial")
+    model = bmb.Model("y ~ x", data, family="negativebinomial")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -180,7 +179,7 @@ def test_predict_poisson(data_count):
 
 def test_predict_t(data_numeric_xy):
     data = data_numeric_xy
-    model = Model("y ~ x", data, family="t")
+    model = bmb.Model("y ~ x", data, family="t")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -190,7 +189,7 @@ def test_predict_t(data_numeric_xy):
     model.predict(idata, kind="pps", data=data.iloc[:20, :])
 
     # A case where the prior for one of the parameters is constant
-    model = Model("y ~ x", data, family="t", priors={"nu": 4})
+    model = bmb.Model("y ~ x", data, family="t", priors={"nu": 4})
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -203,7 +202,7 @@ def test_predict_t(data_numeric_xy):
 def test_predict_wald(data_gamma):
     data = data_gamma
 
-    model = Model("y ~ x", data, family="wald", link="log")
+    model = bmb.Model("y ~ x", data, family="wald", link="log")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata, kind="mean")
@@ -220,7 +219,7 @@ def test_predict_wald(data_gamma):
 
 
 def test_predict_categorical(inhaler):
-    model = Model("rating ~ period + carry + treat", inhaler, family="categorical")
+    model = bmb.Model("rating ~ period + carry + treat", inhaler, family="categorical")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata)
@@ -229,7 +228,7 @@ def test_predict_categorical(inhaler):
     model.predict(idata, data=inhaler.iloc[:20, :])
     assert np.allclose(idata.posterior["rating_mean"].values.sum(-1), 1)
 
-    model = Model("rating ~ period + carry + treat + (1|subject)", inhaler, family="categorical")
+    model = bmb.Model("rating ~ period + carry + treat + (1|subject)", inhaler, family="categorical")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata)
@@ -240,7 +239,7 @@ def test_predict_categorical(inhaler):
 
 
 def test_posterior_predictive_categorical(inhaler):
-    model = Model("rating ~ period", data=inhaler, family="categorical")
+    model = bmb.Model("rating ~ period", data=inhaler, family="categorical")
     idata = model.fit(tune=100, draws=100)
     model.predict(idata, kind="pps")
     pps = idata.posterior_predictive["rating"].to_numpy()
@@ -263,7 +262,7 @@ def test_predict_categorical_group_specific():
         }
     )
 
-    model = Model("y ~ x1 + (0 + x2|x1) + (0 + x3|x1 + x2)", data, family="bernoulli")
+    model = bmb.Model("y ~ x1 + (0 + x2|x1) + (0 + x3|x1 + x2)", data, family="bernoulli")
 
     idata = model.fit(tune=100, draws=100, chains=2)
 
@@ -279,14 +278,14 @@ def test_predict_multinomial(inhaler):
     df.columns = ["treat", "carry", "y1", "y2", "y3", "y4"]
 
     # Intercept only
-    model = Model("c(y1, y2, y3, y4) ~ 1", df, family="multinomial")
+    model = bmb.Model("c(y1, y2, y3, y4) ~ 1", df, family="multinomial")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata)
     model.predict(idata, data=df.iloc[:3, :])
 
     # Numerical predictors
-    model = Model("c(y1, y2, y3, y4) ~ treat + carry", df, family="multinomial")
+    model = bmb.Model("c(y1, y2, y3, y4) ~ treat + carry", df, family="multinomial")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata)
@@ -296,7 +295,7 @@ def test_predict_multinomial(inhaler):
     df["treat"] = df["treat"].replace({-0.5: "A", 0.5: "B"})
     df["carry"] = df["carry"].replace({-1: "a", 0: "b", 1: "c"})
 
-    model = Model("c(y1, y2, y3, y4) ~ treat + carry", df, family="multinomial")
+    model = bmb.Model("c(y1, y2, y3, y4) ~ treat + carry", df, family="multinomial")
     idata = model.fit(tune=100, draws=100)
 
     model.predict(idata)
@@ -313,7 +312,7 @@ def test_predict_multinomial(inhaler):
     )
 
     # Contains group-specific effect
-    model = Model(
+    model = bmb.Model(
         "c(y1, y2, y3, y4) ~ 1 + (1 | state)", data, family="multinomial", noncentered=False
     )
     idata = model.fit(tune=100, draws=100, random_seed=0)
@@ -328,7 +327,7 @@ def test_posterior_predictive_multinomial(inhaler):
     df.columns = ["treat", "carry", "y1", "y2", "y3", "y4"]
 
     # Intercept only
-    model = Model("c(y1, y2, y3, y4) ~ 1", df, family="multinomial")
+    model = bmb.Model("c(y1, y2, y3, y4) ~ 1", df, family="multinomial")
     idata = model.fit(tune=100, draws=100)
 
     # The sum across the columns of the response is the same for all the chain and draws.
@@ -347,7 +346,7 @@ def test_predict_include_group_specific():
         }
     )
 
-    model = Model("y ~ 1 + (1|x1)", data, family="bernoulli")
+    model = bmb.Model("y ~ 1 + (1|x1)", data, family="bernoulli")
     idata = model.fit(tune=100, draws=100, chains=2, random_seed=1234)
     idata_1 = model.predict(idata, data=data, inplace=False, include_group_specific=True)
     idata_2 = model.predict(idata, data=data, inplace=False, include_group_specific=False)
@@ -368,8 +367,8 @@ def test_predict_include_group_specific():
 def test_predict_offset():
     # Simple case
 
-    data = load_data("carclaims")
-    model = Model("numclaims ~ offset(np.log(exposure))", data, family="poisson", link="log")
+    data = bmb.load_data("carclaims")
+    model = bmb.Model("numclaims ~ offset(np.log(exposure))", data, family="poisson", link="log")
     idata = model.fit(tune=100, draws=100, chains=2, random_seed=1234)
     model.predict(idata)
     model.predict(idata, kind="pps")
@@ -384,6 +383,6 @@ def test_predict_offset():
         }
     )
     data["time"] = data["y"] - rng.normal(loc=1, size=100)
-    model = Model("y ~ offset(np.log(time)) + x + (1 | group)", data, family="poisson")
+    model = bmb.Model("y ~ offset(np.log(time)) + x + (1 | group)", data, family="poisson")
     idata = model.fit(tune=100, draws=100, chains=2, target_accept=0.9, random_seed=1234)
     model.predict(idata, kind="pps")

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -6,10 +6,7 @@ import pymc as pm
 import pandas as pd
 from scipy import special
 
-from bambi.data import load_data
-from bambi.families import Family, Likelihood, Link
-from bambi.models import Model
-from bambi.priors import Prior
+import bambi as bmb
 
 
 @pytest.fixture(scope="module")
@@ -23,7 +20,7 @@ def diabetes_data():
 
 
 def test_prior_class():
-    prior = Prior("CheeseWhiz", holes=0, taste=-10)
+    prior = bmb.Prior("CheeseWhiz", holes=0, taste=-10)
     assert prior.name == "CheeseWhiz"
     assert isinstance(prior.args, dict)
     assert prior.args["taste"] == -10
@@ -32,14 +29,14 @@ def test_prior_class():
 
 
 def test_likelihood_class():
-    # Likelihood with recognized name
-    likelihood = Likelihood("Normal", ["mu", "sigma"], "mu")
+    # bmb.Likelihood with recognized name
+    likelihood = bmb.Likelihood("Normal", ["mu", "sigma"], "mu")
     for name in ["name", "params", "parent", "dist"]:
         assert hasattr(likelihood, name)
 
     # A likelihood with unrecognized name
     # The class is not going to complain. Whether "Magic" works in PyMC is up to the user.
-    likelihood = Likelihood("Magic", ["Wizard", "Witcher"], "Wizard")
+    likelihood = bmb.Likelihood("Magic", ["Wizard", "Witcher"], "Wizard")
     for name in ["name", "params", "parent", "dist"]:
         assert hasattr(likelihood, name)
 
@@ -48,33 +45,33 @@ def test_likelihood_bad_parent():
     with pytest.raises(
         ValueError, match="'Mu' is not a valid parameter for the likelihood 'Normal'"
     ):
-        Likelihood("Normal", params=["mu", "sigma"], parent="Mu")
+        bmb.Likelihood("Normal", params=["mu", "sigma"], parent="Mu")
 
     with pytest.raises(
         ValueError, match="'Mu' is not a valid parameter for the likelihood 'Normal'"
     ):
-        Likelihood("Normal", parent="Mu")
+        bmb.Likelihood("Normal", parent="Mu")
 
     with pytest.raises(
         ValueError, match="'mu' is not a valid parameter for the likelihood 'Bernoulli'"
     ):
-        Likelihood("Bernoulli", params=["p"], parent="mu")
+        bmb.Likelihood("Bernoulli", params=["p"], parent="mu")
 
     with pytest.raises(
         ValueError, match="'mu' is not a valid parameter for the likelihood 'Bernoulli'"
     ):
-        Likelihood("Bernoulli", parent="mu")
+        bmb.Likelihood("Bernoulli", parent="mu")
 
 
 def test_likelihood_parent_inferred():
-    lh1 = Likelihood("Normal", parent="mu")
-    lh2 = Likelihood("Normal")
+    lh1 = bmb.Likelihood("Normal", parent="mu")
+    lh2 = bmb.Likelihood("Normal")
     assert lh1.parent == lh2.parent
 
 
 def test_family_class():
-    likelihood = Likelihood("Cheese", params=["holes", "milk"], parent="holes")
-    family = Family("cheese", likelihood=likelihood, link="logit")
+    likelihood = bmb.Likelihood("Cheese", params=["holes", "milk"], parent="holes")
+    family = bmb.Family("cheese", likelihood=likelihood, link="logit")
 
     for name in ["name", "likelihood", "link"]:
         assert hasattr(family, name)
@@ -89,21 +86,21 @@ def test_family_bad_priors():
             "g": rng.choice(["A", "B"], size=100),
         }
     )
-    likelihood = Likelihood("Normal", params=["mu", "sigma"], parent="mu")
-    family = Family("MyNormal", likelihood, "identity")
+    likelihood = bmb.Likelihood("Normal", params=["mu", "sigma"], parent="mu")
+    family = bmb.Family("MyNormal", likelihood, "identity")
     # Required prior is missing
     with pytest.raises(ValueError, match="The component 'sigma' needs a prior."):
-        Model("y ~ x", data, family=family)
+        bmb.Model("y ~ x", data, family=family)
 
-    # Prior is not a prior
+    # bmb.Prior is not a prior
     with pytest.raises(ValueError, match="'Whatever' is not a valid prior."):
-        Model("y ~ x", data, family=family, priors={"sigma": "Whatever"})
+        bmb.Model("y ~ x", data, family=family, priors={"sigma": "Whatever"})
 
 
 def test_auto_scale(diabetes_data):
-    # By default, should scale everything except custom Prior() objects
-    priors = {"BP": Prior("Cauchy", alpha=1, beta=17.5)}
-    model = Model("BMI ~ S1 + S2 + BP", diabetes_data, priors=priors)
+    # By default, should scale everything except custom bmb.Prior() objects
+    priors = {"BP": bmb.Prior("Cauchy", alpha=1, beta=17.5)}
+    model = bmb.Model("BMI ~ S1 + S2 + BP", diabetes_data, priors=priors)
     p1 = model.response_component.terms["S1"].prior
     p2 = model.response_component.terms["S2"].prior
     p3 = model.response_component.terms["BP"].prior
@@ -114,8 +111,8 @@ def test_auto_scale(diabetes_data):
     assert p3.args["beta"] == 17.5
 
     # With auto_scale off, custom priors are considered.
-    priors = {"BP": Prior("Cauchy", alpha=1, beta=17.5)}
-    model = Model("BMI ~ S1 + S2 + BP", diabetes_data, priors=priors, auto_scale=False)
+    priors = {"BP": bmb.Prior("Cauchy", alpha=1, beta=17.5)}
+    model = bmb.Model("BMI ~ S1 + S2 + BP", diabetes_data, priors=priors, auto_scale=False)
     p2_off = model.response_component.terms["S2"].prior
     p3_off = model.response_component.terms["BP"].prior
     assert p2_off.name == "Flat"
@@ -125,8 +122,8 @@ def test_auto_scale(diabetes_data):
 
 def test_prior_str():
     # Tests __str__ method
-    prior1 = Prior("Normal", mu=0, sigma=1)
-    prior2 = Prior("Normal", mu=0, sigma=Prior("HalfNormal", sigma=1))
+    prior1 = bmb.Prior("Normal", mu=0, sigma=1)
+    prior2 = bmb.Prior("Normal", mu=0, sigma=bmb.Prior("HalfNormal", sigma=1))
     assert str(prior1) == "Normal(mu: 0.0, sigma: 1.0)"
     assert str(prior2) == "Normal(mu: 0.0, sigma: HalfNormal(sigma: 1.0))"
     assert str(prior1) == repr(prior1)
@@ -134,32 +131,32 @@ def test_prior_str():
 
 def test_prior_eq():
     # Tests __eq__ method
-    prior1 = Prior("Normal", mu=0, sigma=1)
-    prior2 = Prior("Normal", mu=0, sigma=Prior("HalfNormal", sigma=1))
+    prior1 = bmb.Prior("Normal", mu=0, sigma=1)
+    prior2 = bmb.Prior("Normal", mu=0, sigma=bmb.Prior("HalfNormal", sigma=1))
     assert prior1 == prior1
     assert prior2 == prior2
     assert prior1 != prior2
-    assert prior1 != "Prior"
+    assert prior1 != "bmb.Prior"
 
 
 def test_family_link_unsupported():
-    prior = Prior("CheeseWhiz", holes=0, taste=-10)
-    likelihood = Likelihood("Cheese", parent="holes", params=["holes", "milk"])
-    family = Family("cheese", likelihood=likelihood, link="cloglog")
+    prior = bmb.Prior("CheeseWhiz", holes=0, taste=-10)
+    likelihood = bmb.Likelihood("Cheese", parent="holes", params=["holes", "milk"])
+    family = bmb.Family("cheese", likelihood=likelihood, link="cloglog")
     family.set_default_priors({"milk": prior})
     with pytest.raises(
-        ValueError, match="Link 'Empty' cannot be used for 'holes' with family 'cheese'"
+        ValueError, match="bmb.Link 'Empty' cannot be used for 'holes' with family 'cheese'"
     ):
         family.link = "Empty"
 
 
 def test_custom_link():
     rng = np.random.default_rng(121195)
-    likelihood = Likelihood("Bernoulli", parent="p")
-    link = Link(
+    likelihood = bmb.Likelihood("Bernoulli", parent="p")
+    link = bmb.Link(
         "my_logit", link=special.expit, linkinv=special.logit, linkinv_backend=pm.math.sigmoid
     )
-    family = Family("bernoulli", likelihood, link)
+    family = bmb.Family("bernoulli", likelihood, link)
 
     data = pd.DataFrame(
         {
@@ -168,7 +165,7 @@ def test_custom_link():
             "x2": rng.uniform(size=10),
         }
     )
-    model = Model("y ~ x1 + x2", data, family=family)
+    model = bmb.Model("y ~ x1 + x2", data, family=family)
     model.build()
 
 
@@ -176,13 +173,13 @@ def test_family_bad_type():
     data = pd.DataFrame({"x": [1], "y": [1]})
 
     with pytest.raises(ValueError):
-        Model("y ~ x", data, family=0)
+        bmb.Model("y ~ x", data, family=0)
 
     with pytest.raises(ValueError):
-        Model("y ~ x", data, family=set("gaussian"))
+        bmb.Model("y ~ x", data, family=set("gaussian"))
 
     with pytest.raises(ValueError):
-        Model("y ~ x", data, family={"family": "gaussian"})
+        bmb.Model("y ~ x", data, family={"family": "gaussian"})
 
 
 def test_set_priors():
@@ -196,9 +193,9 @@ def test_set_priors():
             "g": rng.choice(["A", "B"], size=100),
         }
     )
-    model = Model("y ~ x + (1|g)", data)
-    prior = Prior("Uniform", lower=0, upper=50)
-    gp_prior = Prior("Normal", mu=0, sigma=Prior("Normal", mu=0, sigma=1))
+    model = bmb.Model("y ~ x + (1|g)", data)
+    prior = bmb.Prior("Uniform", lower=0, upper=50)
+    gp_prior = bmb.Prior("Normal", mu=0, sigma=bmb.Prior("Normal", mu=0, sigma=1))
 
     # Common
     model.set_priors(common=prior)
@@ -212,7 +209,7 @@ def test_set_priors():
     assert model.response_component.terms["1|g"].prior == gp_prior
 
     # By name
-    model = Model("y ~ x + (1|g)", data)
+    model = bmb.Model("y ~ x + (1|g)", data)
     model.set_priors(priors={"Intercept": prior})
     model.set_priors(priors={"x": prior})
     model.set_priors(priors={"1|g": gp_prior})
@@ -229,8 +226,8 @@ def test_set_prior_unexisting_term():
             "x": rng.normal(size=100),
         }
     )
-    prior = Prior("Uniform", lower=0, upper=50)
-    model = Model("y ~ x", data)
+    prior = bmb.Prior("Uniform", lower=0, upper=50)
+    model = bmb.Model("y ~ x", data)
     with pytest.raises(KeyError):
         model.set_priors(priors={"z": prior})
 
@@ -239,23 +236,23 @@ def test_response_prior():
     rng = np.random.default_rng(121195)
     data = pd.DataFrame({"y": rng.integers(3, 10, size=50), "x": rng.normal(size=50)})
 
-    priors = {"sigma": Prior("Uniform", lower=0, upper=50)}
-    model = Model("y ~ x", data, priors=priors)
+    priors = {"sigma": bmb.Prior("Uniform", lower=0, upper=50)}
+    model = bmb.Model("y ~ x", data, priors=priors)
     priors["sigma"].auto_scale = False  # the one in the model is set to False
     assert model.constant_components["sigma"].prior == priors["sigma"]
 
-    priors = {"alpha": Prior("Uniform", lower=1, upper=20)}
-    model = Model("y ~ x", data, family="negativebinomial", priors=priors)
+    priors = {"alpha": bmb.Prior("Uniform", lower=1, upper=20)}
+    model = bmb.Model("y ~ x", data, family="negativebinomial", priors=priors)
     priors["alpha"].auto_scale = False
     assert model.constant_components["alpha"].prior == priors["alpha"]
 
-    priors = {"alpha": Prior("Uniform", lower=0, upper=50)}
-    model = Model("y ~ x", data, family="gamma", priors=priors)
+    priors = {"alpha": bmb.Prior("Uniform", lower=0, upper=50)}
+    model = bmb.Model("y ~ x", data, family="gamma", priors=priors)
     priors["alpha"].auto_scale = False
     assert model.constant_components["alpha"].prior == priors["alpha"]
 
-    priors = {"alpha": Prior("Uniform", lower=0, upper=50)}
-    model = Model("y ~ x", data, family="gamma", priors=priors)
+    priors = {"alpha": bmb.Prior("Uniform", lower=0, upper=50)}
+    model = bmb.Model("y ~ x", data, family="gamma", priors=priors)
     priors["alpha"].auto_scale = False
     assert model.constant_components["alpha"].prior == priors["alpha"]
 
@@ -264,20 +261,20 @@ def test_set_response_prior():
     rng = np.random.default_rng(121195)
     data = pd.DataFrame({"y": rng.integers(3, 10, size=50), "x": rng.normal(size=50)})
 
-    priors = {"sigma": Prior("Uniform", lower=0, upper=50)}
-    model = Model("y ~ x", data)
+    priors = {"sigma": bmb.Prior("Uniform", lower=0, upper=50)}
+    model = bmb.Model("y ~ x", data)
     model.set_priors(priors)
-    assert model.constant_components["sigma"].prior == Prior("Uniform", False, lower=0, upper=50)
+    assert model.constant_components["sigma"].prior == bmb.Prior("Uniform", False, lower=0, upper=50)
 
-    priors = {"alpha": Prior("Uniform", lower=1, upper=20)}
-    model = Model("y ~ x", data, family="negativebinomial")
+    priors = {"alpha": bmb.Prior("Uniform", lower=1, upper=20)}
+    model = bmb.Model("y ~ x", data, family="negativebinomial")
     model.set_priors(priors)
-    assert model.constant_components["alpha"].prior == Prior("Uniform", False, lower=1, upper=20)
+    assert model.constant_components["alpha"].prior == bmb.Prior("Uniform", False, lower=1, upper=20)
 
-    priors = {"alpha": Prior("Uniform", lower=0, upper=50)}
-    model = Model("y ~ x", data, family="gamma")
+    priors = {"alpha": bmb.Prior("Uniform", lower=0, upper=50)}
+    model = bmb.Model("y ~ x", data, family="gamma")
     model.set_priors(priors)
-    assert model.constant_components["alpha"].prior == Prior("Uniform", False, lower=0, upper=50)
+    assert model.constant_components["alpha"].prior == bmb.Prior("Uniform", False, lower=0, upper=50)
 
 
 def test_prior_shape():
@@ -291,20 +288,20 @@ def test_prior_shape():
         }
     )
 
-    model = Model("score ~ 0 + q", data)
+    model = bmb.Model("score ~ 0 + q", data)
     assert model.response_component.terms["q"].prior.args["mu"].shape == (5,)
     assert model.response_component.terms["q"].prior.args["sigma"].shape == (5,)
 
-    model = Model("score ~ q", data)
+    model = bmb.Model("score ~ q", data)
     assert model.response_component.terms["q"].prior.args["mu"].shape == (4,)
     assert model.response_component.terms["q"].prior.args["sigma"].shape == (4,)
 
-    model = Model("score ~ 0 + q:s", data)
+    model = bmb.Model("score ~ 0 + q:s", data)
     assert model.response_component.terms["q:s"].prior.args["mu"].shape == (15,)
     assert model.response_component.terms["q:s"].prior.args["sigma"].shape == (15,)
 
     # "s" is automatically added to ensure full rank matrix
-    model = Model("score ~ q:s", data)
+    model = bmb.Model("score ~ q:s", data)
     assert model.response_component.terms["Intercept"].prior.args["mu"].shape == ()
     assert model.response_component.terms["Intercept"].prior.args["sigma"].shape == ()
 
@@ -328,27 +325,27 @@ def test_set_priors_but_intercept():
     )
 
     priors = {
-        "x1": Prior("TruncatedNormal", sigma=1, mu=0, lower=0),
-        "x2": Prior("TruncatedNormal", sigma=1, mu=0, upper=0),
+        "x1": bmb.Prior("TruncatedNormal", sigma=1, mu=0, lower=0),
+        "x2": bmb.Prior("TruncatedNormal", sigma=1, mu=0, upper=0),
     }
 
-    Model("y ~ x1 + x2", df, family="bernoulli", priors=priors)
+    bmb.Model("y ~ x1 + x2", df, family="bernoulli", priors=priors)
 
     priors = {
-        "x1": Prior("StudentT", mu=0, nu=4, lam=1),
-        "x2": Prior("StudentT", mu=0, nu=8, lam=2),
+        "x1": bmb.Prior("StudentT", mu=0, nu=4, lam=1),
+        "x2": bmb.Prior("StudentT", mu=0, nu=8, lam=2),
     }
 
-    Model("z ~ x1 + x2 + (1|g)", df, priors=priors)
+    bmb.Model("z ~ x1 + x2 + (1|g)", df, priors=priors)
 
 
 def test_custom_prior():
     def CustomPrior(name, *args, dims=None, **kwargs):
         return pm.Normal(name, *args, dims=dims, **kwargs)
 
-    data = load_data("my_data")
+    data = bmb.load_data("my_data")
 
-    priors = {"x": Prior("CustomPrior", mu=0, sigma=5, dist=CustomPrior)}
-    model = Model("y ~ x", data, priors=priors)
+    priors = {"x": bmb.Prior("CustomPrior", mu=0, sigma=5, dist=CustomPrior)}
+    model = bmb.Model("y ~ x", data, priors=priors)
     model.build()
     assert model.backend.model.free_RVs[-1].str_repr() == "x ~ N(0, 5)"

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -145,7 +145,7 @@ def test_family_link_unsupported():
     family = bmb.Family("cheese", likelihood=likelihood, link="cloglog")
     family.set_default_priors({"milk": prior})
     with pytest.raises(
-        ValueError, match="bmb.Link 'Empty' cannot be used for 'holes' with family 'cheese'"
+        ValueError, match="Link 'Empty' cannot be used for 'holes' with family 'cheese'"
     ):
         family.link = "Empty"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,10 @@ import pytest
 import numpy as np
 import pandas as pd
 
+import bambi as bmb
 from bambi.utils import listify
 from bambi.backend.pymc import probit, cloglog
 from bambi.transformations import censored
-
 
 def test_listify():
     assert listify(None) == []


### PR DESCRIPTION
This draft PR resolves #653 to avoid importing specific objects only in the test files of the `test/` directory  . For directories treated as packages in the [__init__.py](https://github.com/bambinos/bambi/blob/main/bambi/__init__.py) I use `import bambi as bmb`. Directories not treated as packages, I import the submodule individually. For example, `from bambi.terms import CommonTerm`

Tests are completed and passed locally:

- [x] Make sure all test pass.
- [x] Make sure your code passes `black`.
- [x] Make sure your code passes `pylint`.
