### PR TITLE
Add Contact form to our webpage

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
 # Bambi Community Code of Conduct
 
-Bambi adopts the NumFOCUS Code of Conduct directly. In other words, we expect our community to treat others with kindness and understanding.
+Bambi adopts the NumFOCUS Code of Conduct directly. 
+In other words, we expect our community to treat others with kindness and understanding.
 
 # The short version  
 
@@ -34,14 +35,7 @@ If you have experienced or witnessed behavior that violates this
 Code of Conduct, please complete the form below to
 make a report.
 
-**REPORTING FORM:** https://numfocus.typeform.com/to/ynjGdT
-
-Reports are sent to the NumFOCUS Code of Conduct Enforcement Team
-(see below).
-
-You can view the Privacy Policy and Terms of Service for TypeForm here.
-The NumFOCUS Privacy Policy is here:
-https://www.numfocus.org/privacy-policy
+**REPORTING FORM:** https://bambinos.github.io/bambi/contact.html
 
 # Full Code of Conduct
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -20,7 +20,7 @@ website:
   page-navigation: true
   favicon: "logos/favicon.png"
   page-footer:
-    center: © Copyright 2023, The developers of Bambi.
+    center: © Copyright 2024, The developers of Bambi.
   navbar:
     title: false
     background: light
@@ -39,6 +39,8 @@ website:
         file: faq.qmd
       - text: Changelog
         file: changelog.qmd
+      - text: Contact
+        file: contact.qmd
       - icon: github
         href: https://github.com/bambinos/bambi
 

--- a/docs/contact.qmd
+++ b/docs/contact.qmd
@@ -1,0 +1,51 @@
+---
+toc: false
+title: "Contact"
+pagetitle: "Contact"
+---
+
+Bambi is dedicated to providing a harassment-free community for everyone, regardless of gender,
+sexual orientation, gender identity, and expression, disability, physical appearance, 
+body size, race, or religion. We do not tolerate harassment of community members in any form.
+
+However, it is not uncommon to suffer or witness abusive behaviors online. 
+If you have experienced or witnessed any behaviour that violates our 
+[Code of Conduct](https://github.com/bambinos/bambi/blob/main/CODE_OF_CONDUCT.md), 
+we encourage you to report it through the form below.
+
+When reporting an incident, please provide as much detail as possible, including:
+
+* The approximate date, time and location of the incident (please be as specific as possible).
+* Any identifying information of the individual whose behavior is being reported (e.g. name, nickname, screen name, physical description).
+* A description of the behavior, your account of what happened, and any available supporting records (e.g. email, GitHub issue url, screenshots, etc.).
+* If reporting harassing language, please be specific about the words used.
+* A description of the circumstances/context surrounding the incident.
+* Is the incident ongoing, and/or is this part of an ongoing pattern of behavior by this individual?
+* Did anyone else observe the incident? If possible, please provide names and contact info of anyone else who witnessed or was involved in this incident.
+* Any other information you believe we should have about what happened or that you'd like us to know.
+
+**All the information be kept confidential**. 
+If you wish to remain anonymous, your information will not be shared beyond the person 
+receiving the initial report.
+
+We take every report of Code of Conduct violations very seriously and will handle each one
+with care and confidentiality. If you're unsure whether certain behavior is a violation, 
+or if you need help with the reporting process, don't hesitate to reach out to us. 
+We are here to help and support you.
+
+```{=html}
+<form action="https://public.herotofu.com/v1/3f06ee10-1515-11ef-a449-3b7e66789316" method="post" accept-charset="UTF-8" class="bambi-form">
+    <input name="name" id="name" type="text" class="feedback-input" placeholder="Name" required>
+    <input name="email" id="email" type="email" class="feedback-input" placeholder="E-mail" required>
+    <textarea name="text" class="feedback-input" placeholder="Your message" required></textarea>
+  <div>
+    <input type="submit" value="SUBMIT" class="form-submit"/>
+    <div style="text-indent:-99999px; white-space:nowrap; overflow:hidden; position:absolute;" aria-hidden="true">
+      <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" />
+    </div>
+  </div>
+</form>
+```
+
+
+

--- a/docs/contact.qmd
+++ b/docs/contact.qmd
@@ -47,5 +47,7 @@ We are here to help and support you.
 </form>
 ```
 
+<br>
 
-
+Form adapted from the [JAXGP Contact Form](https://jaxgaussianprocesses.com/contact/) 
+and the [NumFOCUS Reporting Form](https://numfocus.typeform.com/to/ynjGdT).

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -217,3 +217,43 @@ a:hover {
 section > .level2 {
   overflow-x: auto;
 }
+
+/* Form styles */
+
+.bambi-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
+.feedback-input {
+  background-color: transparent;
+  border-radius: 5px;
+  border: 2px solid #dcdcdc;
+  box-sizing: border-box;
+  outline: 0;
+  padding: 10px;
+  transition: all 0.3s;
+  width: 100%;
+}
+
+.feedback-input:focus {
+  border: 2px solid #12698a;
+}
+
+.form-submit {
+  background: #12698a;
+  border-radius: 5px;
+  border: 2px solid #12698a;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 24px;
+  font-weight: 700;
+  padding: 8px;
+  transition: all 0.3s;
+  width: 100%;
+}
+
+.form-submit:hover {
+  opacity: 0.8;
+}


### PR DESCRIPTION
This PR adds a contact form to our webpage. The goal is to handle reports ourselves instead of delivering them to NumFOCUS as they handle those of Sponsored projects only (and we're affiliated).