### PR TITLE
Added missing doc string part for center_predictors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "Running black..."
-          black bambi --check
+          black bambi --check --diff --color
 
           echo "Checking code style with pylint..."
           pylint bambi

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -89,7 +89,7 @@ class Model:
     center_predictors : bool
         If ``True`` (default), and if there is an intercept in the common terms, the data is
         centered by subtracting the mean. The centering is undone after sampling to provide
-        the actual intercept in all distributional components that have an intercept.  Note 
+        the actual intercept in all distributional components that have an intercept. Note
         that this changes the interpretation of the prior on the intercept because it refers
         to the intercept of the centered data.
     extra_namespace : dict, optional

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -86,6 +86,10 @@ class Model:
     noncentered : bool
         If ``True`` (default), uses a non-centered parameterization for normal hyperpriors on
         grouped parameters. If ``False``, naive (centered) parameterization is used.
+    center_predictors : bool
+        If ``True`` (default), and if there is an intercept in the common terms, the data is
+        centered by subtracting the mean. The centering is undone after sampling to provide
+        the actual intercept in all distributional components that have an intercept.
     extra_namespace : dict, optional
         Additional user supplied variables with transformations or data to include in the
         environment where the formula is evaluated. Defaults to `None`.

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -89,7 +89,9 @@ class Model:
     center_predictors : bool
         If ``True`` (default), and if there is an intercept in the common terms, the data is
         centered by subtracting the mean. The centering is undone after sampling to provide
-        the actual intercept in all distributional components that have an intercept.
+        the actual intercept in all distributional components that have an intercept.  Note 
+        that this changes the interpretation of the prior on the intercept because it refers
+        to the intercept of the centered data.
     extra_namespace : dict, optional
         Additional user supplied variables with transformations or data to include in the
         environment where the formula is evaluated. Defaults to `None`.


### PR DESCRIPTION
Added missing doc string part for center_predictors

Perhaps the rationale behind centering could be added to help user decide whether to turn it on or not. But I'm not entirely sure about this.