### PR TITLE
change os.rename to os.replace in pre-render.py

### DIFF
--- a/docs/pre_render.py
+++ b/docs/pre_render.py
@@ -3,7 +3,7 @@ import shutil
 
 # Copy CHANGELOG file to 'docs' and change its extension to '.qmd'
 shutil.copyfile("../CHANGELOG.md", "CHANGELOG.md")
-os.rename("CHANGELOG.md", "changelog.qmd")
+os.replace("CHANGELOG.md", "changelog.qmd")
 
 # Remove TOC from it
 lines = """---


### PR DESCRIPTION
Building the `Bambi` docs with quarto was giving a "file exists" error during pre-render while trying to rename "CHANGELOG.md" to "changelog.qmd".    Simply changing `os.rename` to `os.replace` fixes this. 

An alternative would be to add the CHANGELOG.md to the `_quarto.yml` explicitly (quarto can render md too)