### PR TITLE
typo fix -> `SETTINGS_FAMILIES` to `BUILTIN_FAMILIES`

### DIFF
--- a/bambi/defaults/families.py
+++ b/bambi/defaults/families.py
@@ -306,7 +306,7 @@ def get_builtin_family(name):
     `bambi.families.Likelihood` and the `bambi.priors.Prior` instances that are needed to build
     the family.
 
-    The available built-in families are found in `SETTINGS_FAMILIES`.
+    The available built-in families are found in `BUILTIN_FAMILIES`.
 
     Parameters
     ----------


### PR DESCRIPTION
The `SETTINGS_FAMILIES` variable or environment variable doesn't exist in the repository. I think this was supposed to be `BUILTIN_FAMILIES`. Thanks :)

**Thank your for opening a PR!**

Before you proceed, please check the following notes.

* Make sure you describe the changes introduced in the PR.
* If this PR addresses an existing issue, please mention it here.
* Check our [Guidelines for Contributing](https://github.com/bambinos/bambi/blob/main/CONTRIBUTING.md).
* In particular, pay attention to the [pull request checklist](https://github.com/bambinos/bambi/blob/main/CONTRIBUTING.md#pull-request-checklist).
* The most important points are to
    + Install all the needed requirements (`requirements.txt`, `requirements-dev.txt`, etc.)
    + Make sure all test pass.
    + Make sure your code passes `black`.
    + Make sure your code passes `pylint`.
