### PR TITLE
[ENH] Add tqdm Progress Bar for model.predict()

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -804,6 +804,7 @@ class Model:
         include_group_specific=True,
         sample_new_groups=False,
         num_draws=None,
+        random_seed=42,
     ):
         """Predict method for Bambi models
 
@@ -843,6 +844,8 @@ class Model:
         num_draws : int or None, optional
             Determines the number of draws to use for the posterior predictive distribution.
             If `None`, all available draws from the posterior are used.
+        random_seed : int
+            Seed for the random number generator.
 
         Returns
         -------
@@ -869,6 +872,8 @@ class Model:
             idata = deepcopy(idata)
 
         if num_draws is not None:
+            if inplace:
+                raise ValueError("Cannot set `inplace=True` when `num_draws` is not None.")
             total_draws = len(idata.posterior.draw)
             if num_draws > total_draws:
                 warnings.warn(
@@ -878,9 +883,9 @@ class Model:
                 )
                 num_draws = total_draws
 
-            selected_draws = np.random.choice(
-                idata.posterior.draw.values, size=num_draws, replace=False
-            )
+            rng = np.random.default_rng(seed=random_seed)
+
+            selected_draws = rng.choice(idata.posterior.draw.values, size=num_draws, replace=False)
 
             idata_subset = idata.sel(draw=selected_draws)
         else:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -877,13 +877,11 @@ class Model:
                     UserWarning,
                 )
                 num_draws = total_draws
-            
+
             selected_draws = np.random.choice(
-                idata.posterior.draw.values, 
-                size=num_draws, 
-                replace=False
+                idata.posterior.draw.values, size=num_draws, replace=False
             )
-            
+
             idata_subset = idata.sel(draw=selected_draws)
         else:
             idata_subset = idata

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -804,7 +804,7 @@ class Model:
         include_group_specific=True,
         sample_new_groups=False,
         num_draws=None,
-        random_seed=42,
+        random_seed=None,
     ):
         """Predict method for Bambi models
 

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -10,6 +10,7 @@ import formulae as fm
 import pymc as pm
 import pandas as pd
 import numpy as np
+from tqdm import tqdm
 
 from arviz.plots import plot_posterior
 
@@ -995,7 +996,7 @@ class Model:
         hsgp_dict = {}  # To store the HSGP contributions (they are added to the posterior dataset)
         response_dim = "__obs__"
 
-        for name, component in self.distributional_components.items():
+        for name, component in tqdm(self.distributional_components.items()):
             var_name = component.alias if component.alias else name
             means_dict[var_name] = component.predict(
                 idata, data, include_group_specific, hsgp_dict, sample_new_groups


### PR DESCRIPTION
Closes #818 

This PR adds a `tqdm` progress bar to visualise the progress during the running of `model.predict()` method. The progress bar is put around the loop in `_compute_likelihood_params()` method where `distributional_components` are getting processed.

- Passes `black`
- Passes `pylint`

Thanks :)