### PR TITLE
Handle multivariate responses with HSGP

### DIFF
--- a/bambi/backend/model_components.py
+++ b/bambi/backend/model_components.py
@@ -53,7 +53,7 @@ class DistributionalComponent:
             self.build_intercept(bmb_model)
             self.build_offsets()
             self.build_common_terms(pymc_backend, bmb_model)
-            self.build_hsgp_terms(pymc_backend)
+            self.build_hsgp_terms(bmb_model, pymc_backend)
             self.build_group_specific_terms(pymc_backend, bmb_model)
 
     def build_intercept(self, bmb_model):
@@ -109,7 +109,7 @@ class DistributionalComponent:
             # Add term to linear predictor
             self.output += pt.dot(data, coefs)
 
-    def build_hsgp_terms(self, pymc_backend):
+    def build_hsgp_terms(self, bmb_model, pymc_backend):
         """Add HSGP (Hilbert-Space Gaussian Process approximation) terms to the PyMC model.
 
         The linear predictor 'X @ b + Z @ u' can be augmented with non-parametric HSGP terms
@@ -120,7 +120,7 @@ class DistributionalComponent:
             for name, values in hsgp_term.coords.items():
                 if name not in pymc_backend.model.coords:
                     pymc_backend.model.add_coords({name: values})
-            self.output += hsgp_term.build()
+            self.output += hsgp_term.build(bmb_model)
 
     def build_group_specific_terms(self, pymc_backend, bmb_model):
         """Add group-specific (random or varying) terms to the PyMC model.

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -12,7 +12,7 @@ from bambi.backend.utils import (
     make_weighted_distribution,
     GP_KERNELS,
 )
-from bambi.families.multivariate import MultivariateFamily, Multinomial, DirichletMultinomial
+from bambi.families.multivariate import MultivariateFamily
 from bambi.families.univariate import Categorical, Cumulative, StoppingRatio
 from bambi.priors import Prior
 
@@ -234,25 +234,15 @@ class ResponseTerm:
         # Auxiliary parameters and data
         kwargs = {"observed": data, "dims": ("__obs__",)}
 
-        if isinstance(
-            self.family,
-            (
-                MultivariateFamily,
-                Categorical,
-                Cumulative,
-                StoppingRatio,
-                Multinomial,
-                DirichletMultinomial,
-            ),
-        ):
+        if isinstance(self.family, (MultivariateFamily, Categorical, Cumulative, StoppingRatio)):
             response_term = bmb_model.response_component.term
             response_name = response_term.alias or response_term.name
             dim_name = response_name + "_dim"
             pymc_backend.model.add_coords({dim_name: response_term.levels})
             dims = ("__obs__", dim_name)
 
-            # For a subset of the families, the outcome variable has two dimensions too.
-            if isinstance(self.family, (MultivariateFamily, Multinomial, DirichletMultinomial)):
+            # For multivariate families, the outcome variable has two dimensions too.
+            if isinstance(self.family, MultivariateFamily):
                 kwargs["dims"] = dims
         else:
             dims = ("__obs__",)

--- a/bambi/backend/terms.py
+++ b/bambi/backend/terms.py
@@ -250,6 +250,10 @@ class ResponseTerm:
             dim_name = response_name + "_dim"
             pymc_backend.model.add_coords({dim_name: response_term.levels})
             dims = ("__obs__", dim_name)
+
+            # For a subset of the families, the outcome variable has two dimensions too.
+            if isinstance(self.family, (MultivariateFamily, Multinomial, DirichletMultinomial)):
+                kwargs["dims"] = dims
         else:
             dims = ("__obs__",)
 

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -158,9 +158,6 @@ class Family:
                 pm.Truncated.dist(response_dist.dist(**kwargs), lower=lower, upper=upper)
             )
         else:
-            # for k, v in kwargs.items():
-            #     print(k, v.shape)
-            # kwargs["n"] = np.ones(shape=20).astype(int)
             output_array = pm.draw(response_dist.dist(**kwargs))
 
         return xr.DataArray(output_array, coords=coords)

--- a/bambi/families/family.py
+++ b/bambi/families/family.py
@@ -158,6 +158,9 @@ class Family:
                 pm.Truncated.dist(response_dist.dist(**kwargs), lower=lower, upper=upper)
             )
         else:
+            # for k, v in kwargs.items():
+            #     print(k, v.shape)
+            # kwargs["n"] = np.ones(shape=20).astype(int)
             output_array = pm.draw(response_dist.dist(**kwargs))
 
         return xr.DataArray(output_array, coords=coords)


### PR DESCRIPTION
This PR does two things.

* Main: Make it possible to use HSGP with multivariate responses, such as a multinomial likelihood.
* Adjacent: Make multivariate families use two dims. So far, it created an extra dimension which was not equal to the response dimension.

There's something I would like to clarify about HSGP with multivariate responses. With this PR it's possible to do something like

```python
formula = "c(y1, y2, y3) ~ 0 + hsgp(x, m=30, c=2)"
hsgp_model = bmb.Model(formula, df, family="multinomial")

# Setting aliases for a nicer graph
hsgp_model.set_alias({"c(y1, y2, y3)": "result"})
hsgp_model.set_alias({"hsgp(x, m=30, c=2)": "hsgp"})
hsgp_model.build()
hsgp_model.graph()
```

and the graph will look like:

![image](https://github.com/user-attachments/assets/4bf98c9d-b676-4f94-b0a8-7189db7e73af)

See all the dimensions of the response share the same priors for `hsgp_sigma` and `hsgp_ell`. Theoretically, it's possible to use a different coefficient for each response dimension. However, Bambi does not support that, and after some thought I decided it is fine that way. 

The implementation is _very_ complicated already, and it would be much more complicated if we decided to handle this. There's the `by` (and `share_cov`) argument in `hsgp()`, which could make us think we can use it for this purpose. However, that argument expects categories to be values within a given variable. In the multivariate family case, the dimensions are different columns (i.e. `y1`, `y2`, and `y3` in the example above). So, at least, we would need a special way to tell Bambi to handle things differently in this special case.

On top of that, a multivariate model with an HSGP is already a fairly complex model. To have a more granular control of HSGP, one should use a PPL like PyMC. 

I'm open to change my mind in the future, but for now, I think this is good enough.
