### PR TITLE
plot_slopes and slopes

### DIFF
--- a/bambi/plots/__init__.py
+++ b/bambi/plots/__init__.py
@@ -1,4 +1,4 @@
-from bambi.plots.effects import comparisons, slopes, predictions
+from bambi.plots.effects import comparisons, predictions, slopes
 from bambi.plots.plotting import plot_cap, plot_comparison, plot_slopes
 
 

--- a/bambi/plots/__init__.py
+++ b/bambi/plots/__init__.py
@@ -1,5 +1,5 @@
-from bambi.plots.effects import comparisons, predictions
-from bambi.plots.plotting import plot_cap, plot_comparison
+from bambi.plots.effects import comparisons, slopes, predictions
+from bambi.plots.plotting import plot_cap, plot_comparison, plot_slopes
 
 
-__all__ = ["comparisons", "predictions", "plot_cap", "plot_comparison"]
+__all__ = ["comparisons", "slopes", "predictions", "plot_cap", "plot_comparison", "plot_slopes"]

--- a/bambi/plots/create_data.py
+++ b/bambi/plots/create_data.py
@@ -16,97 +16,93 @@ from bambi.plots.utils import (
 )
 
 
+def _grid_level(
+    condition_info: ConditionalInfo, variable_info: VariableInfo, user_passed: bool, kind: str
+):
+    """
+    Creates a "grid" of data by using the covariates passed into the
+    `conditional` argument. Values for the grid are either: (1) computed
+    using a equally spaced grid, mean, and or mode (depending on the
+    covariate dtype), and (2) a user specified value or range of values.
+    """
+    covariates = get_covariates(condition_info.covariates)
+
+    if user_passed:
+        data_dict = {**condition_info.conditional}
+    else:
+        main_values = make_main_values(condition_info.model.data[covariates.main])
+        data_dict = {covariates.main: main_values}
+        data_dict = make_group_panel_values(
+            condition_info.model.data,
+            data_dict,
+            covariates.main,
+            covariates.group,
+            covariates.panel,
+            kind=kind,
+        )
+
+    data_dict[variable_info.name] = variable_info.values
+    comparison_data = set_default_values(condition_info.model, data_dict, kind=kind)
+    # use cartesian product (cross join) to create pairwise grid
+    keys, values = zip(*comparison_data.items())
+    pairwise_grid = pd.DataFrame([dict(zip(keys, v)) for v in itertools.product(*values)])
+    # cannot enfore dtypes if 'slopes' because it may remove floating point of dy/dx
+    if kind == "comparisons":
+        pairwise_grid = enforce_dtypes(condition_info.model.data, pairwise_grid)
+
+    return pairwise_grid
+
+
+def _unit_level(variable_info: VariableInfo, kind: str) -> pd.DataFrame:
+    """
+    Creates the data for unit-level contrasts by using the observed (empirical)
+    data. All covariates in the model are included in the data, except for the
+    contrast predictor. The contrast predictor is replaced with either: (1) the
+    default contrast value, or (2) the user specified contrast value.
+    """
+    covariates = get_model_covariates(variable_info.model)
+    df = variable_info.model.data[covariates].drop(labels=variable_info.name, axis=1)
+
+    variable_vals = variable_info.values
+
+    if kind == "comparisons":
+        variable_vals = np.array(variable_info.values)[..., None]
+        variable_vals = np.repeat(variable_vals, variable_info.model.data.shape[0], axis=1)
+
+    contrast_df_dict = {}
+    for idx, value in enumerate(variable_vals):
+        contrast_df_dict[f"contrast_{idx}"] = df.copy()
+        contrast_df_dict[f"contrast_{idx}"][variable_info.name] = value
+
+    return pd.concat(contrast_df_dict.values())
+
+
 def create_differences_data(
     condition_info: ConditionalInfo, variable_info: VariableInfo, user_passed: bool, kind: str
 ) -> pd.DataFrame:
-    def _grid_level():
-        """
-        Creates a "grid" of data by using the covariates passed into the
-        `conditional` argument. Values for the grid are either: (1) computed
-        using a equally spaced grid, mean, and or mode (depending on the
-        covariate dtype), and (2) a user specified value or range of values.
-        """
-        covariates = get_covariates(condition_info.covariates)
+    """
+    Creates either unit level or grid level data for 'comparisons' and 'slopes'
+    depending if the user passed covariate values.
+    """
 
-        if user_passed:
-            data_dict = {**condition_info.conditional}
-        else:
-            main_values = make_main_values(condition_info.model.data[covariates.main])
-            data_dict = {covariates.main: main_values}
-            data_dict = make_group_panel_values(
-                condition_info.model.data,
-                data_dict,
-                covariates.main,
-                covariates.group,
-                covariates.panel,
-                kind=kind,
-            )
-
-        data_dict[variable_info.name] = variable_info.values
-        comparison_data = set_default_values(condition_info.model, data_dict, kind=kind)
-        # use cartesian product (cross join) to create pairwise grid
-        keys, values = zip(*comparison_data.items())
-        pairwise_grid = pd.DataFrame([dict(zip(keys, v)) for v in itertools.product(*values)])
-
-        # cannot enfore dtypes if 'slopes' because it may remove floating point of dy/dx
-        if kind == "comparisons":
-            pairwise_grid = enforce_dtypes(condition_info.model.data, pairwise_grid)
-
-        return pairwise_grid
-
-    def _unit_level():
-        """
-        Creates the data for unit-level contrasts by using the observed (empirical)
-        data. All covariates in the model are included in the data, except for the
-        contrast predictor. The contrast predictor is replaced with either: (1) the
-        default contrast value, or (2) the user specified contrast value.
-        """
-        covariates = get_model_covariates(variable_info.model)
-        df = variable_info.model.data[covariates].drop(labels=variable_info.name, axis=1)
-
-        variable_vals = variable_info.values
-
-        if kind == "comparisons":
-            variable_vals = np.array(variable_info.values)[..., None]
-            variable_vals = np.repeat(variable_vals, variable_info.model.data.shape[0], axis=1)
-
-        contrast_df_dict = {}
-        for idx, value in enumerate(variable_vals):
-            contrast_df_dict[f"contrast_{idx}"] = df.copy()
-            contrast_df_dict[f"contrast_{idx}"][variable_info.name] = value
-
-        return pd.concat(contrast_df_dict.values())
-
-    return _unit_level() if not condition_info.covariates else _grid_level()
+    if not condition_info.covariates:
+        return _unit_level(variable_info, kind)
+    else:
+        return _grid_level(condition_info, variable_info, user_passed, kind)
 
 
 def create_cap_data(model: Model, covariates: dict) -> pd.DataFrame:
