### PR TITLE
Change CHANGELOG for changelog in doc generation

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -29,7 +29,7 @@ website:
       - text: FAQ
         file: faq.qmd
       - text: Changelog
-        file: CHANGELOG.qmd
+        file: changelog.qmd
       - icon: github
         href: https://github.com/bambinos/bambi
 

--- a/docs/post_render.py
+++ b/docs/post_render.py
@@ -1,4 +1,4 @@
 import os
 
 # Remove CHANGELOG
-os.remove("CHANGELOG.qmd")
+os.remove("changelog.qmd")

--- a/docs/pre_render.py
+++ b/docs/pre_render.py
@@ -3,7 +3,7 @@ import shutil
 
 # Copy CHANGELOG file to 'docs' and change its extension to '.qmd'
 shutil.copyfile("../CHANGELOG.md", "CHANGELOG.md")
-os.rename("CHANGELOG.md", "CHANGELOG.qmd")
+os.rename("CHANGELOG.md", "changelog.qmd")
 
 # Remove TOC from it
 lines = """---
@@ -11,7 +11,7 @@ toc: false
 pagetitle: "Changelog"
 ---
 """
-with open("CHANGELOG.qmd", "r+") as file:
+with open("changelog.qmd", "r+") as file:
     file_data = file.read()
     file.seek(0, 0)
     file.write(lines + "\n" + file_data)


### PR DESCRIPTION
When we click on Changelog in the navbar of our documentation site it downloads a `.qmd` file. I realized that quarto is not generating the HTML for that file and instead, it uses the `.qmd`. Now that it's called `changelog.qmd` it seems to work correctly.