### PR TITLE
Change the jax random number generator key for 32-bit python

### DIFF
--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -252,7 +252,7 @@ class PyMCModel:
                     random_seed = random_seed[0]
                 np.random.seed(random_seed)
 
-            jax_seed = jax.random.PRNGKey(np.random.randint(2**32 - 1))
+            jax_seed = jax.random.PRNGKey(np.random.randint(2**31 - 1))
 
             bx_model = bx.Model.from_pymc(self.model)
             bx_sampler = operator.attrgetter(sampler_backend)(


### PR DESCRIPTION
Resolves #832. See that issue for a full explanation, but long-story-short, the current value of `2**32-1` yields an overflow error in 32-bit python.

 In theory we can do `2**31` and not `2**31-1` if we would like, the former seems to run without issue as well, I just kept with the `-1` to be consistent with the current implementation.