-    """Create data for a Conditional Adjusted Predictions
-
-    Parameters
-    ----------
-    model : bambi.Model
-        An instance of a Bambi model
-    covariates : dict
-        A dictionary of length between one and three.
-        Keys must be taken from ("horizontal", "color", "panel").
-        The values indicate the names of variables.
-
-    Returns
-    -------
-    pandas.DataFrame
-        The data for the Conditional Adjusted Predictions dataframe and or
-        plotting.
+    """
+    Creates a data grid for conditional adjusted predictions using the covariates
+    passed by the user.
     """
     data = model.data
     covariates = get_covariates(covariates)
     main, group, panel = covariates.main, covariates.group, covariates.panel
 
-    # Obtain data for main variable
     main_values = make_main_values(data[main])
     data_dict = {main: main_values}
 
-    # Obtain data for group and panel variables if not None
     data_dict = make_group_panel_values(data, data_dict, main, group, panel, kind="predictions")
     data_dict = set_default_values(model, data_dict, kind="predictions")
 

--- a/bambi/plots/create_data.py
+++ b/bambi/plots/create_data.py
@@ -6,14 +6,78 @@ import pandas as pd
 from bambi.models import Model
 from bambi.plots.utils import (
     ConditionalInfo,
-    ContrastInfo,
     enforce_dtypes,
     get_covariates,
     get_model_covariates,
     make_group_panel_values,
     make_main_values,
     set_default_values,
+    VariableInfo,
 )
+
+
+def create_differences_data(
+    condition_info: ConditionalInfo, variable_info: VariableInfo, user_passed: bool, kind: str
+) -> pd.DataFrame:
+    def _grid_level():
+        """
+        Creates a "grid" of data by using the covariates passed into the
+        `conditional` argument. Values for the grid are either: (1) computed
+        using a equally spaced grid, mean, and or mode (depending on the
+        covariate dtype), and (2) a user specified value or range of values.
+        """
+        covariates = get_covariates(condition_info.covariates)
+
+        if user_passed:
+            data_dict = {**condition_info.conditional}
+        else:
+            main_values = make_main_values(condition_info.model.data[covariates.main])
+            data_dict = {covariates.main: main_values}
+            data_dict = make_group_panel_values(
+                condition_info.model.data,
+                data_dict,
+                covariates.main,
+                covariates.group,
+                covariates.panel,
+                kind=kind,
+            )
+
+        data_dict[variable_info.name] = variable_info.values
+        comparison_data = set_default_values(condition_info.model, data_dict, kind=kind)
+        # use cartesian product (cross join) to create pairwise grid
+        keys, values = zip(*comparison_data.items())
+        pairwise_grid = pd.DataFrame([dict(zip(keys, v)) for v in itertools.product(*values)])
+
+        # cannot enfore dtypes if 'slopes' because it may remove floating point of dy/dx
+        if kind == "comparisons":
+            pairwise_grid = enforce_dtypes(condition_info.model.data, pairwise_grid)
+
+        return pairwise_grid
+
+    def _unit_level():
+        """
+        Creates the data for unit-level contrasts by using the observed (empirical)
+        data. All covariates in the model are included in the data, except for the
+        contrast predictor. The contrast predictor is replaced with either: (1) the
+        default contrast value, or (2) the user specified contrast value.
+        """
+        covariates = get_model_covariates(variable_info.model)
+        df = variable_info.model.data[covariates].drop(labels=variable_info.name, axis=1)
+
+        variable_vals = variable_info.values
+
+        if kind == "comparisons":
+            variable_vals = np.array(variable_info.values)[..., None]
+            variable_vals = np.repeat(variable_vals, variable_info.model.data.shape[0], axis=1)
+
+        contrast_df_dict = {}
+        for idx, value in enumerate(variable_vals):
+            contrast_df_dict[f"contrast_{idx}"] = df.copy()
+            contrast_df_dict[f"contrast_{idx}"][variable_info.name] = value
+
+        return pd.concat(contrast_df_dict.values())
+
+    return _unit_level() if not condition_info.covariates else _grid_level()
 
 
 def create_cap_data(model: Model, covariates: dict) -> pd.DataFrame:
@@ -45,85 +109,5 @@ def create_cap_data(model: Model, covariates: dict) -> pd.DataFrame:
     # Obtain data for group and panel variables if not None
     data_dict = make_group_panel_values(data, data_dict, main, group, panel, kind="predictions")
     data_dict = set_default_values(model, data_dict, kind="predictions")
+
     return enforce_dtypes(data, pd.DataFrame(data_dict))
-
-
-def create_comparisons_data(
-    condition: ConditionalInfo, contrast: ContrastInfo, user_passed: bool = False
-) -> pd.DataFrame:
-    """Create data for a Conditional Adjusted Comparisons
-
-    Parameters
-    ----------
-    condition: ConditionalInfo
-        A dataclass instance containing the model, contrast, and conditional
-        covariates to be used in the comparisons.
-    contrast: ContrastInfo
-        A dataclass instance containing the model, and contrast name and values.
-    user_passed: bool, optional
-        Whether the user passed their own 'conditional' data. Defaults to False.
-
-    Returns
-    -------
-    pd.DataFrame
-        The data for the Conditional Adjusted Comparisons dataframe and or
-        plotting.
-    """
-
-    def _grid_level(condition: ConditionalInfo, contrast: ContrastInfo):
-        """
-        Creates the data for grid-level contrasts by using the covariates passed
-        into the `conditional` arg. Values for the grid are either: (1) computed
-        using a equally spaced grid, mean, and or mode (depending on the covariate
-        dtype), and (2) a user specified value or range of values.
-        """
-        covariates = get_covariates(condition.covariates)
-
-        if user_passed:
-            data_dict = {**condition.conditional}
-        else:
-            main_values = make_main_values(condition.model.data[covariates.main])
-            data_dict = {covariates.main: main_values}
-            data_dict = make_group_panel_values(
-                condition.model.data,
-                data_dict,
-                covariates.main,
-                covariates.group,
-                covariates.panel,
-                kind="comparison",
-            )
-
-        data_dict[contrast.name] = contrast.values
-        comparison_data = set_default_values(condition.model, data_dict, kind="comparison")
-        # use cartesian product (cross join) to create contrasts
-        keys, values = zip(*comparison_data.items())
-        contrast_dict = [dict(zip(keys, v)) for v in itertools.product(*values)]
-
-        return enforce_dtypes(condition.model.data, pd.DataFrame(contrast_dict))
-
-    def _unit_level(contrast: ContrastInfo):
-        """
-        Creates the data for unit-level contrasts by using the observed (empirical)
-        data. All covariates in the model are included in the data, except for the
-        contrast predictor. The contrast predictor is replaced with either: (1) the
-        default contrast value, or (2) the user specified contrast value.
-        """
-        covariates = get_model_covariates(contrast.model)
-        df = contrast.model.data[covariates].drop(labels=contrast.name, axis=1)
-
-        contrast_vals = np.array(contrast.values)[..., None]
-        contrast_vals = np.repeat(contrast_vals, contrast.model.data.shape[0], axis=1)
-
-        contrast_df_dict = {}
-        for idx, value in enumerate(contrast_vals):
-            contrast_df_dict[f"contrast_{idx}"] = df.copy()
-            contrast_df_dict[f"contrast_{idx}"][contrast.name] = value
-
-        return pd.concat(contrast_df_dict.values())
-
-    if not condition.conditional:
-        df = _unit_level(contrast)
-    else:
-        df = _grid_level(condition, contrast)
-
-    return df

--- a/bambi/plots/create_data.py
+++ b/bambi/plots/create_data.py
@@ -46,9 +46,11 @@ def _grid_level(
     # use cartesian product (cross join) to create pairwise grid
     keys, values = zip(*comparison_data.items())
     pairwise_grid = pd.DataFrame([dict(zip(keys, v)) for v in itertools.product(*values)])
-    # cannot enfore dtypes if 'slopes' because it may remove floating point of dy/dx
+    # can't enforce dtype on numeric 'wrt' as it may remove floating point epsilons
     if kind == "comparisons":
         pairwise_grid = enforce_dtypes(condition_info.model.data, pairwise_grid)
+    elif kind == "slopes":
+        pairwise_grid = enforce_dtypes(condition_info.model.data, pairwise_grid, variable_info.name)
 
     return pairwise_grid
 

--- a/bambi/plots/effects.py
+++ b/bambi/plots/effects.py
@@ -280,7 +280,7 @@ class PredictiveDifferences:
 
     def average_by(self, variable: Union[bool, str]) -> pd.DataFrame:
         """
