### PR TITLE
interpret get name of LazyVariable 

### DIFF
--- a/bambi/interpret/utils.py
+++ b/bambi/interpret/utils.py
@@ -4,9 +4,11 @@ from dataclasses import dataclass, field
 from typing import Union
 
 import numpy as np
-from formulae.terms.call import Call
 import pandas as pd
 import xarray as xr
+
+from formulae.terms.call import Call
+from formulae.terms.call_resolver import LazyVariable
 
 from bambi import Model
 from bambi.utils import listify
@@ -229,7 +231,6 @@ def get_model_covariates(model: Model) -> np.ndarray:
     """
     Return covariates specified in the model.
     """
-
     terms = get_model_terms(model)
     covariates = []
     for term in terms.values():
@@ -237,7 +238,10 @@ def get_model_covariates(model: Model) -> np.ndarray:
             for component in term.components:
                 # if the component is a function call, use the argument names
                 if isinstance(component, Call):
-                    covariates.append([arg.name for arg in component.call.args])
+                    # covariates.append([arg.name for arg in component.call.args])
+                    covariates.append(
+                        [arg.name for arg in component.call.args if isinstance(arg, LazyVariable)]
+                    )
                 else:
                     covariates.append([component.name])
         elif hasattr(term, "factor"):

--- a/bambi/interpret/utils.py
+++ b/bambi/interpret/utils.py
@@ -238,7 +238,6 @@ def get_model_covariates(model: Model) -> np.ndarray:
             for component in term.components:
                 # if the component is a function call, use the argument names
                 if isinstance(component, Call):
-                    # covariates.append([arg.name for arg in component.call.args])
                     covariates.append(
                         [arg.name for arg in component.call.args if isinstance(arg, LazyVariable)]
                     )


### PR DESCRIPTION
This PR resolves #772 to parse model components that are a formulae `LazyVariable` instance. These instances happen when a user calls a formulae stateful transformation function. In Bambi, there are really "two" function you can call on model terms:

1. A formulae stateful transformation, i.e. basis splines, polynomial
2. Function call from the environment, i.e. log transformation using numpy

I have added tests to the interpret module to reflect the two different types of function calls. I only added the tests for `bmb.interpert.predictions` since comparisons and slopes call the same function `get_model_covariates` where the bug was happening. So testing predictions implicitly tests the other two functions.