### PR TITLE
Add constrained transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add configuration facilities to Bambi (#745) 
 * Interpet submodule now outputs informative messages when computing default values (#745) 
 * Bambi supports weighted responses (#761)
+* Bambi supports constrained responses (#764)
 
 ### Maintenance and fixes
 

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -368,6 +368,7 @@ class ResponseTerm:
             # Get a weighted version of the response distribution
             weighted_dist = make_weighted_distribution(distribution)
             dist_rv = weighted_dist(self.name, weights, **kwargs, observed=observed, dims=dims)
+        # All of the other response kinds are "not special" and thus are handled the same way
         else:
             dist_rv = distribution(self.name, **kwargs)
 

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -326,6 +326,34 @@ class ResponseTerm:
                 self.name, stateless_dist, lower=lower, upper=upper, observed=observed, dims=dims
             )
 
+        # Handle constrained responses (through truncated distributions)
+        elif self.term.is_constrained:
+            dims = kwargs.pop("dims", None)
+            data_matrix = kwargs.pop("observed")
+
+            # Get values of the response variable
+            observed = np.squeeze(data_matrix[:, 0])
+
+            # Get truncation values
+            lower = np.squeeze(data_matrix[:, 1])
+            upper = np.squeeze(data_matrix[:, 2])
+
+            # Handle 'None' and scalars appropriately
+            if np.all(lower == -np.inf):
+                lower = None
+            elif np.all(lower == lower[0]):
+                lower = lower[0]
+
+            if np.all(upper == np.inf):
+                upper = None
+            elif np.all(upper == upper[0]):
+                upper = upper[0]
+
+            stateless_dist = distribution.dist(**kwargs)
+            dist_rv = pm.Truncated(
+                self.name, stateless_dist, lower=lower, upper=upper, observed=observed, dims=dims
+            )
+
         # Handle weighted responses
         elif self.term.is_weighted:
             dims = kwargs.pop("dims", None)
@@ -361,7 +389,12 @@ class ResponseTerm:
         if isinstance(self.family, (Multinomial, DirichletMultinomial)):
             return kwargs
 
-        if self.term.is_censored or self.term.is_truncated or self.term.is_weighted:
+        if (
+            self.term.is_censored
+            or self.term.is_truncated
+            or self.term.is_weighted
+            or self.term.is_constrained
+        ):
             return kwargs
 
         dims, data = kwargs["dims"], kwargs["observed"]

--- a/bambi/terms/response.py
+++ b/bambi/terms/response.py
@@ -2,7 +2,12 @@ import formulae.terms
 
 from bambi.terms.base import BaseTerm
 
-from bambi.terms.utils import is_censored_response, is_truncated_response, is_weighted_response
+from bambi.terms.utils import (
+    is_censored_response,
+    is_constrained_response,
+    is_truncated_response,
+    is_weighted_response,
+)
 
 
 class ResponseTerm(BaseTerm):
@@ -10,6 +15,7 @@ class ResponseTerm(BaseTerm):
         self.term = response.term.term
         self.family = family
         self.is_censored = is_censored_response(self.term)
+        self.is_constrained = is_constrained_response(self.term)
         self.is_truncated = is_truncated_response(self.term)
         self.is_weighted = is_weighted_response(self.term)
 

--- a/bambi/terms/response.py
+++ b/bambi/terms/response.py
@@ -2,22 +2,17 @@ import formulae.terms
 
 from bambi.terms.base import BaseTerm
 
-from bambi.terms.utils import (
-    is_censored_response,
-    is_constrained_response,
-    is_truncated_response,
-    is_weighted_response,
-)
+from bambi.terms.utils import is_response_of_kind
 
 
 class ResponseTerm(BaseTerm):
     def __init__(self, response, family):
         self.term = response.term.term
         self.family = family
-        self.is_censored = is_censored_response(self.term)
-        self.is_constrained = is_constrained_response(self.term)
-        self.is_truncated = is_truncated_response(self.term)
-        self.is_weighted = is_weighted_response(self.term)
+        self.is_censored = is_response_of_kind(self.term, "censored")
+        self.is_constrained = is_response_of_kind(self.term, "constrained")
+        self.is_truncated = is_response_of_kind(self.term, "truncated")
+        self.is_weighted = is_response_of_kind(self.term, "weighted")
 
     @property
     def term(self):
@@ -87,23 +82,3 @@ class ResponseTerm(BaseTerm):
             else:
                 extras += [f"reference: {self.reference}"]
         return self.make_str(extras)
-
-
-# Categorical
-# -> Nominal
-#   -> Binary
-# -> Ordinal
-
-# These aren't actually used to do something with data, but mostly to give information to the user
-# Well, the ordinal kind can be useful as well.
-# class Categorical:
-#     pass
-
-# class Nominal(Categorical):
-#     pass
-
-# class Ordinal(Categorical):
-#     pass
-
-# class Binary(Nominal):
-#     pass

--- a/bambi/terms/utils.py
+++ b/bambi/terms/utils.py
@@ -12,7 +12,7 @@ def is_call_component(component) -> bool:
     return isinstance(component, fm.terms.call.Call)
 
 
-def is_call_of_kind(call, kind):
+def is_call_of_kind(call, kind: str) -> bool:
     """Determines if formulae call component is of certain kind
 
     To do so, it checks whether the callee has metadata and whether the 'kind' slot matches the
@@ -22,41 +22,11 @@ def is_call_of_kind(call, kind):
     return hasattr(function, "__metadata__") and function.__metadata__["kind"] == kind
 
 
-def is_censored_response(term):
-    """Determines if a formulae term represents a censored response"""
+def is_response_of_kind(term, kind: str) -> bool:
+    """Determines if a formulae term represents a response of a certain kind"""
     if not is_single_component(term):
         return False
     component = term.components[0]  # get the first (and single) component
     if not is_call_component(component):
         return False
-    return is_call_of_kind(component, "censored")
-
-
-def is_truncated_response(term):
-    """Determines if a formulae term represents a truncated response"""
-    if not is_single_component(term):
-        return False
-    component = term.components[0]  # get the first (and single) component
-    if not is_call_component(component):
-        return False
-    return is_call_of_kind(component, "truncated")
-
-
-def is_constrained_response(term):
-    """Determines if a formulae term represents a constrained response"""
-    if not is_single_component(term):
-        return False
-    component = term.components[0]  # get the first (and single) component
-    if not is_call_component(component):
-        return False
-    return is_call_of_kind(component, "constrained")
-
-
-def is_weighted_response(term):
-    """Determines if a formulae term represents a weighted response"""
-    if not is_single_component(term):
-        return False
-    component = term.components[0]  # get the first (and single) component
-    if not is_call_component(component):
-        return False
-    return is_call_of_kind(component, "weighted")
+    return is_call_of_kind(component, kind)

--- a/bambi/terms/utils.py
+++ b/bambi/terms/utils.py
@@ -42,6 +42,16 @@ def is_truncated_response(term):
     return is_call_of_kind(component, "truncated")
 
 
+def is_constrained_response(term):
+    """Determines if a formulae term represents a constrained response"""
+    if not is_single_component(term):
+        return False
+    component = term.components[0]  # get the first (and single) component
+    if not is_call_component(component):
+        return False
+    return is_call_of_kind(component, "constrained")
+
+
 def is_weighted_response(term):
     """Determines if a formulae term represents a weighted response"""
     if not is_single_component(term):

--- a/bambi/transformations.py
+++ b/bambi/transformations.py
@@ -128,6 +128,23 @@ def truncated(x, lb=None, ub=None):
 truncated.__metadata__ = {"kind": "truncated"}
 
 
+def constrained(x, lb=None, ub=None):
+    """Construct an array for a constrained response
+
+    It's exactly like truncated, but it's interpreted by Bambi in a different way as this
+    one truncates/constrains the bounds of a probability distribution, while `truncated()` is
+    interpreted as the missing data mechanism.
+
+    `lb` and `ub` can only be scalar values.
+    """
+    assert lb is None or isinstance(lb, (int, float))
+    assert ub is None or isinstance(ub, (int, float))
+    return truncated(x, lb, ub)
+
+
+constrained.__metadata__ = {"kind": "constrained"}
+
+
 def weighted(x, weights):
     """Construct array for a weighted response
 
@@ -403,6 +420,7 @@ def get_distance(x):
 transformations_namespace = {
     "c": c,
     "censored": censored,
+    "constrained": constrained,
     "truncated": truncated,
     "weighted": weighted,
     "log": np.log,

--- a/bambi/transformations.py
+++ b/bambi/transformations.py
@@ -137,8 +137,11 @@ def constrained(x, lb=None, ub=None):
 
     `lb` and `ub` can only be scalar values.
     """
-    assert lb is None or isinstance(lb, (int, float))
-    assert ub is None or isinstance(ub, (int, float))
+    if not (lb is None or isinstance(lb, (int, float))):
+        raise ValueError("'lb' must be None or scalar.")
+
+    if not (ub is None or isinstance(ub, (int, float))):
+        raise ValueError("'ub' must be None or scalar.")
     return truncated(x, lb, ub)
 
 


### PR DESCRIPTION
This PR adds a new transformation that can be used in response terms. This is similar to `truncated` but it directly **constrains** the bounds of the response distribution (remember, `truncated` refers to the missing data mechanism).

The usage is `constrained(value, lower, upper) ~ whatever`. `lower` and `upper` must be scalar or `None`.

It uses the original bounds when obtaining draws from the posterior predictive distribution.

**Edit** closes #750 