### PR TITLE
Fixed formatting in t-test examples

### DIFF
--- a/docs/notebooks/t-test.ipynb
+++ b/docs/notebooks/t-test.ipynb
@@ -203,7 +203,9 @@
     "\n",
     "$$\n",
     "\\beta_0 + \\epsilon_i = \\beta_0 + \\beta_1 + \\epsilon_i\\\\\n",
-    "0 = \\beta_1\n",
+    "$$\n",
+    "$$\n",
+    "\\beta_1 = 0\n",
     "$$\n",
     "\n",
     "Thus, we can see that testing whether the mean of the two populations are equal is equivalent to testing whether $\\beta_1$ is 0."


### PR DESCRIPTION
Formatted the docs for [t-test](https://bambinos.github.io/bambi/notebooks/t-test.html) for better readability, by adding a line break to distinguish between the consecutive steps.

**Before**
$\beta_0 + \epsilon_i = \beta_0 + \beta_1 + \epsilon_i\\ 0 = \beta_1 $

**After**
$\beta_0 + \epsilon_i = \beta_0 + \beta_1 + \epsilon_i\\ $
$\beta_1 = 0 $

Fixes #860 

- [x] code passes `black`
- [x] code passes `pylint`
- [x] all tests pass

