### PR TITLE
Type-hint and type-overload a few common Model methods

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-name-in-module
 # pylint: disable=too-many-lines
 import logging
+from typing import Literal, Optional, overload
 import warnings
 
 from copy import deepcopy
@@ -11,6 +12,7 @@ import pymc as pm
 import pandas as pd
 
 from arviz.plots import plot_posterior
+from arviz import InferenceData
 
 from bambi.backend import PyMCModel
 from bambi.defaults import get_builtin_family
@@ -225,21 +227,57 @@ class Model:
         # Build priors
         self._build_priors()
 
+    @overload
     def fit(
         self,
-        draws=1000,
-        tune=1000,
-        discard_tuned_samples=True,
-        omit_offsets=True,
-        include_mean=False,
-        inference_method="mcmc",
-        init="auto",
-        n_init=50000,
-        chains=None,
-        cores=None,
-        random_seed=None,
+        draws: int = 1000,
+        tune: int = 1000,
+        discard_tuned_samples: bool = True,
+        omit_offsets: bool = True,
+        include_mean: bool = False,
+        inference_method: Literal["mcmc", "blackjax_nuts", "numpyro_nuts", "laplace"] = "mcmc",
+        init: str = "auto",
+        n_init: int = 50000,
+        chains: Optional[int] = None,
+        cores: Optional[int] = None,
+        random_seed: Optional[int] = None,
         **kwargs,
-    ):
+    ) -> InferenceData: ...
+
+    @overload
+    def fit(
+        self,
+        draws: int = 1000,
+        tune: int = 1000,
+        discard_tuned_samples: bool = True,
+        omit_offsets: bool = True,
+        include_mean: bool = False,
+        inference_method: Literal["vi"] = ...,
+        init: str = "auto",
+        n_init: int = 50000,
+        chains: Optional[int] = None,
+        cores: Optional[int] = None,
+        random_seed: Optional[int] = None,
+        **kwargs,
+    ) -> pm.MeanField: ...
+
+    def fit(
+        self,
+        draws: int = 1000,
+        tune: int = 1000,
+        discard_tuned_samples: bool = True,
+        omit_offsets: bool = True,
+        include_mean: bool = False,
+        inference_method: Literal[
+            "mcmc", "blackjax_nuts", "numpyro_nuts", "vi", "laplace"
+        ] = "mcmc",
+        init: str = "auto",
+        n_init: int = 50000,
+        chains: Optional[int] = None,
+        cores: Optional[int] = None,
+        random_seed: Optional[int] = None,
+        **kwargs,
+    ) -> InferenceData | pm.MeanField:
         """Fit the model using PyMC.
 
         Parameters

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -801,15 +801,37 @@ class Model:
 
         return idata
 
+    @overload
     def predict(
         self,
-        idata,
-        kind="mean",
-        data=None,
-        inplace=True,
-        include_group_specific=True,
-        sample_new_groups=False,
-    ):
+        idata: InferenceData,
+        kind: Literal["mean", "pps"] = "mean",
+        data: Optional[pd.DataFrame] = None,
+        inplace: Literal[True] = True,
+        include_group_specific: bool = True,
+        sample_new_groups: bool = False,
+    ) -> None: ...
+
+    @overload
+    def predict(
+        self,
+        idata: InferenceData,
+        kind: Literal["mean", "pps"] = "mean",
+        data: Optional[pd.DataFrame] = None,
+        inplace: Literal[False] = False,
+        include_group_specific: bool = True,
+        sample_new_groups: bool = False,
+    ) -> InferenceData: ...
+
+    def predict(
+        self,
+        idata: InferenceData,
+        kind: Literal["mean", "pps"] = "mean",
+        data: Optional[pd.DataFrame] = None,
+        inplace: bool = True,
+        include_group_specific: bool = True,
+        sample_new_groups: bool = False,
+    ) -> Optional[InferenceData]:
         """Predict method for Bambi models
 
         Obtains in-sample and out-of-sample predictions from a fitted Bambi model.

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-name-in-module
 # pylint: disable=too-many-lines
 import logging
-from typing import Literal, Optional, Union, overload
+from typing import Callable, Literal, Optional, Union, overload
 import warnings
 
 from copy import deepcopy
@@ -104,18 +104,18 @@ class Model:
     # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
-        formula,
-        data,
-        family="gaussian",
-        priors=None,
-        link=None,
-        categorical=None,
-        potentials=None,
-        dropna=False,
-        auto_scale=True,
-        noncentered=True,
-        center_predictors=True,
-        extra_namespace=None,
+        formula: Union[str, Formula],
+        data: pd.DataFrame,
+        family: Union[str, Family] = "gaussian",
+        priors: Optional[dict[str, Prior]] = None,
+        link: Optional[Union[str, dict[str, str]]] = None,
+        categorical: Optional[Union[str, list[str]]] = None,
+        potentials: Optional[list[tuple[str, Callable]]] = None,
+        dropna: bool = False,
+        auto_scale: bool = True,
+        noncentered: bool = True,
+        center_predictors: bool = True,
+        extra_namespace: Optional[dict] = None,
     ):
         # attributes that are set later
         self.components = {}  # Constant and Distributional components

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-name-in-module
 # pylint: disable=too-many-lines
 import logging
-from typing import Literal, Optional, overload
+from typing import Literal, Optional, Union, overload
 import warnings
 
 from copy import deepcopy
@@ -760,7 +760,13 @@ class Model:
             )
         return axes
 
-    def prior_predictive(self, draws=500, var_names=None, omit_offsets=True, random_seed=None):
+    def prior_predictive(
+        self,
+        draws: int = 500,
+        var_names: Optional[Union[str, list[str]]] = None,
+        omit_offsets: bool = True,
+        random_seed: Optional[int] = None,
+    ) -> InferenceData:
         """Generate samples from the prior predictive distribution.
 
         Parameters


### PR DESCRIPTION
Hello!

I have used pymc extensively over the last two years, and have finally had a play with bambi. I _really_ like it - it has some really nice defaults, and the formula syntax is great!

I noticed that some type hinting was missing on the most commonly used Model methods, so I decided to add that. I initially just wanted to add some overload methods to `Model.fit`, so that it would clearly be returning an `InferenceData` object when called with the appropriate `inference_method`s. Then I got a bit carried away, since it wasn't very difficult to add the remaining commonly used methods. I've [previously added type hinting](https://github.com/pymc-devs/pymc/pulls?q=is%3Apr+sort%3Aupdated-desc+author%3Athomasaarholt+is%3Aclosed) to some of the functions in pymc.

I am using pyright to check the types. This is what is used in VSCode for type checking, docstrings and autocompletion.
This PR does not change any behaviour or logic, only adds type hinting that make IDEs better at understanding the code.

Here is a screenshot of my editor from before the changes are made:
<img width="1196" alt="image" src="https://github.com/bambinos/bambi/assets/2721423/eb0a10c6-afa3-4ce7-8a98-578eb833c5be">

And here they are after:
<img width="833" alt="image" src="https://github.com/bambinos/bambi/assets/2721423/60a7f4bf-5671-4ee0-951b-1eddc634ae0b">

[Here is the run.py file in a gist](https://gist.github.com/thomasaarholt/68e30bfc11e5e9f0cd7534f3b3cb20fb).