### PR TITLE
Update docstring and args

### DIFF
--- a/bambi/interpret/effects.py
+++ b/bambi/interpret/effects.py
@@ -531,7 +531,7 @@ def predictions(
 
     if pps:
         idata = model.predict(
-            idata, data=cap_data, sample_new_groups=sample_new_groups, inplace=False, kind="pps"
+            idata, data=cap_data, sample_new_groups=sample_new_groups, inplace=False, kind="response"
         )
         y_hat = response_transform(idata["posterior_predictive"][response.name])
         y_hat_mean = y_hat.mean(("chain", "draw"))

--- a/bambi/interpret/effects.py
+++ b/bambi/interpret/effects.py
@@ -531,7 +531,11 @@ def predictions(
 
     if pps:
         idata = model.predict(
-            idata, data=cap_data, sample_new_groups=sample_new_groups, inplace=False, kind="response"
+            idata,
+            data=cap_data,
+            sample_new_groups=sample_new_groups,
+            inplace=False,
+            kind="response",
         )
         y_hat = response_transform(idata["posterior_predictive"][response.name])
         y_hat_mean = y_hat.mean(("chain", "draw"))

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -826,7 +826,7 @@ class Model:
             ``idata`` with the predictions added. If ``kind="response_params"``, a new variable
             with the name of the parent parameter, e.g. ``"mu"`` and ``"sigma" for a Gaussian
             likelihood, or ``"p"`` for a Bernoulli likelihood, is added to the ``posterior`` group.
-            If ``kind="response"``, it appends a ``posterior_predictive`` group to ``idata``. If 
+            If ``kind="response"``, it appends a ``posterior_predictive`` group to ``idata``. If
             any of these already exist, it will be overwritten.
         include_group_specific : bool
             Determines if predictions incorporate group-specific effects. If ``False``, predictions

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -823,8 +823,8 @@ class Model:
         inplace : bool
             If ``True`` it will modify ``idata`` in-place. Otherwise, it will return a copy of
             ``idata`` with the predictions added. If ``kind="response_params"``, a new variable
-            with the name of the parent parameter, e.g. ``"mu"`` or ``"p"``is added to the 
-            ``posterior`` group. If ``kind="response"``, it appends a ``posterior_predictive`` group 
+            with the name of the parent parameter, e.g. ``"mu"`` or ``"p"``is added to the
+            ``posterior`` group. If ``kind="response"``, it appends a ``posterior_predictive`` group
             to ``idata``. If any of these already exist, it will be overwritten.
         include_group_specific : bool
             Determines if predictions incorporate group-specific effects. If ``False``, predictions

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -812,11 +812,11 @@ class Model:
         idata : InferenceData
             The ``InferenceData`` instance returned by ``.fit()``.
         kind : str
-            Indicates the type of prediction required. Can be ``"response_params"`` or ``"response"``. The
-            first returns draws from the posterior distribution of the mean, while the latter
-            returns the draws from the posterior predictive distribution (i.e. the posterior
-            probability distribution for a new observation) in addition to the mean posterior
-            distribution. Defaults to ``"response_params"``.
+            Indicates the type of prediction required. Can be ``"response_params"`` or
+            ``"response"``. The first returns draws from the posterior distribution of
+            the mean, while the latter returns the draws from the posterior predictive
+            distribution (i.e. the posterior probability distribution for a new observation)
+            in addition to the mean posterior distribution. Defaults to ``"response_params"``.
         data : pandas.DataFrame or None
             An optional data frame with values for the predictors that are used to obtain
             out-of-sample predictions. If omitted, the original dataset is used.

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -813,19 +813,21 @@ class Model:
             The ``InferenceData`` instance returned by ``.fit()``.
         kind : str
             Indicates the type of prediction required. Can be ``"response_params"`` or
-            ``"response"``. The first returns draws from the posterior distribution of
-            the mean, while the latter returns the draws from the posterior predictive
-            distribution (i.e. the posterior probability distribution for a new observation)
-            in addition to the mean posterior distribution. Defaults to ``"response_params"``.
+            ``"response"``. The first returns draws from the posterior distribution of the
+            likelihood parameters, while the latter returns the draws from the posterior
+            predictive distribution (i.e. the posterior probability distribution for a new
+            observation) in addition to the posterior distribution. Defaults to
+            ``"response_params"``.
         data : pandas.DataFrame or None
             An optional data frame with values for the predictors that are used to obtain
             out-of-sample predictions. If omitted, the original dataset is used.
         inplace : bool
             If ``True`` it will modify ``idata`` in-place. Otherwise, it will return a copy of
             ``idata`` with the predictions added. If ``kind="response_params"``, a new variable
-            with the name of the parent parameter, e.g. ``"mu"`` or ``"p"``is added to the
-            ``posterior`` group. If ``kind="response"``, it appends a ``posterior_predictive`` group
-            to ``idata``. If any of these already exist, it will be overwritten.
+            with the name of the parent parameter, e.g. ``"mu"`` and ``"sigma" for a Gaussian
+            likelihood, or ``"p"`` for a Bernoulli likelihood, is added to the ``posterior`` group.
+            If ``kind="response"``, it appends a ``posterior_predictive`` group to ``idata``. If 
+            any of these already exist, it will be overwritten.
         include_group_specific : bool
             Determines if predictions incorporate group-specific effects. If ``False``, predictions
             are made with common effects only (i.e. group specific are set to zero). Defaults to

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -812,20 +812,20 @@ class Model:
         idata : InferenceData
             The ``InferenceData`` instance returned by ``.fit()``.
         kind : str
-            Indicates the type of prediction required. Can be ``"mean"`` or ``"pps"``. The
+            Indicates the type of prediction required. Can be ``"response_params"`` or ``"response"``. The
             first returns draws from the posterior distribution of the mean, while the latter
             returns the draws from the posterior predictive distribution (i.e. the posterior
             probability distribution for a new observation) in addition to the mean posterior
-            distribution. Defaults to ``"mean"``.
+            distribution. Defaults to ``"response_params"``.
         data : pandas.DataFrame or None
             An optional data frame with values for the predictors that are used to obtain
             out-of-sample predictions. If omitted, the original dataset is used.
         inplace : bool
             If ``True`` it will modify ``idata`` in-place. Otherwise, it will return a copy of
-            ``idata`` with the predictions added. If ``kind="mean"``, a new variable ending in
-            ``"_mean"`` is added to the ``posterior`` group. If ``kind="pps"``, it appends a
-            ``posterior_predictive`` group to ``idata``. If any of these already exist, it will be
-            overwritten.
+            ``idata`` with the predictions added. If ``kind="response_params"``, a new variable
+            with the name of the parent parameter, e.g. ``"mu"`` or ``"p"``is added to the 
+            ``posterior`` group. If ``kind="response"``, it appends a ``posterior_predictive`` group 
+            to ``idata``. If any of these already exist, it will be overwritten.
         include_group_specific : bool
             Determines if predictions incorporate group-specific effects. If ``False``, predictions
             are made with common effects only (i.e. group specific are set to zero). Defaults to


### PR DESCRIPTION
This PR changes the docstring of `kind` in `model.predict` to reflect the changes in #804. 

Additionally, in the `interpret` function `predictions`, we allow the user to compute posterior predictive samples. I updated the argument passed to `model.predict` from `kind="pps"` to `kind="response"` to reflect the changes in the merged PR above.