### PR TITLE
Fix random seed handling for "vi"

### DIFF
--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -148,7 +148,7 @@ class PyMCModel:
                 **kwargs,
             )
         elif inference_method in self.pymc_methods["vi"]:
-            result = self._run_vi(**kwargs)
+            result = self._run_vi(random_seed, **kwargs)
         elif inference_method == "laplace":
             result = self._run_laplace(draws, omit_offsets, include_response_params)
         else:
@@ -382,9 +382,9 @@ class PyMCModel:
 
         return idata
 
-    def _run_vi(self, **kwargs):
+    def _run_vi(self, random_seed, **kwargs):
         with self.model:
-            self.vi_approx = pm.fit(**kwargs)
+            self.vi_approx = pm.fit(random_seed=random_seed, **kwargs)
         return self.vi_approx
 
     def _run_laplace(self, draws, omit_offsets, include_response_params):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -824,16 +824,16 @@ class TestBeta(FitPredictParent):
         model.predict(idata, kind="response")
 
         assert (0 < idata.posterior["mu"]).all() & (idata.posterior["mu"] < 1).all()
-        assert (0 < idata.posterior_predictive["yield"]).all() & (
-            idata.posterior_predictive["yield"] < 1
+        assert (0 <= idata.posterior_predictive["yield"]).all() & (
+            idata.posterior_predictive["yield"] <= 1
         ).all()
 
         model.predict(idata, kind="response_params", data=gasoline_data.iloc[:20, :])
         model.predict(idata, kind="response", data=gasoline_data.iloc[:20, :])
 
         assert (0 < idata.posterior["mu"]).all() & (idata.posterior["mu"] < 1).all()
-        assert (0 < idata.posterior_predictive["yield"]).all() & (
-            idata.posterior_predictive["yield"] < 1
+        assert (0 <= idata.posterior_predictive["yield"]).all() & (
+            idata.posterior_predictive["yield"] <= 1
         ).all()
 
 


### PR DESCRIPTION
Random seed was not properly passed on when `inference_method="vi"`. This is now resolved.


- [x]  Install all the needed requirements (`requirements.txt`, `requirements-dev.txt`, etc.)
- [x] Make sure all test pass.
- [x] Make sure your code passes `black`.
- [x] Make sure your code passes `pylint`.
