### PR TITLE
Update additional dependencies install command

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,13 +66,13 @@ Please reasonably document any additions or changes to the codebase, when in dou
 
    ```bash
    pip install -e .
-   pip install .[dev]
+   pip install '.[dev]'
    ```
 
    If you're going to develop futures related to JAX, install jax-related dependencies.
 
    ```bash
-   pip install .[jax]
+   pip install '.[jax]'
    ```
 
 1. Develop the feature on your feature branch. Add changed files using `git add` and then `git commit` files:


### PR DESCRIPTION
Was starting to do some development and ran into the following:

```bash
pip install .[dev]
zsh: no matches found: .[dev]
```

Found that adding the single quote around it resolved it, so updated the instructions accordingly:

```bash
pip install '.[dev]'
```

And similar for the jax dependencies.

I assume this is ubiquitous, but if it's just a zsh for some reason, feel free to disregard.