### PR TITLE
Added the link to Strack RRR paper

### DIFF
--- a/docs/notebooks/Strack_RRR_re_analysis.ipynb
+++ b/docs/notebooks/Strack_RRR_re_analysis.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this Jupyter notebook, we do a Bayesian reanalysis of the data reported in the [recent registered replication report](http://www.psychologicalscience.org/pdf/StrackRRR_manuscript_accepted.pdf) (RRR) of a famous study by Strack, Martin & Stepper (1988). The original Strack et al. study tested a *facial feedback hypothesis* arguing that emotional responses are, in part, driven by facial expressions (rather than expressions always following from emotions). Strack and colleagues reported that participants rated cartoons as more funny when the participants held a pen in their teeth (unknowingly inducing a smile) than when they held a pen between their lips (unknowingly inducing a pout). The article has been cited over 1,400 times, and has been enormously influential in popularizing the view that affective experiences and outward expressions of affective experiences can both influence each other (instead of the relationship being a one-way street from experience to expression). In 2016, a Registered Replication Report led by Wagenmakers and colleagues attempted to replicate Study 1 from Strack, Martin, & Stepper (1988) in 17 independent experiments comprising over 2,500 participants. The RRR reported no evidence in support of the effect.\n",
+    "In this Jupyter notebook, we do a Bayesian reanalysis of the data reported in the [recent registered replication report](https://doi.org/10.1177/1745691616674458) (RRR) of a famous study by Strack, Martin & Stepper (1988). The original Strack et al. study tested a *facial feedback hypothesis* arguing that emotional responses are, in part, driven by facial expressions (rather than expressions always following from emotions). Strack and colleagues reported that participants rated cartoons as more funny when the participants held a pen in their teeth (unknowingly inducing a smile) than when they held a pen between their lips (unknowingly inducing a pout). The article has been cited over 1,400 times, and has been enormously influential in popularizing the view that affective experiences and outward expressions of affective experiences can both influence each other (instead of the relationship being a one-way street from experience to expression). In 2016, a Registered Replication Report led by Wagenmakers and colleagues attempted to replicate Study 1 from Strack, Martin, & Stepper (1988) in 17 independent experiments comprising over 2,500 participants. The RRR reported no evidence in support of the effect.\n",
     "\n",
     "Because the emphasis here is on fitting models in Bambi, we spend very little time on quality control and data exploration; our goal is simply to show how one can replicate and extend the primary analysis reported in the RRR in a few lines of Bambi code."
    ]
@@ -971,9 +971,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -985,7 +985,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.5"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Notebook: Bayesian Workflow (Strack RRR Analysis Replication)
https://bambinos.github.io/bambi/notebooks/Strack_RRR_re_analysis.html

The update link of the Registered Replication Report:
https://doi.org/10.1177/1745691616674458

Original link does not work:
https://www.psychologicalscience.org/pdf/StrackRRR_manuscript_accepted.pdf