-        Uses the original 'summary_df' to perform a marginal (if 'variable=True') 
+        Uses the original 'summary_df' to perform a marginal (if 'variable=True')
         or group by average if covariate(s) are passed.
         """
         if variable is True:

--- a/bambi/plots/effects.py
+++ b/bambi/plots/effects.py
@@ -468,8 +468,9 @@ def comparisons(
     Raises
     ------
     ValueError
-        If length of ``contrast`` is greater than 1.
-        If length of ``contrast`` is greater than 2 and ``conditional`` is ``None``.
+        If `wrt` is a dict and length of ``contrast`` is greater than 1.
+        If `wrt` is a dict and length of ``contrast`` is greater than 2 and 
+        ``conditional`` is ``None``.
         If ``conditional`` is None and ``contrast`` is categorical with > 2 values.
         If ``comparison_type`` is not 'diff' or 'ratio'.
         If ``prob`` is not > 0 and < 1.

--- a/bambi/plots/effects.py
+++ b/bambi/plots/effects.py
@@ -595,6 +595,9 @@ def slopes(
             raise ValueError(f"Only one predictor can be passed to 'wrt'. {len(wrt)} were passed.")
         wrt_name = list(wrt.keys())[0]
 
+    if slope not in ("dydx", "dyex", "eyex", "eydx"):
+        raise ValueError("'slope' must be one of ('dydx', 'dyex', 'eyex', 'eydx')")
+
     if prob is None:
         prob = az.rcParams["stats.hdi_prob"]
     if not 0 < prob < 1:

--- a/bambi/plots/effects.py
+++ b/bambi/plots/effects.py
@@ -279,6 +279,10 @@ class PredictiveDifferences:
         return self.summary_df
 
     def average_by(self, variable: Union[bool, str]) -> pd.DataFrame:
+        """
+        Uses the original 'summary_df' to perform a marginal (if 'variable=True') 
+        or group by average if covariate(s) are passed.
+        """
         if variable is True:
             contrast_df_avg = average_over(self.summary_df, None)
             contrast_df_avg.insert(0, "term", self.variable.name)
@@ -566,6 +570,10 @@ def slopes(
         the response.
         'eyex' represents a percentage increase in 'wrt' is associated with an n-percent
         change in the response.
+        'eydx' represents a unit increase in 'wrt' is associated with an n-percent
+        change in the response.
+        'dyex' represents a percent change in 'wrt' is associated with a unit increase
+        in the response.
     use_hdi : bool, optional
         Whether to compute the highest density interval (defaults to True) or the quantiles.
     prob : float, optional
@@ -584,8 +592,9 @@ def slopes(
     Raises
     ------
     ValueError
-        If ``conditional`` is ``None`` and ``wrt`` is a dictionary.
+        If ``conditional`` is ``None`` and values are passed to ``wrt``.
         If length of ``wrt`` is greater than 1.
+        If ``slope`` is not 'dydx', 'dyex', 'eyex', or 'eydx'.
         If ``prob`` is not > 0 and < 1.
     """
     if conditional is None and isinstance(wrt, dict):

--- a/bambi/plots/effects.py
+++ b/bambi/plots/effects.py
@@ -132,7 +132,6 @@ class PredictiveDifferences:
         """
         Computes the slope estimate for 'dydx', 'dyex', 'eyex', 'eydx'.
         """
-
         predictive_difference = (predictive_difference / eps).rename(self.response.name_target)
 
         if slope in ("eyex", "dyex"):
@@ -239,11 +238,11 @@ class PredictiveDifferences:
         if len(self.variable.values) > 2 and self.kind == "comparisons":
             summary_df = self.preds_data.drop(columns=self.variable.name).drop_duplicates()
             covariates_cols = summary_df.columns
-            covariate_vals = np.tile(summary_df.T, len(self.variable.values))
-            summary_df = pd.DataFrame(data=covariate_vals.T, columns=covariates_cols)
             contrast_values = list(itertools.combinations(self.variable.values.flatten(), 2))
+            covariate_vals = np.tile(summary_df.T, len(contrast_values))
+            summary_df = pd.DataFrame(data=covariate_vals.T, columns=covariates_cols)
             contrast_values = np.repeat(
-                contrast_values, self.preds_data.shape[0] // len(contrast_values), axis=0
+                contrast_values, summary_df.shape[0] // len(contrast_values), axis=0
             )
             contrast_values = [tuple(elem) for elem in contrast_values]
         else:
@@ -287,13 +286,13 @@ class PredictiveDifferences:
             contrast_df_avg = average_over(self.summary_df, None)
             contrast_df_avg.insert(0, "term", self.variable.name)
             contrast_df_avg.insert(1, "estimate_type", self.estimate_name)
-            if self.kind != "slopes":
+            if self.kind != "slopes" and len(self.variable.values) < 3:
                 contrast_df_avg.insert(2, "value", self.contrast_values)
         else:
             contrast_df_avg = average_over(self.summary_df, variable)
             contrast_df_avg.insert(0, "term", self.variable.name)
             contrast_df_avg.insert(1, "estimate_type", self.estimate_name)
-            if self.kind != "slopes":
+            if self.kind != "slopes" and len(self.variable.values) < 3:
                 contrast_df_avg.insert(2, "value", self.contrast_values)
 
         return contrast_df_avg.reset_index(drop=True)
@@ -353,7 +352,6 @@ def predictions(
         If passed ``covariates`` is not in correct key, value format.
         If length of ``covariates`` is not between 1 and 3.
     """
-
     if pps and target != "mean":
         raise ValueError("When passing 'pps=True', target must be 'mean'")
 
@@ -475,7 +473,6 @@ def comparisons(
         If ``comparison_type`` is not 'diff' or 'ratio'.
         If ``prob`` is not > 0 and < 1.
     """
-
     if not isinstance(contrast, (dict, list, str)):
         raise ValueError("'contrast' must be a string, dictionary, or list.")
     if isinstance(contrast, (dict, list)):

--- a/bambi/plots/effects.py
+++ b/bambi/plots/effects.py
@@ -469,7 +469,7 @@ def comparisons(
     ------
     ValueError
         If `wrt` is a dict and length of ``contrast`` is greater than 1.
-        If `wrt` is a dict and length of ``contrast`` is greater than 2 and 
+        If `wrt` is a dict and length of ``contrast`` is greater than 2 and
         ``conditional`` is ``None``.
         If ``conditional`` is None and ``contrast`` is categorical with > 2 values.
         If ``comparison_type`` is not 'diff' or 'ratio'.

--- a/bambi/plots/plot_types.py
+++ b/bambi/plots/plot_types.py
@@ -46,7 +46,7 @@ def plot_numeric(
         ax = axes[0]
         values_main = transform_main(plot_data[main])
         ax.plot(values_main, y_hat_mean, solid_capstyle="butt", color="C0")
-        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.4)
+        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], color="C0", alpha=0.4)
     elif "group" in covariates and not "panel" in covariates:
         ax = axes[0]
         colors = get_unique_levels(plot_data[color])

