### PR TITLE
Plot predictions categorical error

### DIFF
--- a/bambi/interpret/plot_types.py
+++ b/bambi/interpret/plot_types.py
@@ -217,11 +217,21 @@ def plot_categoric(covariates: Covariates, plot_data: pd.DataFrame, legend: bool
             ax.vlines(idxs_main, y_hat_bounds[0], y_hat_bounds[1], color="C0")
     elif "group" in covariates and not "panel" in covariates:
         ax = axes[0]
-        for i, clr in enumerate(colors):
-            idx = (plot_data[color] == clr).to_numpy()
-            idxs = idxs_main + colors_offset[i]
-            ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
-            ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
+        if main == color:
+            # When main and group are the same variable, each color corresponds to one main level
+            for i, clr in enumerate(colors):
+                idx = (plot_data[color] == clr).to_numpy()
+                # Find which main level this color corresponds to
+                main_level_idx = np.where(main_levels == clr)[0][0]
+                idxs = main_level_idx + colors_offset[i]
+                ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
+                ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
+        else:
+            for i, clr in enumerate(colors):
+                idx = (plot_data[color] == clr).to_numpy()
+                idxs = idxs_main + colors_offset[i]
+                ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
+                ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
     elif not "group" in covariates and "panel" in covariates:
         for ax, pnl in zip(axes.ravel(), panels):
             idx = (plot_data[panel] == pnl).to_numpy()
@@ -229,13 +239,34 @@ def plot_categoric(covariates: Covariates, plot_data: pd.DataFrame, legend: bool
             ax.vlines(idxs_main, y_hat_bounds[0][idx], y_hat_bounds[1][idx])
             ax.set(title=f"{panel} = {pnl}")
     elif "group" in covariates and "panel" in covariates:
-        if color == panel:
+        if main == color == panel:
+            # When main, group and panel are all the same variable
+            for i, (ax, pnl) in enumerate(zip(axes.ravel(), panels)):
+                idx = (plot_data[panel] == pnl).to_numpy()
+                # Find which main level this panel corresponds to
+                main_level_idx = np.where(main_levels == pnl)[0][0]
+                idxs = main_level_idx
+                ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
+                ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
+                ax.set(title=f"{panel} = {pnl}")
+        elif color == panel:
             for i, (ax, pnl) in enumerate(zip(axes.ravel(), panels)):
                 idx = (plot_data[panel] == pnl).to_numpy()
                 idxs = idxs_main + colors_offset[i]
                 ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
                 ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
                 ax.set(title=f"{panel} = {pnl}")
+        elif main == color:
+            # When main and group are the same variable
+            for ax, pnl in zip(axes.ravel(), panels):
+                for i, clr in enumerate(colors):
+                    idx = ((plot_data[panel] == pnl) & (plot_data[color] == clr)).to_numpy()
+                    # Find which main level this color corresponds to
+                    main_level_idx = np.where(main_levels == clr)[0][0]
+                    idxs = main_level_idx + colors_offset[i]
+                    ax.scatter(idxs, y_hat_mean[idx], color=f"C{i}")
+                    ax.vlines(idxs, y_hat_bounds[0][idx], y_hat_bounds[1][idx], color=f"C{i}")
+                    ax.set(title=f"{panel} = {pnl}")
         else:
             for ax, pnl in zip(axes.ravel(), panels):
                 for i, clr in enumerate(colors):

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -446,20 +446,16 @@ class TestPredictions:
         # Test that the plot works with a non-formulae transformation
         plot_predictions(model, idata, "x1")
 
-    def test_same_variable_conditional_and_group(self):
-        # Create test data with categorical variable
-        rng = np.random.default_rng(1234)
-        levels = list("ABC")
-        df = pd.DataFrame({"y": rng.normal(size=100), "factor": rng.choice(levels, size=100)})
+    def test_same_variable_conditional_and_group(self, mtcars):
+        model, idata = mtcars
 
-        model = bmb.Model("y ~ factor", data=df)
-        idata = model.fit(tune=100, draws=100, random_seed=1234)
-
+        # Plot predictions where a categorical variable is passed to both
+        # `conditional` and as the `group` variable
         plot_predictions(
             model=model,
             idata=idata,
-            conditional="factor",
-            subplot_kwargs={"group": "factor"}
+            conditional="am",
+            subplot_kwargs={"group": "am"}
         )
 
 

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -196,7 +196,7 @@ def formulae_transform():
 @pytest.fixture(scope="module")
 def nonformulae_transform():
     """
-    A model with a non-formulae transformation on a term. 
+    A model with a non-formulae transformation on a term.
     """
     np.random.seed(0)
     x1 = np.random.uniform(1, 50, 50)
@@ -433,8 +433,8 @@ class TestPredictions:
     def test_categorical_response(self, food_choice, covariates):
         model, idata = food_choice
         plot_predictions(model, idata, covariates)
-    
-    
+
+
     def test_term_transformations(self, formulae_transform, nonformulae_transform):
         model, idata = formulae_transform
 
@@ -442,9 +442,25 @@ class TestPredictions:
         plot_predictions(model, idata, ["x2", "x1"])
 
         model, idata = nonformulae_transform
-    
+
         # Test that the plot works with a non-formulae transformation
         plot_predictions(model, idata, "x1")
+
+    def test_same_variable_conditional_and_group(self):
+        # Create test data with categorical variable
+        rng = np.random.default_rng(1234)
+        levels = list("ABC")
+        df = pd.DataFrame({"y": rng.normal(size=100), "factor": rng.choice(levels, size=100)})
+
+        model = bmb.Model("y ~ factor", data=df)
+        idata = model.fit(tune=100, draws=100, random_seed=1234)
+
+        plot_predictions(
+            model=model,
+            idata=idata,
+            conditional="factor",
+            subplot_kwargs={"group": "factor"}
+        )
 
 
 class TestComparison:


### PR DESCRIPTION
Resolves #870. Previously, calling `bambi.interpret_plot_predictions()` would fail when we condition and color by the same categorical variable. 

In the `plot_categoric` function in [bambi/bambi/interpret/plot_types.py](https://github.com/bambinos/bambi/blob/2a4f7e1b29cc7b1be868f807882c7df1ebbc7976/bambi/interpret/plot_types.py#L221-L224), when both the main conditional variable and the group variable were the same (e.g., both "factor"), the code would filter the data to only include rows where `color == clr` (one specific level of the factor), but still try to plot using positions for all levels of the main variable. This created a mismatch between the x-coordinates (all levels) and y-coordinates (one level only).

To resolve the error, more logic was added in the `plot_categoric` function to ensure the proper filtering and handling of variables when passed as `main`, `group`, or `panel`.

```python
import bambi as bmb
import numpy as np
import pandas as pd

rng = np.random.default_rng(1234)
levels = list("ABC")
df = pd.DataFrame({"y": rng.normal(size=100), "factor": rng.choice(levels, size=100)})

model = bmb.Model("y ~ factor", data=df)
idata = model.fit()

bmb.interpret.plot_predictions(
    model=model,
    idata=idata,
    conditional="factor",
    subplot_kwargs={"group": "factor"}
)
```
![Figure_1](https://github.com/user-attachments/assets/bbb1017e-3ccc-4350-8135-28422332b541)




