### PR TITLE
interpret slopes `prob` argument bug

### DIFF
--- a/bambi/interpret/effects.py
+++ b/bambi/interpret/effects.py
@@ -825,7 +825,7 @@ def slopes(
 
     if slope not in ("dydx", "dyex", "eyex", "eydx"):
         raise ValueError("'slope' must be one of ('dydx', 'dyex', 'eyex', 'eydx')")
- 
+
     if prob is None:
         prob = az.rcParams["stats.hdi_prob"]
     if not 0 < prob < 1:

--- a/bambi/interpret/effects.py
+++ b/bambi/interpret/effects.py
@@ -75,7 +75,7 @@ class ResponseInfo:
 @dataclass
 class Estimate:
     """Stores the mean and bounds (uncertainty interval) of 'comparisons' and
-    'effects' estimates. Used in 'PredictiveDifferences' to store typed data
+    'slopes' estimates. Used in 'PredictiveDifferences' to store typed data
     for the summary dataframe.
 
     Parameters
@@ -608,7 +608,7 @@ def comparisons(
         Whether to compute the highest density interval (defaults to True) or the quantiles.
     prob : float, optional
         The probability for the credibility intervals. Must be between 0 and 1. Defaults to 0.94.
-        Changing the global variable ``az.rcParam["stats.hdi_prob"]`` affects this default.
+        Changing the global variable ``az.rcParams["stats.hdi_prob"]`` affects this default.
     transforms : dict, optional
         Transformations that are applied to each of the variables being plotted. The keys are the
         name of the variables, and the values are functions to be applied. Defaults to ``None``.
@@ -769,7 +769,7 @@ def slopes(
         Whether to compute the highest density interval (defaults to True) or the quantiles.
     prob : float, optional
         The probability for the credibility intervals. Must be between 0 and 1. Defaults to 0.94.
-        Changing the global variable ``az.rcParam["stats.hdi_prob"]`` affects this default.
+        Changing the global variable ``az.rcParams["stats.hdi_prob"]`` affects this default.
     transforms : dict, optional
         Transformations that are applied to each of the variables being plotted. The keys are the
         name of the variables, and the values are functions to be applied. Defaults to ``None``.
@@ -825,7 +825,7 @@ def slopes(
 
     if slope not in ("dydx", "dyex", "eyex", "eydx"):
         raise ValueError("'slope' must be one of ('dydx', 'dyex', 'eyex', 'eydx')")
-
+ 
     if prob is None:
         prob = az.rcParams["stats.hdi_prob"]
     if not 0 < prob < 1:
@@ -870,7 +870,7 @@ def slopes(
         model, slopes_data, wrt_info, conditional_info, response, use_hdi, effect_type
     )
     slopes_summary = predictive_difference.get_estimate(
-        idata, response_transform, "diff", slope, eps
+        idata, response_transform, "diff", slope, eps, prob
     ).get_summary_df(response_dim)
 
     if average_by:


### PR DESCRIPTION
Resolves #748. The `prob` argument in `def slopes()` was never passed to the `get_estimate()` method. Thus, `get_estimate()` was always using a default of 0.94. This PR passes `prob` correctly to resolve the bug. Note: the `comparisons`  and `predictions` function works as expected.