### PR TITLE
`plot_cap` default args. not working for categorical regression

### DIFF
--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -259,15 +259,30 @@ def plot_cap(
     return fig, axes
 
 
-def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, axes):
+def _plot_cap_numeric(
+        covariates, 
+        cap_data, 
+        y_hat_mean, 
+        y_hat_bounds, 
+        transforms, 
+        legend, 
+        axes
+    ):
     main = covariates.get("horizontal")
     transform_main = transforms.get(main, identity)
+    y_hat_bounds_dim = y_hat_bounds.ndim
 
     if len(covariates) == 1:
         ax = axes[0]
         values_main = transform_main(cap_data[main])
         ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
-        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.4)
+        if y_hat_bounds_dim > 2:
+            for dim in range(y_hat_bounds_dim):
+                ax.fill_between(
+                    values_main, y_hat_bounds[0][dim], y_hat_bounds[1][dim], alpha=0.4
+                )
+        else:
+            ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.4)
     elif "color" in covariates and not "panel" in covariates:
         ax = axes[0]
         color = covariates.get("color")
@@ -276,13 +291,23 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
             idx = (cap_data[color] == clr).to_numpy()
             values_main = transform_main(cap_data.loc[idx, main])
             ax.plot(values_main, y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
-            ax.fill_between(
-                values_main,
-                y_hat_bounds[0][idx],
-                y_hat_bounds[1][idx],
-                alpha=0.4,
-                color=f"C{i}",
-            )
+            if y_hat_bounds_dim > 2:
+                for dim in range(y_hat_bounds_dim):
+                    ax.fill_between(
+                        values_main,
+                        y_hat_bounds[0][dim][idx],
+                        y_hat_bounds[1][dim][idx],
+                        alpha=0.4,
+                        color=f"C{i}",
+                    )
+            else:
+                ax.fill_between(
+                    values_main,
+                    y_hat_bounds[0][idx],
+                    y_hat_bounds[1][idx],
+                    alpha=0.4,
+                    color=f"C{i}",
+                )
     elif not "color" in covariates and "panel" in covariates:
         panel = covariates.get("panel")
         panels = get_unique_levels(cap_data[panel])
@@ -290,7 +315,17 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
             idx = (cap_data[panel] == pnl).to_numpy()
             values_main = transform_main(cap_data.loc[idx, main])
             ax.plot(values_main, y_hat_mean[idx], solid_capstyle="butt")
-            ax.fill_between(values_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx], alpha=0.4)
+            if y_hat_bounds_dim > 2:
+                for dim in range(y_hat_bounds_dim):
+                    ax.fill_between(
+                        values_main,
+                        y_hat_bounds[0][dim][idx],
+                        y_hat_bounds[1][dim][idx],
+                        alpha=0.4,
+                    )
+            else:
+                ax.fill_between(
+                    values_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx], alpha=0.4)
             ax.set(title=f"{panel} = {pnl}")
     elif "color" in covariates and "panel" in covariates:
         color = covariates.get("color")