--- a/bambi/plots/plot_types.py
+++ b/bambi/plots/plot_types.py
@@ -45,8 +45,8 @@ def plot_numeric(
     if len(covariates) == 1:
         ax = axes[0]
         values_main = transform_main(plot_data[main])
-        ax.plot(values_main, y_hat_mean, solid_capstyle="butt", color="C0")
-        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], color="C0", alpha=0.4)
+        ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
+        ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.4)
     elif "group" in covariates and not "panel" in covariates:
         ax = axes[0]
         colors = get_unique_levels(plot_data[color])
@@ -155,8 +155,8 @@ def plot_categoric(covariates: Covariates, plot_data: pd.DataFrame, legend: bool
 
     if len(covariates) == 1:
         ax = axes[0]
-        ax.scatter(idxs_main, y_hat_mean, color="C0")
-        ax.vlines(idxs_main, y_hat_bounds[0], y_hat_bounds[1], color="C0")
+        ax.scatter(idxs_main, y_hat_mean)
+        ax.vlines(idxs_main, y_hat_bounds[0], y_hat_bounds[1])
     elif "group" in covariates and not "panel" in covariates:
         ax = axes[0]
         for i, clr in enumerate(colors):

--- a/bambi/plots/plot_types.py
+++ b/bambi/plots/plot_types.py
@@ -45,7 +45,7 @@ def plot_numeric(
     if len(covariates) == 1:
         ax = axes[0]
         values_main = transform_main(plot_data[main])
-        ax.plot(values_main, y_hat_mean, solid_capstyle="butt")
+        ax.plot(values_main, y_hat_mean, solid_capstyle="butt", color="C0")
         ax.fill_between(values_main, y_hat_bounds[0], y_hat_bounds[1], alpha=0.4)
     elif "group" in covariates and not "panel" in covariates:
         ax = axes[0]
@@ -155,8 +155,8 @@ def plot_categoric(covariates: Covariates, plot_data: pd.DataFrame, legend: bool
 
     if len(covariates) == 1:
         ax = axes[0]
-        ax.scatter(idxs_main, y_hat_mean)
-        ax.vlines(idxs_main, y_hat_bounds[0], y_hat_bounds[1])
+        ax.scatter(idxs_main, y_hat_mean, color="C0")
+        ax.vlines(idxs_main, y_hat_bounds[0], y_hat_bounds[1], color="C0")
     elif "group" in covariates and not "panel" in covariates:
         ax = axes[0]
         for i, clr in enumerate(colors):

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -14,7 +14,7 @@ from bambi.plots.utils import get_covariates, ConditionalInfo
 from bambi.utils import get_aliased_name, listify
 
 
-def plot_differences(
+def _plot_differences(
     model: Model,
     conditional_info: ConditionalInfo,
     summary_df: pd.DataFrame,
@@ -319,7 +319,7 @@ def plot_comparison(
         transforms=transforms,
     )
 
-    return plot_differences(
+    return _plot_differences(
         model=model,
         conditional_info=conditional_info,
         summary_df=contrast_summary,
@@ -348,7 +348,7 @@ def plot_slopes(
     fig_kwargs=None,
     subplot_kwargs=None,
 ):
-    """Plot Conditional Adjusted Comparisons
+    """Plot Conditional Adjusted Slopes
 
     Parameters
     ----------
@@ -357,15 +357,24 @@ def plot_slopes(
     idata : arviz.InferenceData
         The InferenceData object that contains the samples from the posterior distribution of
         the model.
-    contrast : str, dict, list
-        The predictor name whose contrast we would like to compare.
+    wrt : str, dict
+        The slope of the regression with respect to (wrt) this predictor will be computed.
+        If 'wrt' is numeric, the derivative is computed, else if string or categorical,
+        'comparisons' is called to compute difference in group means.
     conditional : str, dict, list
         The covariates we would like to condition on.
-    average_by: str, list, optional
+    average_by: str, list, bool, optional
         The covariates we would like to average by. The passed covariate(s) will marginalize
-        over the other covariates in the model. Defaults to ``None``.
-    comparison_type : str, optional
-        The type of comparison to plot. Defaults to 'diff'.
+        over the other covariates in the model. If True, it averages over all covariates
+        in the model to obtain the average estimate. Defaults to ``None``.
+    eps : float, optional
+        To compute the slope, 'wrt' is evaluated at wrt +/- 'eps'. The rate of change is then
+        computed as the difference between the two values divided by 'eps'. Defaults to 1e-4.
+    slope: str, optional
+        The type of slope to compute. Defaults to 'dydx'.
+        'dydx' represents a unit increase in 'wrt' is associated with an n-unit change in the response.
+        'eyex' represents a percentage increase in 'wrt' is associated with an n-percent change in
+        the response.
     use_hdi : bool, optional
         Whether to compute the highest density interval (defaults to True) or the quantiles.
     prob : float, optional
@@ -423,7 +432,7 @@ def plot_slopes(
     if average_by is True:
         raise ValueError(
             "Plotting when 'average_by = True' is not possible as 'True' marginalizes "
-            "over all covariates resulting in a single 'dy/dx' estimate. "
+            "over all covariates resulting in a single slope estimate. "
             "Please specify a covariate(s) to 'average_by'."
         )
 
@@ -445,7 +454,7 @@ def plot_slopes(
         transforms=transforms,
     )
 
-    return plot_differences(
+    return _plot_differences(
         model=model,
         conditional_info=conditional_info,
         summary_df=slopes_summary,

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -410,7 +410,7 @@ def plot_slopes(
     Raises
     ------
     ValueError
-        If number of values passed with ``conditional`` is >= 2 and 
+        If number of values passed with ``conditional`` is >= 2 and
         ``average_by`` are both ``None``.
         If ``conditional`` and ``average_by`` are both ``None``.
         If length of ``conditional`` is greater than 3 and ``average_by`` is ``None``.

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -281,8 +281,31 @@ def plot_comparison(
     Warning
         If length of ``contrast`` is greater than 2.
     """
+    contrast_name = contrast
+    if isinstance(contrast, dict):
+        contrast_name, contrast_levels = next(iter(contrast.items()))
+        if len(contrast_levels) > 2 and average_by is None:
+            raise ValueError(
+                "When plotting with more than 2 values for 'contrast', you must "
+                "pass a covariate to 'average_by'. "
+                f"{contrast_name} has {len(contrast_levels)} values."
+            )
+
+    if not isinstance(contrast, dict):
+        if is_categorical_dtype(model.data[contrast_name]) or is_string_dtype(
+            model.data[contrast_name]
+        ):
+            contrast_levels = len(model.data[contrast_name].unique())
+            if contrast_levels > 2 and average_by is None:
+                raise ValueError(
+                    "When plotting with more than 2 values for 'contrast', you must "
+                    f"pass a covariate to 'average_by'. {contrast_name} has "
+                    f"{contrast_levels} values."
+                )
+
     if conditional is None and average_by is None:
         raise ValueError("Must specify at least one of 'conditional' or 'average_by'.")
+
     if conditional is not None:
         if not isinstance(conditional, str):
             if len(conditional) > 3 and average_by is None:
@@ -296,15 +319,6 @@ def plot_comparison(
             "over all covariates resulting in a single comparison estimate. "
             "Please specify a covariate(s) to 'average_by'."
         )
-
-    if isinstance(contrast, dict):
-        contrast_name, contrast_level = next(iter(contrast.items()))
-        if len(contrast_level) > 2 and average_by is None:
-            raise ValueError(
-                "When plotting with more than 2 values for 'contrast', you must "
-                "pass a covariate to 'average_by'. "
-                f"{contrast_name} has {len(contrast_level)} values."
-            )
 
     conditional_info = ConditionalInfo(model, conditional)
 
@@ -417,22 +431,31 @@ def plot_slopes(
         If length of ``conditional`` is greater than 3 and ``average_by`` is ``None``.
         If ``slope`` is not one of ('dydx', 'dyex', 'eyex', 'eydx').
     """
+    wrt_name = wrt
     if isinstance(wrt, dict):
         wrt_name, wrt_value = next(iter(wrt.items()))
+
         if not isinstance(wrt_value, (list, np.ndarray)):
             wrt_value = [wrt_value]
 
-        if not is_categorical_dtype(model.data[wrt_name]) or not is_string_dtype(
-            model.data[wrt_name]
-        ):
-            if len(wrt_value) >= 2 and average_by is None:
+        if len(wrt_value) > 2 and average_by is None:
+            raise ValueError(
+                "When plotting with more than 2 values for 'wrt', you must "
+                "pass a covariate to 'average_by'"
+            )
+
+    if not isinstance(wrt, dict):
+        if is_categorical_dtype(model.data[wrt_name]) or is_string_dtype(model.data[wrt_name]):
+            num_values = len(model.data[wrt_name].unique())
+            if num_values > 2 and average_by is None:
                 raise ValueError(
                     "When plotting with more than 2 values for 'wrt', you must "
-                    "pass a covariate to 'average_by'"
+                    f"pass a covariate to 'average_by'. {wrt_name} has {num_values} values."
                 )
 
     if conditional is None and average_by is None:
         raise ValueError("Must specify at least one of 'conditional' or 'average_by'.")
+
     if conditional is not None:
         if not isinstance(conditional, str):
             if len(conditional) > 3 and average_by is None:

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -372,20 +372,24 @@ def plot_slopes(
         computed as the difference between the two values divided by 'eps'. Defaults to 1e-4.
     slope: str, optional
         The type of slope to compute. Defaults to 'dydx'.
-        'dydx' represents a unit increase in 'wrt' is associated with an n-unit change in the
-        response.
-        'eyex' represents a percentage increase in 'wrt' is associated with an n-percent change in
+        'dydx' represents a unit increase in 'wrt' is associated with an n-unit change in
         the response.
+        'eyex' represents a percentage increase in 'wrt' is associated with an n-percent
+        change in the response.
+        'eydx' represents a unit increase in 'wrt' is associated with an n-percent
+        change in the response.
+        'dyex' represents a percent change in 'wrt' is associated with a unit increase
+        in the response.
     use_hdi : bool, optional
         Whether to compute the highest density interval (defaults to True) or the quantiles.
     prob : float, optional
         The probability for the credibility intervals. Must be between 0 and 1. Defaults to 0.94.
         Changing the global variable ``az.rcParam["stats.hdi_prob"]`` affects this default.
-    legend : bool, optional
-        Whether to automatically include a legend in the plot. Defaults to ``True``.
     transforms : dict, optional
         Transformations that are applied to each of the variables being plotted. The keys are the
         name of the variables, and the values are functions to be applied. Defaults to ``None``.
+    legend : bool, optional
+        Whether to automatically include a legend in the plot. Defaults to ``True``.
     ax : matplotlib.axes._subplots.AxesSubplot, optional
         A matplotlib axes object or a sequence of them. If None, this function instantiates a
         new axes object. Defaults to ``None``.
@@ -406,11 +410,11 @@ def plot_slopes(
     Raises
     ------
     ValueError
+        If number of values passed with ``conditional`` is >= 2 and 
+        ``average_by`` are both ``None``.
         If ``conditional`` and ``average_by`` are both ``None``.
         If length of ``conditional`` is greater than 3 and ``average_by`` is ``None``.
-
-    Warning
-        If length of ``contrast`` is greater than 2.
+        If ``slope`` is not one of ('dydx', 'dyex', 'eyex', 'eydx').
     """
     if isinstance(wrt, dict):
         contrast_level = next(iter(wrt.values()))

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -413,11 +413,13 @@ def plot_slopes(
         If length of ``contrast`` is greater than 2.
     """
     if isinstance(wrt, dict):
-        contrast_name, contrast_level = next(iter(wrt.items()))
-        if len(contrast_level) > 2:
+        contrast_level = next(iter(wrt.values()))
+        if not isinstance(contrast_level, (list, np.ndarray)):
+            contrast_level = [contrast_level]
+        if len(contrast_level) >= 2 and average_by is None:
             raise ValueError(
-                f"Plotting when 'wrt' has > 2 values is not supported. "
-                f"{contrast_name} has {len(contrast_level)} values."
+                "When plotting with more than 2 values for 'wrt', you must "
+                "pass a covariate to 'average_by'"
             )
 
     if conditional is None and average_by is None:

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -372,7 +372,8 @@ def plot_slopes(
         computed as the difference between the two values divided by 'eps'. Defaults to 1e-4.
     slope: str, optional
         The type of slope to compute. Defaults to 'dydx'.
-        'dydx' represents a unit increase in 'wrt' is associated with an n-unit change in the response.
+        'dydx' represents a unit increase in 'wrt' is associated with an n-unit change in the
+        response.
         'eyex' represents a percentage increase in 'wrt' is associated with an n-percent change in
         the response.
     use_hdi : bool, optional
@@ -436,8 +437,8 @@ def plot_slopes(
             "Please specify a covariate(s) to 'average_by'."
         )
 
-    if slope not in ("dydx", "eyex"):
-        raise ValueError("'slope' must be one of ('dydx', 'eyex')")
+    if slope not in ("dydx", "dyex", "eyex", "eydx"):
+        raise ValueError("'slope' must be one of ('dydx', 'dyex', 'eyex', 'eydx')")
 
     conditional_info = ConditionalInfo(model, conditional)
 

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -26,7 +26,7 @@ def _plot_differences(
     subplot_kwargs=None,
 ):
     """
-    Common function used for both ``plot_comparisons`` and ``plot_slopes``
+    Common function used for both 'plot_comparisons' and 'plot_slopes'.
     """
 
     if (subplot_kwargs and not average_by) or (subplot_kwargs and average_by):

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -299,9 +299,10 @@ def plot_comparison(
 
     if isinstance(contrast, dict):
         contrast_name, contrast_level = next(iter(contrast.items()))
-        if len(contrast_level) > 2:
+        if len(contrast_level) > 2 and average_by is None:
             raise ValueError(
-                f"Plotting when 'contrast' has > 2 values is not supported. "
+                "When plotting with more than 2 values for 'contrast', you must "
+                "pass a covariate to 'average_by'. "
                 f"{contrast_name} has {len(contrast_level)} values."
             )
 
@@ -417,14 +418,18 @@ def plot_slopes(
         If ``slope`` is not one of ('dydx', 'dyex', 'eyex', 'eydx').
     """
     if isinstance(wrt, dict):
-        contrast_level = next(iter(wrt.values()))
-        if not isinstance(contrast_level, (list, np.ndarray)):
-            contrast_level = [contrast_level]
-        if len(contrast_level) >= 2 and average_by is None:
-            raise ValueError(
-                "When plotting with more than 2 values for 'wrt', you must "
-                "pass a covariate to 'average_by'"
-            )
+        wrt_name, wrt_value = next(iter(wrt.items()))
+        if not isinstance(wrt_value, (list, np.ndarray)):
+            wrt_value = [wrt_value]
+
+        if not is_categorical_dtype(model.data[wrt_name]) or not is_string_dtype(
+            model.data[wrt_name]
+        ):
+            if len(wrt_value) >= 2 and average_by is None:
+                raise ValueError(
+                    "When plotting with more than 2 values for 'wrt', you must "
+                    "pass a covariate to 'average_by'"
+                )
 
     if conditional is None and average_by is None:
         raise ValueError("Must specify at least one of 'conditional' or 'average_by'.")

--- a/bambi/plots/plotting.py
+++ b/bambi/plots/plotting.py
@@ -1,19 +1,84 @@
-# pylint: disable = protected-access
-# pylint: disable = too-many-function-args
-# pylint: disable = too-many-nested-blocks
 from typing import Union
 
 import arviz as az
 from arviz.plots.backends.matplotlib import create_axes_grid
 from arviz.plots.plot_utils import default_grid
 import numpy as np
+import pandas as pd
 from pandas.api.types import is_categorical_dtype, is_numeric_dtype, is_string_dtype
 
 from bambi.models import Model
-from bambi.plots.effects import comparisons, predictions
+from bambi.plots.effects import comparisons, slopes, predictions
 from bambi.plots.plot_types import plot_categoric, plot_numeric
 from bambi.plots.utils import get_covariates, ConditionalInfo
 from bambi.utils import get_aliased_name, listify
+
+
+def plot_differences(
+    model: Model,
+    conditional_info: ConditionalInfo,
+    summary_df: pd.DataFrame,
+    average_by: Union[str, list] = None,
+    transforms=None,
+    legend: bool = True,
+    ax=None,
+    fig_kwargs=None,
+    subplot_kwargs=None,
+):
+    """
+    Common function used for both ``plot_comparisons`` and ``plot_slopes``
+    """
+
+    if (subplot_kwargs and not average_by) or (subplot_kwargs and average_by):
+        for key, value in subplot_kwargs.items():
+            conditional_info.covariates.update({key: value})
+        covariates = get_covariates(conditional_info.covariates)
+    elif average_by and not subplot_kwargs:
+        if not isinstance(average_by, list):
+            average_by = listify(average_by)
+        covariate_kinds = ("main", "group", "panel")
+        average_by = dict(zip(covariate_kinds, average_by))
+        covariates = get_covariates(average_by)
+    else:
+        covariates = get_covariates(conditional_info.covariates)
+
+    if transforms is None:
+        transforms = {}
+
+    response_name = get_aliased_name(model.response_component.response_term)
+
+    if ax is None:
+        fig_kwargs = {} if fig_kwargs is None else fig_kwargs
+        panels_n = len(np.unique(summary_df[covariates.panel])) if covariates.panel else 1
+        rows, cols = default_grid(panels_n)
+        fig, axes = create_axes_grid(panels_n, rows, cols, backend_kwargs=fig_kwargs)
+        axes = np.atleast_1d(axes)
+    else:
+        axes = np.atleast_1d(ax)
+        if isinstance(axes[0], np.ndarray):
+            fig = axes[0][0].get_figure()
+        else:
+            fig = axes[0].get_figure()
+
+    if is_numeric_dtype(summary_df[covariates.main]):
+        # main condition variable can be numeric but at the same time only
+        # a few values, so it is treated as categoric
+        if np.unique(summary_df[covariates.main]).shape[0] <= 5:
+            axes = plot_categoric(covariates, summary_df, legend, axes)
+        else:
+            axes = plot_numeric(covariates, summary_df, transforms, legend, axes)
+    elif is_categorical_dtype(summary_df[covariates.main]) or is_string_dtype(
+        summary_df[covariates.main]
+    ):
+        axes = plot_categoric(covariates, summary_df, legend, axes)
+    else:
+        raise TypeError("Main covariate must be numeric or categoric.")
+
+    response_name = get_aliased_name(model.response_component.response_term)
+    for ax in axes.ravel():  # pylint: disable = redefined-argument-from-local
+        ax.set(xlabel=covariates.main, ylabel=response_name)
+
+    return fig, axes
 
 
 def plot_cap(
@@ -225,7 +290,6 @@ def plot_comparison(
                     "Must specify a covariate to 'average_by' when number of covariates"
                     "passed to 'conditional' is greater than 3."
                 )
-
     if average_by is True:
         raise ValueError(
             "Plotting when 'average_by = True' is not possible as 'True' marginalizes "
@@ -241,7 +305,9 @@ def plot_comparison(
                 f"{contrast_name} has {len(contrast_level)} values."
             )
 
-    contrast_df = comparisons(
+    conditional_info = ConditionalInfo(model, conditional)
+
+    contrast_summary = comparisons(
         model=model,
         idata=idata,
         contrast=contrast,
@@ -253,55 +319,140 @@ def plot_comparison(
         transforms=transforms,
     )
 
+    return plot_differences(
+        model=model,
+        conditional_info=conditional_info,
+        summary_df=contrast_summary,
+        average_by=average_by,
+        transforms=transforms,
+        legend=legend,
+        ax=ax,
+        fig_kwargs=fig_kwargs,
+        subplot_kwargs=subplot_kwargs,
+    )
+
+
+def plot_slopes(
+    model: Model,
+    idata: az.InferenceData,
+    wrt: Union[str, dict],
+    conditional: Union[str, dict, list, None] = None,
+    average_by: Union[str, list] = None,
+    eps: float = 1e-4,
+    slope: str = "dydx",
+    use_hdi: bool = True,
+    prob=None,
+    transforms=None,
+    legend: bool = True,
+    ax=None,
+    fig_kwargs=None,
+    subplot_kwargs=None,
+):
+    """Plot Conditional Adjusted Comparisons
+
+    Parameters
+    ----------
+    model : bambi.Model
+        The model for which we want to plot the predictions.
+    idata : arviz.InferenceData
+        The InferenceData object that contains the samples from the posterior distribution of
+        the model.
+    contrast : str, dict, list
+        The predictor name whose contrast we would like to compare.
+    conditional : str, dict, list
+        The covariates we would like to condition on.
+    average_by: str, list, optional
+        The covariates we would like to average by. The passed covariate(s) will marginalize
+        over the other covariates in the model. Defaults to ``None``.
+    comparison_type : str, optional
+        The type of comparison to plot. Defaults to 'diff'.
+    use_hdi : bool, optional
+        Whether to compute the highest density interval (defaults to True) or the quantiles.
+    prob : float, optional
+        The probability for the credibility intervals. Must be between 0 and 1. Defaults to 0.94.
+        Changing the global variable ``az.rcParam["stats.hdi_prob"]`` affects this default.
+    legend : bool, optional
+        Whether to automatically include a legend in the plot. Defaults to ``True``.
+    transforms : dict, optional
+        Transformations that are applied to each of the variables being plotted. The keys are the
+        name of the variables, and the values are functions to be applied. Defaults to ``None``.
+    ax : matplotlib.axes._subplots.AxesSubplot, optional
+        A matplotlib axes object or a sequence of them. If None, this function instantiates a
+        new axes object. Defaults to ``None``.
+    fig_kwargs : optional
+        Keyword arguments passed to the matplotlib figure function as a dict. For example,
+        ``fig_kwargs=dict(figsize=(11, 8)), sharey=True`` would make the figure 11 inches wide
+        by 8 inches high and would share the y-axis values.
+    subplot_kwargs : optional
+        Keyword arguments used to determine the covariates used for the horizontal, group,
+        and panel axes. For example, ``subplot_kwargs=dict(main="x", group="y", panel="z")`` would
+        plot the horizontal axis as ``x``, the color (hue) as ``y``, and the panel axis as ``z``.
+
+    Returns
+    -------
+    matplotlib.figure.Figure, matplotlib.axes._subplots.AxesSubplot
+        A tuple with the figure and the axes.
+
+    Raises
+    ------
+    ValueError
+        If ``conditional`` and ``average_by`` are both ``None``.
+        If length of ``conditional`` is greater than 3 and ``average_by`` is ``None``.
+
+    Warning
+        If length of ``contrast`` is greater than 2.
+    """
+    if isinstance(wrt, dict):
+        contrast_name, contrast_level = next(iter(wrt.items()))
+        if len(contrast_level) > 2:
+            raise ValueError(
+                f"Plotting when 'wrt' has > 2 values is not supported. "
+                f"{contrast_name} has {len(contrast_level)} values."
+            )
+
+    if conditional is None and average_by is None:
+        raise ValueError("Must specify at least one of 'conditional' or 'average_by'.")
+    if conditional is not None:
+        if not isinstance(conditional, str):
+            if len(conditional) > 3 and average_by is None:
+                raise ValueError(
+                    "Must specify a covariate to 'average_by' when number of covariates"
+                    "passed to 'conditional' is greater than 3."
+                )
+
+    if average_by is True:
+        raise ValueError(
+            "Plotting when 'average_by = True' is not possible as 'True' marginalizes "
+            "over all covariates resulting in a single 'dy/dx' estimate. "
+            "Please specify a covariate(s) to 'average_by'."
+        )
+
+    if slope not in ("dydx", "eyex"):
+        raise ValueError("'slope' must be one of ('dydx', 'eyex')")
+
     conditional_info = ConditionalInfo(model, conditional)
 
-    if (subplot_kwargs and not average_by) or (subplot_kwargs and average_by):
-        for key, value in subplot_kwargs.items():
-            conditional_info.covariates.update({key: value})
-        covariates = get_covariates(conditional_info.covariates)
-    elif average_by and not subplot_kwargs:
-        if not isinstance(average_by, list):
-            average_by = listify(average_by)
-        covariate_kinds = ("main", "group", "panel")
-        average_by = dict(zip(covariate_kinds, average_by))
-        covariates = get_covariates(average_by)
-    else:
-        covariates = get_covariates(conditional_info.covariates)
+    slopes_summary = slopes(
+        model=model,
+        idata=idata,
+        wrt=wrt,
+        conditional=conditional,
+        average_by=average_by,
+        eps=eps,
+        slope=slope,
+        use_hdi=use_hdi,
+        prob=prob,
+        transforms=transforms,
+    )
 
-    if transforms is None:
-        transforms = {}
-
-    response_name = get_aliased_name(model.response_component.response_term)
-
-    if ax is None:
-        fig_kwargs = {} if fig_kwargs is None else fig_kwargs
-        panels_n = len(np.unique(contrast_df[covariates.panel])) if covariates.panel else 1
-        rows, cols = default_grid(panels_n)
-        fig, axes = create_axes_grid(panels_n, rows, cols, backend_kwargs=fig_kwargs)
-        axes = np.atleast_1d(axes)
-    else:
-        axes = np.atleast_1d(ax)
-        if isinstance(axes[0], np.ndarray):
-            fig = axes[0][0].get_figure()
-        else:
-            fig = axes[0].get_figure()
-
-    if is_numeric_dtype(contrast_df[covariates.main]):
-        # main condition variable can be numeric but at the same time only
-        # a few values, so it is treated as categoric
-        if np.unique(contrast_df[covariates.main]).shape[0] <= 5:
-            axes = plot_categoric(covariates, contrast_df, legend, axes)
-        else:
-            axes = plot_numeric(covariates, contrast_df, transforms, legend, axes)
-    elif is_categorical_dtype(contrast_df[covariates.main]) or is_string_dtype(
-        contrast_df[covariates.main]
-    ):
-        axes = plot_categoric(covariates, contrast_df, legend, axes)
-    else:
-        raise TypeError("Main covariate must be numeric or categoric.")
-
-    response_name = get_aliased_name(model.response_component.response_term)
-    for ax in axes.ravel():  # pylint: disable = redefined-argument-from-local
-        ax.set(xlabel=covariates.main, ylabel=response_name)
-
-    return fig, axes
+    return plot_differences(
+        model=model,
+        conditional_info=conditional_info,
+        summary_df=slopes_summary,
+        average_by=average_by,
+        transforms=transforms,
+        legend=legend,
+        ax=ax,
+        fig_kwargs=fig_kwargs,
+        subplot_kwargs=subplot_kwargs,
+    )

--- a/bambi/plots/utils.py
+++ b/bambi/plots/utils.py
@@ -1,4 +1,5 @@
 # pylint: disable = too-many-function-args
+# pylint: disable = too-many-nested-blocks
 from dataclasses import dataclass, field
 from statistics import mode
 from typing import Union
@@ -26,7 +27,7 @@ class VariableInfo:
 
     def __post_init__(self):
         """
-        Post init method that sets the name and values attributes based on the
+        Post init that sets the name and values attributes based on the
         the effect type (i.e., slopes or comparisons), if the user provided their
         own values, and dtype of the variable
         """
@@ -76,7 +77,6 @@ class VariableInfo:
                                 elif self.kind == "comparisons":
                                     values = self.centered_difference(predictor_data, self.eps)
                                     values = values.astype(dtype)
-
                             elif component.kind == "categoric":
                                 values = get_unique_levels(predictor_data)
 
@@ -244,7 +244,7 @@ def make_group_panel_values(
                 group_values = np.tile(np.repeat(group_values, main_n), panel_n)
                 panel_values = np.repeat(panel_values, main_n * group_n)
                 data_dict.update({main: main_values, group: group_values, panel: panel_values})
-    elif kind == "comparisons" or kind == "slopes":
+    elif kind in ("comparisons", "slopes"):
         # for comparisons and slopes, we need unique values for numeric and categorical
         # group/panel covariates since we iterate over pairwise combinations of values
         if group and not panel:
@@ -260,11 +260,11 @@ def set_default_values(model: Model, data_dict: dict, kind: str):
     Set default values for each variable in the model if the user did not
     pass them in the data_dict.
     """
-    assert kind in [
+    assert kind in (
         "comparisons",
         "predictions",
         "slopes",
-    ], "kind must be either 'comparisons', 'slopes', or 'predictions'"
+    ), "kind must be either 'comparisons', 'slopes', or 'predictions'"
 
     terms = get_model_terms(model)
 
@@ -286,7 +286,7 @@ def set_default_values(model: Model, data_dict: dict, kind: str):
                         elif component.kind == "categoric":
                             data_dict[name] = mode(model.data[name])
 
-    if kind == "comparisons" or kind == "slopes":
+    if kind in ("comparisons", "slopes"):
         # if value in dict is not a list then convert to a list
         for key, value in data_dict.items():
             if not isinstance(value, (list, np.ndarray)):

--- a/bambi/plots/utils.py
+++ b/bambi/plots/utils.py
@@ -15,10 +15,40 @@ from bambi.utils import listify
 
 @dataclass
 class VariableInfo:
+    """
+    Stores information about the variable (covariate) passed into the 'contrast'
+    or 'wrt' argument for comparisons and slopes. Depending on the effect type
+    ('slopes' or 'comparisons'), the values attribute is either: (1) the values
+    passed with the 'contrast' or 'wrt' argument, or (2) default are values
+    computed by calling 'set_default_variable_values()'.
+
+    'VariableInfo' is used to create 'slopes' and 'comparisons' data as well as
+    computing the estimates for the 'slopes' and 'comparisons' effects.
+
+    Parameters
+    ----------
+    model : Model
+        The bambi Model object.
+    variable : str, dict, or list
+        The variable of interest passed by the user. `contrast` if 'comparisons'
+        and `wrt` if 'slopes'.
+    kind : str
+        The effect type. Either 'slopes' or 'comparisons'.
+    grid : bool or None, optional
+        Whether a grid of pairwise values should be used as the data for generating
+        predictions. Defaults to False.
+    eps : float or None, optional
+        The epsilon value used to add to the variable of interest's values when
+        computing the 'slopes' effect. Defualts to None.
+    user_passed : bool, optional
+        Whether the user passed their own values for the variable of interest.
+        Defaults to False.
+    """
+
     model: Model
     variable: Union[str, dict, list]
     kind: str
-    grid: Union[bool, None] = None
+    grid: Union[bool, None] = False
     eps: Union[float, None] = None
     user_passed: bool = False
     name: str = field(init=False)
@@ -27,9 +57,9 @@ class VariableInfo:
 
     def __post_init__(self):
         """
-        Post init that sets the name and values attributes based on the
-        the effect type (i.e., slopes or comparisons), if the user provided their
-        own values, and dtype of the variable
+        Sets the name and values attributes based on the the effect type
+        ('slopes' or 'comparisons'), if the user provided their own values,
+        and dtype of the 'variable'.
         """
         if isinstance(self.variable, dict):
             self.user_passed = True
@@ -48,19 +78,33 @@ class VariableInfo:
         elif not isinstance(self.variable, (list, dict, str)):
             raise TypeError("`variable` must be a list, dict, or string")
 
-    def centered_difference(self, x, eps, dtype):
+    def centered_difference(self, x, eps, dtype) -> np.ndarray:
         return np.array([x - eps, x + eps], dtype=dtype)
 
-    def epsilon_difference(self, x, eps):
+    def epsilon_difference(self, x, eps) -> np.ndarray:
         return np.array([x, x + eps])
 
-    def set_default_variable_values(self):
+    def set_default_variable_values(self) -> np.ndarray:
+        """
+        Returns default values for the variable of interest ('contrast' and 'wrt')
+        for the 'slopes' and 'comparisons' effects depending on the dtype of the
+        variable of interest, effect type, and if self.grid is True. The scenarios
+        are described below:
+
+        If numeric dtype and kind is 'comparisons', the returned value is a
+        centered difference based on the mean of `variable'.
+
+        If numeric dtype and kind is 'slopes', the returned value is an epsilon
+        difference based on the mean of `variable'.
+
+        If categoric dtype the returned value is the unique levels of `variable'.
+        """
         terms = get_model_terms(self.model)
-        # Get default values for each variable in the model
+        # get default values for each variable in the model
         for term in terms.values():
             if hasattr(term, "components"):
                 for component in term.components:
-                    # If the component is a function call, use the argument names
+                    # if the component is a function call, use the argument names
                     if isinstance(component, Call):
                         names = [arg.name for arg in component.call.args]
                     else:
@@ -86,6 +130,21 @@ class VariableInfo:
 
 @dataclass
 class ConditionalInfo:
+    """
+    Stores information about the conditional (covariates) passed into the
+    'conditional' argument for 'comparisons' and 'slopes' effects.
+
+    'ConditionalInfo' is used to create 'slopes' and 'comparisons' data as well
+    as computing the estimates for the 'slopes' and 'comparisons' effects.
+
+    Parameters
+    ----------
+    model : bambi.Model
+        The bambi model object.
+    conditional : str, dict, or list
+        The covariate(s) specified by the user to condition on.
+    """
+
     model: Model
     conditional: Union[str, dict, list]
     covariates: dict = field(init=False)
@@ -103,13 +162,17 @@ class ConditionalInfo:
             self.covariates = dict(zip(covariate_kinds, self.covariates))
             self.user_passed = False
         elif isinstance(self.conditional, dict):
-            self.covariates = {k: listify(v) for k, v in self.conditional.items()}
             self.covariates = dict(zip(covariate_kinds, self.conditional))
             self.user_passed = True
 
 
 @dataclass
 class Covariates:
+    """
+    Stores the 'main', 'group', and 'panel' covariates from the 'conditional'
+    argument in 'slopes' and 'comparisons'.
+    """
+
     main: str
     group: Union[str, None]
     panel: Union[str, None]
@@ -142,7 +205,7 @@ def get_model_terms(model: Model) -> dict:
     return terms
 
 
-def get_model_covariates(model: Model):
+def get_model_covariates(model: Model) -> np.ndarray:
     """
     Return covariates specified in the model.
     """
@@ -256,7 +319,7 @@ def make_group_panel_values(
     return data_dict
 
 
-def set_default_values(model: Model, data_dict: dict, kind: str):
+def set_default_values(model: Model, data_dict: dict, kind: str) -> dict:
     """
     Set default values for each variable in the model if the user did not
     pass them in the data_dict.
@@ -293,13 +356,13 @@ def set_default_values(model: Model, data_dict: dict, kind: str):
             if not isinstance(value, (list, np.ndarray)):
                 data_dict[key] = [value]
         return data_dict
-    # elif kind == "predictions":
+
     return data_dict
 
 
 def make_main_values(x: np.ndarray, grid_n: int = 50) -> np.ndarray:
     """
-    Compuet main values based on original data using a grid of evenly spaced
+    Compute main values based on original data using a grid of evenly spaced
     values for numeric predictors and unique levels for categoric predictors.
     """
     if is_numeric_dtype(x):


### PR DESCRIPTION
This draft PR introduces `slopes` and `plot_slopes`. Slopes can be defined as the "partial derivative of the regression equation with respect to (wrt) a regressor of interest" (definition taken from [marginaleffects](https://vincentarelbundock.github.io/marginaleffects/articles/slopes.html)). `slopes` and `plot_slopes` allow the user to view a summary dataframe and or plot the slope of the regressor of interest (wrt). This PR supports the following quantities of interest:

- unit level slopes
- average slopes
- average by group slopes
- user defined value slopes

Additionally, this PR also supports the interpretation of slopes as an elasticity (percent change in $x$ is associated with a percentage change in $y$). If the regressor of interest is categorical, computing an elasticity is not possible. For example, there is no % change in penguin species. Furthermore, if `wrt` is categorical when calling `slopes`, then `comparisons` is called to compute the difference in contrast means.

`slopes` and `comparisons` are closely related. Thus, I have refactored the code such that these two functions can use the same code when building the summary dataframe and plotting. Lastly, I simplified the code to build the summary data frames. 