### PR TITLE
[WIP] Fix HSGP predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Documentation
 
+* Our Code of Conduct now includes how to send a report (#783)
+
 ### Deprecation
 
 ## 0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Maintenance and fixes
 
+* Fix bug in predictions with models using HSGP (#780)
+
 ### Documentation
 
 * Our Code of Conduct now includes how to send a report (#783)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,9 @@
 # Bambi Community Code of Conduct
 
+Bambi adopts the NumFOCUS Code of Conduct directly. In other words, we expect our community to treat others with kindness and understanding.
+
+# The short version  
+
 Be kind to others. Do not insult or put down others.
 Behave professionally. Remember that harassment and sexist, racist,
 or exclusionary jokes are not appropriate.
@@ -15,3 +19,31 @@ or religion. We do not tolerate harassment of community members
 in any form.
 
 Thank you for helping make this a welcoming, friendly community for all.
+
+# How to Submit a Report
+
+If you feel that there has been a Code of Conduct violation an anonymous
+reporting form is available.
+
+**If you feel your safety is in jeopardy or the situation is an
+emergency, we urge you to contact local law enforcement before making
+a report. (In the U.S., dial 911.)**
+
+We are committed to promptly addressing any reported issues.
+If you have experienced or witnessed behavior that violates this 
+Code of Conduct, please complete the form below to
+make a report.
+
+**REPORTING FORM:** https://numfocus.typeform.com/to/ynjGdT
+
+Reports are sent to the NumFOCUS Code of Conduct Enforcement Team
+(see below).
+
+You can view the Privacy Policy and Terms of Service for TypeForm here.
+The NumFOCUS Privacy Policy is here:
+https://www.numfocus.org/privacy-policy
+
+# Full Code of Conduct
+
+The full text of the NumFOCUS/Bambi Code of Conduct can be found on
+NumFOCUS's website  https://numfocus.org/code-of-conduct

--- a/bambi/interpret/utils.py
+++ b/bambi/interpret/utils.py
@@ -236,10 +236,19 @@ def get_model_covariates(model: Model) -> np.ndarray:
     for term in terms.values():
         if hasattr(term, "components"):
             for component in term.components:
-                # if the component is a function call, use the argument names
+                # if the component is a function call, look for relevant argument names
                 if isinstance(component, Call):
+                    # Add variable names passed as unnamed arguments
                     covariates.append(
                         [arg.name for arg in component.call.args if isinstance(arg, LazyVariable)]
+                    )
+                    # Add variable names passed as named arguments
+                    covariates.append(
+                        [
+                            kwarg_value.name
+                            for kwarg_value in component.call.kwargs.values()
+                            if isinstance(kwarg_value, LazyVariable)
+                        ]
                     )
                 else:
                     covariates.append([component.name])

--- a/bambi/model_components.py
+++ b/bambi/model_components.py
@@ -292,7 +292,6 @@ class DistributionalComponent:
         # Remove columns of X that are associated with HSGP contributions
         # All the slices _must be_ deleted at the same time. Otherwise the slice objects don't
         # reflect the right columns of X at the time they're used
-        # TODO: test this
         if hsgp_slices:
             X = np.delete(X, np.r_[tuple(hsgp_slices)], axis=1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 
 dependencies = [
     "arviz>=0.12.0",
-    "formulae>=0.5.0",
+    "formulae>=0.5.3",
     "graphviz",
     "pandas>=1.0.0",
     "pymc>=5.5.0",


### PR DESCRIPTION
Fixes predictions when HSGP contains a `by` variable.

* It makes sure the underlying design matrix is not modified until the data of all HSGP components are used.
* Modifies `get_model_covariates` so it also looks at the named arguments of function calls.
  * For this, this PR in formulae was also needed https://github.com/bambinos/formulae/pull/107

~~TODO: implement tests?~~

Edit : it closes #776 