### PR TITLE
Resolve import error

### DIFF
--- a/bambi/backend/inference_methods.py
+++ b/bambi/backend/inference_methods.py
@@ -72,6 +72,8 @@ class InferenceMethods:
 
     @property
     def names(self):
+        if self.bayeux_model is None:
+            return {"pymc": self.pymc_methods}
         return {"pymc": self.pymc_methods, "bayeux": self.bayeux_methods}
 
 

--- a/bambi/backend/inference_methods.py
+++ b/bambi/backend/inference_methods.py
@@ -17,6 +17,9 @@ class InferenceMethods:
         self.pymc_methods = self._pymc_methods()
 
     def _get_bayeux_methods(self, model):
+        # If bayeux is not installed, return an empty MCMC list.
+        if model is None:
+            return {"mcmc": []}
         # Bambi only supports bayeux MCMC methods
         mcmc_methods = model.methods.get("mcmc")
         return {"mcmc": mcmc_methods}
@@ -85,7 +88,7 @@ def bayeux_model():
         A dummy model with a simple quadratic likelihood function.
     """
     if importlib.util.find_spec("bayeux") is None:
-        return {"mcmc": []}
+        return None
 
     import bayeux as bx  # pylint: disable=import-outside-toplevel
 

--- a/bambi/backend/inference_methods.py
+++ b/bambi/backend/inference_methods.py
@@ -72,8 +72,6 @@ class InferenceMethods:
 
     @property
     def names(self):
-        if self.bayeux_model is None:
-            return {"pymc": self.pymc_methods}
         return {"pymc": self.pymc_methods, "bayeux": self.bayeux_methods}
 
 


### PR DESCRIPTION
Resolves #820. 

Before, in the function `bayeux_model`, if bayeux is not installed we would early return a dictionary, else if bayeux is installed, then a class is returned. We would then try to access `.methods` on the dict as if it were a class, resulting in the error.