### PR TITLE
Support PyMC 5.13 and fix bayeux related issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * Fix bug in predictions with models using HSGP (#780)
 * Fix `get_model_covariates()` utility function (#801)
+* Upgrade PyMC dependency to >= 5.13 (#803)
+* Use `pm.compute_deterministics()` to compute deterministics when bayeux based samplers are used (#803)
 
 ### Documentation
 

--- a/bambi/backend/model_components.py
+++ b/bambi/backend/model_components.py
@@ -154,6 +154,11 @@ class DistributionalComponent:
             elif isinstance(bmb_model.family, (MultivariateFamily, Categorical)):
                 self.output += coef * predictor[:, np.newaxis]
             else:
+                # FIXME: here we see why it fails
+                print("coef shape", coef.shape.eval())
+                print("coef squeezed shape", coef.squeeze().shape.eval())
+                print("predictor shape", predictor.shape)
+                print((coef * predictor).shape.eval())
                 self.output += coef * predictor
 
     def build_response(self, pymc_backend, bmb_model):

--- a/bambi/backend/model_components.py
+++ b/bambi/backend/model_components.py
@@ -154,11 +154,6 @@ class DistributionalComponent:
             elif isinstance(bmb_model.family, (MultivariateFamily, Categorical)):
                 self.output += coef * predictor[:, np.newaxis]
             else:
-                # FIXME: here we see why it fails
-                print("coef shape", coef.shape.eval())
-                print("coef squeezed shape", coef.squeeze().shape.eval())
-                print("predictor shape", predictor.shape)
-                print((coef * predictor).shape.eval())
                 self.output += coef * predictor
 
     def build_response(self, pymc_backend, bmb_model):

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -110,11 +110,13 @@ class GroupSpecificTerm:
             response_dims = list(spec.response_component.response_term.coords)
 
         dims = list(self.coords) + response_dims
+        coef = self.build_distribution(self.term.prior, label, dims=dims, **kwargs)
+
         # Squeeze ensures we don't have a shape of (n, 1) when we mean (n, )
         # This happens with categorical predictors with two levels and intercept.
-        # FIXME: This is not working anymore!
         # See https://github.com/pymc-devs/pymc/issues/7246
-        coef = self.build_distribution(self.term.prior, label, dims=dims, **kwargs).squeeze()
+        if len(coef.shape.eval()) == 2 and coef.shape.eval()[-1] == 1:
+            coef = pt.specify_broadcastable(coef, 1).squeeze()
         coef = coef[self.term.group_index]
 
         return coef, predictor

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -112,6 +112,8 @@ class GroupSpecificTerm:
         dims = list(self.coords) + response_dims
         # Squeeze ensures we don't have a shape of (n, 1) when we mean (n, )
         # This happens with categorical predictors with two levels and intercept.
+        # FIXME: This is not working anymore!
+        # See https://github.com/pymc-devs/pymc/issues/7246
         coef = self.build_distribution(self.term.prior, label, dims=dims, **kwargs).squeeze()
         coef = coef[self.term.group_index]
 

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -403,7 +403,7 @@ class StoppingRatio(UnivariateFamily):
     def transform_backend_kwargs(kwargs):
         # P(Y = k) = F(threshold_k - eta) * \prod_{j=1}^{k-1}{1 - F(threshold_j - eta)}
         p = kwargs.pop("p")
-        n_columns = p.type.shape[-1]
+        n_columns = p.shape.eval()[-1]
         p = pt.concatenate(
             [
                 pt.shape_padright(p[..., 0]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "formulae>=0.5.3",
     "graphviz",
     "pandas>=1.0.0",
-    "pymc>=5.12.0,<5.13.0",
+    "pymc>=5.13.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
* Modify `PyMCModel._clean_results()` to
  1. Compute deterministics using the new `pm.compute_deterministics()` function when a bayeux based sampler is used.
  2. Be more robust at renaming dimension names when a bayeux based sampler is used.
  3. Drop unused dimensions before transposing.
* Use `pt.specify_broadcastable` with group-specific effects when the expression side is a factor variable of two levels. It's a very specific case, but we support it and it was failing with PyMC 5.13 as all coords started to be mutable with this PyMC version.

This PR closes #800

---

**Why I modified how we rename dims with bayeux**. See the following example:

```python
from io import StringIO

import requests

import arviz as az
import bambi as bmb
import pandas as pd

url = "https://raw.githubusercontent.com/crnolan/pyrba/main/data.txt"  # replace with your url
response = requests.get(url)
df = pd.read_table(StringIO(response.text), delimiter=r"\s+")

results = model.fit(
    num_warmup=250, num_samples=200, num_chains=2, inference_method="numpyro_nuts"
)
```

With the old implementation, it would have failed. Look at

https://github.com/bambinos/bambi/blob/5c00663ef290744f20f7f9de700d9051a2ea55b7/bambi/backend/pymc.py#L275-L281

what happened in that case was that `pymc_model_dims` and `bayeux_dims` where of different lengths and thus the dictionary created was mixing things.

This new approach

```python
        dims_original = list(self.model.coords)

        # Identify bayeux idata and rename dims and coordinates to match PyMC model
        if idata_from == "bayeux":
            cleaned_dims = {
                f"{dim}_0": dim
                for dim in dims_original
                if not dim.endswith("_obs") and f"{dim}_0" in idata.posterior.dims
            }
```

exploits the fact that we know we can only rename dims passed to the model, they can't finish with `_obs` and they have to be in the posterior. And most importantly, the "bad" bayeux names are like the original names with an extra `_0` (e.g. `party_id_dim` original and `party_id_dim_0` as result in bayeux).