### PR TITLE
[ENH] Add the Option to Choose Number of Draws in PPD

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -804,6 +804,7 @@ class Model:
         include_group_specific=True,
         sample_new_groups=False,
         num_draws=None,
+        random_seed=42,
     ):
         """Predict method for Bambi models
 
@@ -843,6 +844,8 @@ class Model:
         num_draws : int or None, optional
             Determines the number of draws to use for the posterior predictive distribution.
             If `None`, all available draws from the posterior are used.
+        random_seed : int
+            Seed for the random number generator.
 
         Returns
         -------
@@ -869,6 +872,8 @@ class Model:
             idata = deepcopy(idata)
 
         if num_draws is not None:
+            if inplace:
+                raise ValueError("Cannot set `inplace=True` when `num_draws` is not None.")
             total_draws = len(idata.posterior.draw)
             if num_draws > total_draws:
                 warnings.warn(
@@ -878,9 +883,9 @@ class Model:
                 )
                 num_draws = total_draws
 
-            selected_draws = np.random.choice(
-                idata.posterior.draw.values, size=num_draws, replace=False
-            )
+            rng = np.random.default_rng(seed=random_seed)
+
+            selected_draws = rng.choice(idata.posterior.draw.values, size=num_draws, replace=False)
 
             idata_subset = idata.sel(draw=selected_draws)
         else:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -877,13 +877,11 @@ class Model:
                     UserWarning,
                 )
                 num_draws = total_draws
-            
+
             selected_draws = np.random.choice(
-                idata.posterior.draw.values, 
-                size=num_draws, 
-                replace=False
+                idata.posterior.draw.values, size=num_draws, replace=False
             )
-            
+
             idata_subset = idata.sel(draw=selected_draws)
         else:
             idata_subset = idata

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -804,7 +804,7 @@ class Model:
         include_group_specific=True,
         sample_new_groups=False,
         num_draws=None,
-        random_seed=42,
+        random_seed=None,
     ):
         """Predict method for Bambi models
 


### PR DESCRIPTION
Closes #739 

This PR modifies the `predict` method in the `Model` class such that it now accepts an optional argument `num_draws` and then randomly selects the number of draws from the posterior predictive distribution, i.e, `num_draws` from the total draws without replacement. If the `num_draws` is more than the total draws then it gives a warning and falls back to the total draws. 

- Passes `pylint` 
- Passes `black`

I will appreciate help with the testing of the method with this new parameter. 
