### PR TITLE
Return interpret data

### DIFF
--- a/bambi/interpret/effects.py
+++ b/bambi/interpret/effects.py
@@ -713,7 +713,8 @@ def comparisons(
 
     # early return since 'PredictiveDifferences' does not need to be called
     if return_idata:
-        return get_posterior(response.name_obs, idata, comparisons_data)
+        # return get_posterior(response.name_obs, idata, comparisons_data)
+        return comparisons_data, idata
 
     # returns empty array if model predictions do not have multiple dimensions
     response_dim_key = response.name + "_dim"

--- a/bambi/interpret/utils.py
+++ b/bambi/interpret/utils.py
@@ -394,16 +394,10 @@ def make_group_values(x: np.ndarray, groups_n: int = 5) -> np.ndarray:
 
 
 def get_group_offset(n, lower: float = 0.05, upper: float = 0.4) -> np.ndarray:
-    # Complementary log log function, scaled.
-    # See following code to have an idea of how this function looks like
-    # lower, upper = 0.05, 0.4
-    # x = np.linspace(2, 9)
-    # y = get_group_offset(x, lower, upper)
-    # fig, ax = plt.subplots(figsize=(8, 5))
-    # ax.plot(x, y)
-    # ax.axvline(2, color="k", ls="--")
-    # ax.axhline(lower, color="k", ls="--")
-    # ax.axhline(upper, color="k", ls="--")
+    """
+    When plotting categoric variables, this function computes the offset of the
+    stripplot points based on the number of groups ``n``.
+    """
     intercept, slope = 3.25, 1
     return lower + np.exp(-np.exp(intercept - slope * n)) * (upper - lower)
 
@@ -441,10 +435,15 @@ def get_posterior(
     response_obs: str, idata: az.InferenceData, pred_data: pd.DataFrame
 ) -> pd.DataFrame:
     """
-    Merges the posterior draws with the corresponding observation that produced
-    that draw.
+    Merges the posterior or posterior predictive draws with the corresponding
+    observation that produced that draw.
     """
-    posterior_df = idata.posterior.to_dataframe().reset_index()
+    # if `pps=True` in 'predictions', then use posterior predictive draws
+    if "posterior_predictive" in idata.groups():
+        posterior_df = idata.posterior_predictive.to_dataframe().reset_index()
+    else:
+        posterior_df = idata.posterior.to_dataframe().reset_index()
+
     posterior_df = posterior_df.set_index(response_obs)
     posterior_df = posterior_df.merge(pred_data, left_index=True, right_index=True)
     posterior_df = posterior_df.rename(columns=lambda x: x.replace("_x", ""))

--- a/tests/test_interpret.py
+++ b/tests/test_interpret.py
@@ -12,15 +12,175 @@ import bambi as bmb
 
 @pytest.fixture(scope="module")
 def mtcars():
-    data = bmb.load_data('mtcars')
+    "Model with common level effects only"
+    data = bmb.load_data("mtcars")
     data["am"] = pd.Categorical(data["am"], categories=[0, 1], ordered=True)
     model = bmb.Model("mpg ~ hp * drat * am", data)
     idata = model.fit(tune=500, draws=500, random_seed=1234)
     return model, idata
 
 
+@pytest.fixture(scope="module")
+def sleep_study():
+    "Model with common and group specific effects"
+    data = bmb.load_data("sleepstudy")
+    model = bmb.Model("Reaction ~ 1 + Days + (Days | Subject)", data)
+    idata = model.fit(tune=500, draws=500, random_seed=1234)
+    return model, idata
+
+
+@pytest.fixture(scope="module")
+def food_choice():
+    """
+    Model a categorical response using the 'categorical' family to test 'interpret'
+    plotting functions for a model whose predictions have multiple response
+    dimensions (levels).
+    """
+    length = [
+        1.3,
+        1.32,
+        1.32,
+        1.4,
+        1.42,
+        1.42,
+        1.47,
+        1.47,
+        1.5,
+        1.52,
+        1.63,
+        1.65,
+        1.65,
+        1.65,
+        1.65,
+        1.68,
+        1.7,
+        1.73,
+        1.78,
+        1.78,
+        1.8,
+        1.85,
+        1.93,
+        1.93,
+        1.98,
+        2.03,
+        2.03,
+        2.31,
+        2.36,
+        2.46,
+        3.25,
+        3.28,
+        3.33,
+        3.56,
+        3.58,
+        3.66,
+        3.68,
+        3.71,
+        3.89,
+        1.24,
+        1.3,
+        1.45,
+        1.45,
+        1.55,
+        1.6,
+        1.6,
+        1.65,
+        1.78,
+        1.78,
+        1.8,
+        1.88,
+        2.16,
+        2.26,
+        2.31,
+        2.36,
+        2.39,
+        2.41,
+        2.44,
+        2.56,
+        2.67,
+        2.72,
+        2.79,
+        2.84,
+    ]
+    choice = [
+        "I",
+        "F",
+        "F",
+        "F",
+        "I",
+        "F",
+        "I",
+        "F",
+        "I",
+        "I",
+        "I",
+        "O",
+        "O",
+        "I",
+        "F",
+        "F",
+        "I",
+        "O",
+        "F",
+        "O",
+        "F",
+        "F",
+        "I",
+        "F",
+        "I",
+        "F",
+        "F",
+        "F",
+        "F",
+        "F",
+        "O",
+        "O",
+        "F",
+        "F",
+        "F",
+        "F",
+        "O",
+        "F",
+        "F",
+        "I",
+        "I",
+        "I",
+        "O",
+        "I",
+        "I",
+        "I",
+        "F",
+        "I",
+        "O",
+        "I",
+        "I",
+        "F",
+        "F",
+        "F",
+        "F",
+        "F",
+        "F",
+        "F",
+        "O",
+        "F",
+        "I",
+        "F",
+        "F",
+    ]
+    sex = ["Male"] * 32 + ["Female"] * 31
+    data = pd.DataFrame({"choice": choice, "length": length, "sex": sex})
+    data["choice"] = pd.Categorical(
+        data["choice"].map({"I": "Invertebrates", "F": "Fish", "O": "Other"}),
+        ["Other", "Invertebrates", "Fish"],
+        ordered=True,
+    )
+
+    model = bmb.Model("choice ~ length + sex", data, family="categorical")
+    idata = model.fit(tune=500, draws=500, random_seed=1234)
+    return model, idata
+
+
 @pytest.mark.parametrize("return_idata", [True, False])
-def test_return_idata(mtcars, return_idata):
+def test_return_idata_common_effects(mtcars, return_idata):
     model, idata = mtcars
 
     bmb.interpret.predictions(
@@ -32,4 +192,33 @@ def test_return_idata(mtcars, return_idata):
     bmb.interpret.slopes(
         model, idata, "hp", "wt", return_idata=return_idata
     )
-    
+
+
+@pytest.mark.parametrize("return_idata", [True, False])
+def test_return_idata_group_effects(sleep_study, return_idata):
+    model, idata = sleep_study
+
+    bmb.interpret.predictions(
+        model, idata, ["Days", "Subject"], sample_new_groups=True, return_idata=return_idata
+        )
+    bmb.interpret.comparisons(
+        model, idata, "Days", "Subject", sample_new_groups=True, return_idata=return_idata
+    )
+    bmb.interpret.slopes(
+        model, idata, "Days", "Subject", sample_new_groups=True, return_idata=return_idata
+    )
+
+
+@pytest.mark.parametrize("return_idata", [True, False])
+def test_return_idata_categorical(food_choice, return_idata):
+    model, idata = food_choice
+
+    bmb.interpret.predictions(
+        model, idata, ["length", "sex"], return_idata=return_idata
+        )
+    bmb.interpret.comparisons(
+        model, idata, "sex", "length", return_idata=return_idata
+    )
+    bmb.interpret.slopes(
+        model, idata, "length", "sex", return_idata=return_idata
+    )

--- a/tests/test_interpret.py
+++ b/tests/test_interpret.py
@@ -1,0 +1,35 @@
+"""
+This module contains tests for the non-plotting functions of the 'interpret'
+sub-package. In some cases, 'comparisons()', 'predictions()' and 'slopes()' 
+contain arguments not in their respective plotting functions. Such arguments
+are tested here.
+"""
+import pandas as pd
+import pytest
+
+import bambi as bmb
+
+
+@pytest.fixture(scope="module")
+def mtcars():
+    data = bmb.load_data('mtcars')
+    data["am"] = pd.Categorical(data["am"], categories=[0, 1], ordered=True)
+    model = bmb.Model("mpg ~ hp * drat * am", data)
+    idata = model.fit(tune=500, draws=500, random_seed=1234)
+    return model, idata
+
+
+@pytest.mark.parametrize("return_idata", [True, False])
+def test_return_idata(mtcars, return_idata):
+    model, idata = mtcars
+
+    bmb.interpret.predictions(
+        model, idata, ["hp", "wt"], return_idata=return_idata
+        )
+    bmb.interpret.comparisons(
+        model, idata, "hp", "wt", return_idata=return_idata
+    )
+    bmb.interpret.slopes(
+        model, idata, "hp", "wt", return_idata=return_idata
+    )
+    


### PR DESCRIPTION
This PR addresses issue https://github.com/bambinos/bambi/issues/703 and #751 by adding a parameter `return_idata: bool = False` in comparisons(), predictions(), and slopes() that merges the posterior draws with the corresponding observation that "produced" that draw and returns it as a dataframe. 

Most of the code diff is from adding a new test file that tests non-plotting functionality of the interpret sub-package not tested in `test_plots.py`.

```python3
fish_data = pd.read_stata("http://www.stata-press.com/data/r11/fish.dta")
cols = ["count", "livebait", "camper", "persons", "child"]
fish_data = fish_data[cols]
fish_data["livebait"] = pd.Categorical(fish_data["livebait"])
fish_data["camper"] = pd.Categorical(fish_data["camper"])

fish_model = bmb.Model(
    "count ~ livebait + camper + persons + child", 
    fish_data, 
    family='zero_inflated_poisson'
)

fish_idata = fish_model.fit(
    draws=1000, 
    target_accept=0.95, 
    random_seed=1234, 
    chains=4
)
```

With `return_idata=True`, **one** data frame is returned. This dataframe contains the inference data from the posterior group`InferenceData` object, observed data, and parameter estimates. In the case that a user is calling `predictions` with `pps=True`, then the posterior predictive group is used. {marginaleffects} has a similar [functionality](https://marginaleffects.com/articles/brms.html#random-variables-posterior-and-ggdist) for Bayesian models.

Below are a few examples:

```python3
bmb.interpret.predictions(
    model=fish_model,
    idata=fish_idata,
    conditional=["persons", "child", "livebait"],
    return_idata=True
) 
```

chain | draw | livebait_dim | camper_dim | Intercept | livebait | camper | persons | child | count_psi | count_mean | persons_obs | child_obs | livebait_obs | camper_obs
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | 0 | 1.0 | 1.0 | -2.560515 | 1.877271 | 0.658819 | 0.850313 | -1.256469 | 0.619094 | 0.349454 | 1.0 | 0.0 | 0.0 | 1.0
0 | 1 | 1.0 | 1.0 | -2.746079 | 1.852347 | 0.794963 | 0.848145 | -1.302583 | 0.643842 | 0.331884 | 1.0 | 0.0 | 0.0 | 1.0
0 | 2 | 1.0 | 1.0 | -2.669619 | 1.674642 | 0.693835 | 0.923590 | -1.588417 | 0.683065 | 0.349171 | 1.0 | 0.0 | 0.0 | 1.0
0 | 3 | 1.0 | 1.0 | -2.581749 | 1.474203 | 0.661846 | 0.958753 | -1.624487 | 0.684139 | 0.382453 | 1.0 | 0.0 | 0.0 | 1.0
0 | 4 | 1.0 | 1.0 | -2.866501 | 2.162873 | 0.575769 | 0.860328 | -1.311473 | 0.647937 | 0.239212 | 1.0 | 0.0 | 0.0 | 1.0

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(212, 212, 212); font-family: -apple-system, system-ui, sans-serif; font-size: 10px; font-variant-ligatures: normal; orphans: 2; widows: 2; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1200000 rows × 15 columns</p>

Returning the inference data when calling comparisons will allow the user to conduct more specific or complex comparisons leveraging group by aggregations:

```python3
bmb.interpret.comparisons(
    model=fish_model,
    idata=fish_idata,
    contrast={"persons": [1, 4]},
    conditional={"child": [0, 1, 2], "livebait": [0, 1]},
    return_idata=True
) 
```

chain | draw | livebait_dim | camper_dim | Intercept | livebait | camper | persons | child | count_psi | count_mean | child_obs | livebait_obs | persons_obs | camper_obs
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | 0 | 1.0 | 1.0 | -2.560515 | 1.877271 | 0.658819 | 0.850313 | -1.256469 | 0.619094 | 0.349454 | 0.0 | 0 | 1.0 | 1.0
0 | 1 | 1.0 | 1.0 | -2.746079 | 1.852347 | 0.794963 | 0.848145 | -1.302583 | 0.643842 | 0.331884 | 0.0 | 0 | 1.0 | 1.0
0 | 2 | 1.0 | 1.0 | -2.669619 | 1.674642 | 0.693835 | 0.923590 | -1.588417 | 0.683065 | 0.349171 | 0.0 | 0 | 1.0 | 1.0
0 | 3 | 1.0 | 1.0 | -2.581749 | 1.474203 | 0.661846 | 0.958753 | -1.624487 | 0.684139 | 0.382453 | 0.0 | 0 | 1.0 | 1.0
0 | 4 | 1.0 | 1.0 | -2.866501 | 2.162873 | 0.575769 | 0.860328 | -1.311473 | 0.647937 | 0.239212 | 0.0 | 0 | 1.0 | 1.0

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(212, 212, 212); font-family: -apple-system, system-ui, sans-serif; font-size: 10px; font-variant-ligatures: normal; orphans: 2; widows: 2; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">48000 rows × 15 columns</p>

Initially, I wanted to return the `az.InferenceData` object. However, due to the following limitations I settled on a DataFrame:

- I could [add new groups](https://python.arviz.org/en/stable/getting_started/WorkingWithInferenceData.html#add-groups-to-inferencedata-objects) to the inference data object, but then it isn't clear to me how to perform group by aggregations on the posterior dataset while taking into account this new group.

- Additionally, the data shouldn't be merged as a data variable in the az.InferenceData.posterior dataset because, when aggregations are performed along the coordinates, these aggregations will also be applied to the data used to generate the predictions (since they were merged as a data variable).

- Lastly, the data could be merged and made as a coordinate so you can specify along which dimension(s) you want to compute the aggregation. Although, I can't seem to groupby more than one coordinate. For example, `xr.Dataset.groupby([coord1, coord2])` results in the following error:

`TypeError: group must be an xarray.DataArray or the name of an xarray variable or dimension. Received ['coord1', 'coord2'] instead.`

_Note_: depending on the model specification and number of chains and draws, it is possible there will be millions of rows returned. 

To do:
- [x] add case for when `pps=True` (posterior predictive samples) in `predictions`. Currently, I only access the posterior group of the InferenceData to build the dataframe.
