### PR TITLE
Prevent underscores from being removed in dim names

### DIFF
--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -126,7 +126,7 @@ class GroupSpecificTerm:
         new_coords = {}
         for key, value in coords.items():
             _, kind = key.split("__")
-            new_coords[self.term.alias + kind] = value
+            new_coords[self.term.alias + "__" + kind] = value
         return new_coords
 
     def build_distribution(self, prior, label, **kwargs):

--- a/bambi/families/multivariate.py
+++ b/bambi/families/multivariate.py
@@ -73,7 +73,7 @@ class Multinomial(MultivariateFamily):
 
     def get_coords(self, response):
         # For the moment, it always uses the first column as reference.
-        name = response.name + "_dim"
+        name = get_aliased_name(response) + "_dim"
         labels = self.get_levels(response)
         return {name: labels[1:]}
 

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -93,7 +93,7 @@ class Categorical(UnivariateFamily):
         return np.nonzero(response.term.data)[1]
 
     def get_coords(self, response):
-        name = response.name + "_dim"
+        name = get_aliased_name(response) + "_dim"
         return {name: [level for level in response.levels if level != response.reference]}
 
     def get_reference(self, response):


### PR DESCRIPTION
The dimension names of the groups specific effects end with `__expr_dim` and `__factor_dim`.

For example, if the term is `(categorical | group)` then the dimension names are `categorical__expr_dim` and `group__factor_dim`. 

When using aliases, we were replacing the term name with the alias, but we were accidentally removing the `"__"`, so dimnames would turn out to be `aliasfactor_dim`. This PR fixes that so the dimname is `alias__factor_dim`.