@@ -302,20 +337,16 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
                 idx = (cap_data[panel] == pnl).to_numpy()
                 values_main = transform_main(cap_data.loc[idx, main])
                 ax.plot(values_main, y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
-                ax.fill_between(
-                    values_main,
-                    y_hat_bounds[0][idx],
-                    y_hat_bounds[1][idx],
-                    alpha=0.4,
-                    color=f"C{i}",
-                )
-                ax.set(title=f"{panel} = {pnl}")
-        else:
-            for ax, pnl in zip(axes.ravel(), panels):
-                for i, clr in enumerate(colors):
-                    idx = ((cap_data[panel] == pnl) & (cap_data[color] == clr)).to_numpy()
-                    values_main = transform_main(cap_data.loc[idx, main])
-                    ax.plot(values_main, y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
+                if y_hat_bounds_dim > 2:
+                    for dim in range(y_hat_bounds_dim):
+                        ax.fill_between(
+                            values_main,
+                            y_hat_bounds[0][dim][idx],
+                            y_hat_bounds[1][dim][idx],
+                            alpha=0.4,
+                            color=f"C{i}",
+                        )
+                else:
                     ax.fill_between(
                         values_main,
                         y_hat_bounds[0][idx],
@@ -323,6 +354,30 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
                         alpha=0.4,
                         color=f"C{i}",
                     )
+                ax.set(title=f"{panel} = {pnl}")
+        else:
+            for ax, pnl in zip(axes.ravel(), panels):
+                for i, clr in enumerate(colors):
+                    idx = ((cap_data[panel] == pnl) & (cap_data[color] == clr)).to_numpy()
+                    values_main = transform_main(cap_data.loc[idx, main])
+                    ax.plot(values_main, y_hat_mean[idx], color=f"C{i}", solid_capstyle="butt")
+                    if y_hat_bounds_dim > 2:
+                        for dim in range(y_hat_bounds_dim):
+                            ax.fill_between(
+                                values_main,
+                                y_hat_bounds[0][dim][idx],
+                                y_hat_bounds[1][dim][idx],
+                                alpha=0.4,
+                                color=f"C{i}",
+                            )
+                    else:
+                        ax.fill_between(
+                            values_main,
+                            y_hat_bounds[0][idx],
+                            y_hat_bounds[1][idx],
+                            alpha=0.4,
+                            color=f"C{i}",
+                        )
                     ax.set(title=f"{panel} = {pnl}")
 
     if "color" in covariates and legend:
@@ -337,6 +392,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
             ax.legend(
                 handles, tuple(colors), title=color, handlelength=1.3, handleheight=1, loc="best"
             )
+    
     return axes
 
 

--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -452,8 +452,22 @@ def _plot_cap_categoric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, 
                     ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
                     ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
                     ax.set(title=f"{panel} = {pnl}")
+                    
+    if type(legend) != bool:
+        title = list(legend.keys())[0]
+        values = list(legend.values())[0]
+        handles = [
+            (
+                Line2D([], [], color=f"C{i}", solid_capstyle="butt"),
+                Patch(color=f"C{i}", alpha=0.4, lw=1),
+            )
+            for i in range(len(values))
+        ]
+        for ax in axes.ravel():
+            ax.set_label(values)
+            ax.legend(handles, values, title=title, handlelength=1.3, handleheight=1, loc="best")
 
-    if "color" in covariates and legend:
+    elif "color" in covariates and legend:
         handles = [
             Line2D([], [], c=f"C{i}", marker="o", label=level) for i, level in enumerate(colors)
         ]

--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -373,7 +373,7 @@ def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms
                         )
                     ax.set(title=f"{panel} = {pnl}")
 
-    if type(legend) != bool:
+    if not isinstance(legend, bool):
         title = list(legend.keys())[0]
         values = list(legend.values())[0]
         handles = [
@@ -452,8 +452,8 @@ def _plot_cap_categoric(covariates, cap_data, y_hat_mean, y_hat_bounds, legend, 
                     ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
                     ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
                     ax.set(title=f"{panel} = {pnl}")
-                    
-    if type(legend) != bool:
+
+    if not isinstance(legend, bool):
         title = list(legend.keys())[0]
         values = list(legend.values())[0]
         handles = [

--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -260,18 +260,10 @@ def plot_cap(
     for ax in axes.ravel():  # pylint: disable = redefined-argument-from-local
         ax.set(xlabel=main, ylabel=ylabel)
 
-    return fig, axes, idata
+    return fig, axes
 
 
-def _plot_cap_numeric(
-        covariates, 
-        cap_data, 
-        y_hat_mean, 
-        y_hat_bounds, 
-        transforms, 
-        legend, 
-        axes
-    ):
+def _plot_cap_numeric(covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, axes):
     main = covariates.get("horizontal")
     transform_main = transforms.get(main, identity)
     y_hat_bounds_dim = y_hat_bounds.ndim
@@ -282,9 +274,7 @@ def _plot_cap_numeric(
         ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
         if y_hat_bounds_dim > 2:
             for dim in range(y_hat_bounds_dim):
-                ax.fill_between(
-                    values_main, y_hat_bounds[0][dim], y_hat_bounds[1][dim], alpha=0.4
-                )
+                ax.fill_between(values_main, y_hat_bounds[0][dim], y_hat_bounds[1][dim], alpha=0.4)
         else:
             ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.4)
     elif "color" in covariates and not "panel" in covariates:
@@ -328,8 +318,7 @@ def _plot_cap_numeric(
                         alpha=0.4,
                     )
             else:
-                ax.fill_between(
-                    values_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx], alpha=0.4)
+                ax.fill_between(values_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx], alpha=0.4)
             ax.set(title=f"{panel} = {pnl}")
     elif "color" in covariates and "panel" in covariates:
         color = covariates.get("color")
@@ -396,9 +385,7 @@ def _plot_cap_numeric(
         ]
         for ax in axes.ravel():
             ax.set_label(values)
-            ax.legend(
-                handles, values, title=title, handlelength=1.3, handleheight=1, loc="best"
-            )
+            ax.legend(handles, values, title=title, handlelength=1.3, handleheight=1, loc="best")
     elif "color" in covariates and legend:
         handles = [
             (
@@ -409,9 +396,9 @@ def _plot_cap_numeric(
         ]
         for ax in axes.ravel():
             ax.legend(
-                handles, tuple(values), title=values, handlelength=1.3, handleheight=1, loc="best"
+                handles, tuple(colors), title=color, handlelength=1.3, handleheight=1, loc="best"
             )
-    
+
     return axes
 
 

--- a/bambi/plots/plot_cap.py
+++ b/bambi/plots/plot_cap.py
@@ -243,6 +243,10 @@ def plot_cap(
             fig = axes[0].get_figure()
 
     main = covariates.get("horizontal")
+
+    if is_categorical_dtype(model.data[response_name]):
+        legend = {response_name: (model.data[response_name].cat.categories.tolist())}
+
     if is_numeric_dtype(cap_data[main]):
         axes = _plot_cap_numeric(
             covariates, cap_data, y_hat_mean, y_hat_bounds, transforms, legend, axes
@@ -256,7 +260,7 @@ def plot_cap(
     for ax in axes.ravel():  # pylint: disable = redefined-argument-from-local
         ax.set(xlabel=main, ylabel=ylabel)
 
-    return fig, axes
+    return fig, axes, idata
 
 
 def _plot_cap_numeric(
@@ -380,7 +384,22 @@ def _plot_cap_numeric(
                         )
                     ax.set(title=f"{panel} = {pnl}")
 
-    if "color" in covariates and legend:
+    if type(legend) != bool:
+        title = list(legend.keys())[0]
+        values = list(legend.values())[0]
+        handles = [
+            (
+                Line2D([], [], color=f"C{i}", solid_capstyle="butt"),
+                Patch(color=f"C{i}", alpha=0.4, lw=1),
+            )
+            for i in range(len(values))
+        ]
+        for ax in axes.ravel():
+            ax.set_label(values)
+            ax.legend(
+                handles, values, title=title, handlelength=1.3, handleheight=1, loc="best"
+            )
+    elif "color" in covariates and legend:
         handles = [
             (
                 Line2D([], [], color=f"C{i}", solid_capstyle="butt"),
@@ -390,7 +409,7 @@ def _plot_cap_numeric(
         ]
         for ax in axes.ravel():
             ax.legend(
-                handles, tuple(colors), title=color, handlelength=1.3, handleheight=1, loc="best"
+                handles, tuple(values), title=values, handlelength=1.3, handleheight=1, loc="best"
             )
     
     return axes


### PR DESCRIPTION
This draft PR addresses issue #669 that adds additional logic in `_plot_cap_numeric()` of the `plot_cap` function to support indexing of N-dimensional `y_hat_bounds` to ensure `ax.fill_between()` works for $K$ outcome classes.

Before plotting begins in `_plot_cap_numeric()`, an additional variable `y_hat_bounds_dim = y_hat_bounds.ndim` is created to identify the number of dimensions. Then, when plotting is performed, an if / else statement is used to determine if `ndims > 2`. If yes, then we loop through each dimension and plot `ax.fill_between()`, else no for loop is needed. 

The added logic allows `ax.fill_between()` to scale to $K$ classes, but it requires copy and paste of the if / else statement for each `color` `panel` combination inside of `_plot_cap_numeric`. Which in my opinion is kind of ugly and doesn't adhere to DRY. But it works.

Below are a few examples. I also identified that the class names are not specified in the legend due to the fact that the legend currently only looks in the covariates for the unique names. 

To Do:
- [x] run tests
- [x] run black 
- [x] fix legend to display outcome variable class names

```python3
import arviz as az
import numpy as np
import pandas as pd
import matplotlib.pyplot as plt

import bambi as bmb
from bambi.plots import plot_cap

length = [
    1.3, 1.32, 1.32, 1.4, 1.42, 1.42, 1.47, 1.47, 1.5, 1.52, 1.63, 1.65, 1.65, 1.65, 1.65,
    1.68, 1.7, 1.73, 1.78, 1.78, 1.8, 1.85, 1.93, 1.93, 1.98, 2.03, 2.03, 2.31, 2.36, 2.46,
    3.25, 3.28, 3.33, 3.56, 3.58, 3.66, 3.68, 3.71, 3.89, 1.24, 1.3, 1.45, 1.45, 1.55, 1.6,
    1.6, 1.65, 1.78, 1.78, 1.8, 1.88, 2.16, 2.26, 2.31, 2.36, 2.39, 2.41, 2.44, 2.56, 2.67,
    2.72, 2.79, 2.84
]
choice = [
    "I", "F", "F", "F", "I", "F", "I", "F", "I", "I", "I", "O", "O", "I", "F", "F",
    "I", "O", "F", "O", "F", "F", "I", "F", "I", "F", "F", "F", "F", "F", "O", "O",
    "F", "F", "F", "F", "O", "F", "F", "I", "I", "I", "O", "I", "I", "I", "F", "I",
    "O", "I", "I", "F", "F", "F", "F", "F", "F", "F", "O", "F", "I", "F", "F"
]

sex = ["Male"] * 32 + ["Female"] * 31
data = pd.DataFrame({"choice": choice, "length": length, "sex": sex})
data["choice"]  = pd.Categorical(
    data["choice"].map({"I": "Invertebrates", "F": "Fish", "O": "Other"}),
    ["Other", "Invertebrates", "Fish"],
    ordered=True
)
```

```python3
fig, ax = plot_cap(
    model=model,
    idata=idata,
    covariates="length",
    pps=False,
    legend=True, # not working with response classes
)
fig.set_size_inches(7, 3)
```
![image](https://github.com/bambinos/bambi/assets/63432018/2995275d-33aa-4db6-8cc1-d6dec9300c66)

See there is no legend for class names. Making it hard to distinguish the lines.

```python3
fig, ax = plot_cap(
    model=model,
    idata=idata,
    covariates={"horizontal": "length", "color": "sex", "panel": "sex"},
    fig_kwargs={"figsize": (16, 5), "sharey": True},
    pps=False
);
```
![image](https://github.com/bambinos/bambi/assets/63432018/72843399-5318-4e72-b74a-aa4a49290565)

Again, there is no legend for class names. The legend correctly identifies the sex, but it would be more informative if the title was kept to the sex type and the legend indicated the class.