### PR TITLE
DOC Updated links in Robust Linear Regression

### DIFF
--- a/docs/notebooks/t_regression.ipynb
+++ b/docs/notebooks/t_regression.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Robust Linear Regression\n",
     "\n",
-    "This example has been lifted from the [PyMC Docs](https://docs.pymc.io/notebooks/GLM-robust.html), and adapted to for Bambi by Tyler James Burch ([\\@tjburch](https://github.com/tjburch) on GitHub).\n",
+    "This example has been lifted from the [PyMC Docs](https://www.pymc.io/projects/examples/en/latest/generalized_linear_models/GLM-robust.html), and adapted to for Bambi by Tyler James Burch ([\\@tjburch](https://github.com/tjburch) on GitHub).\n",
     "\n",
     "Many toy datasets circumvent problems that practitioners run into with real data. Specifically, the assumption of normality can be easily violated by outliers, which can cause havoc in traditional linear regression. One way to navigate this is through _robust linear regression_, outlined in this example.\n",
     "\n",
@@ -516,7 +516,7 @@
    "source": [
     "As we can see, the tails of the Student T are much larger, which means values far from the mean are more likely when compared to the normal distribution.\n",
     "\n",
-    "The T distribution is specified by a number of degrees of freedom ($\\nu$). In [`numpy.random.standard_t`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.standard_t.html) this is the parameter `df`, in the [pymc T distribution](https://docs.pymc.io/api/distributions/continuous.html#pymc3.distributions.continuous.StudentT), it's `nu`. It is constrained to real numbers greater than 0. As the degrees of freedom increase, the probability in the tails Student T distribution decrease. In the limit of $\\nu \\rightarrow + \\infty$, the Student T distribution is a normal distribution. Below, the T distribution is plotted for various $\\nu$."
+    "The T distribution is specified by a number of degrees of freedom ($\\nu$). In [`numpy.random.standard_t`](https://numpy.org/doc/stable/reference/random/generated/numpy.random.standard_t.html) this is the parameter `df`, in the [pymc T distribution](https://www.pymc.io/projects/docs/en/stable/api/distributions/generated/pymc.StudentT.html), it's `nu`. It is constrained to real numbers greater than 0. As the degrees of freedom increase, the probability in the tails Student T distribution decrease. In the limit of $\\nu \\rightarrow + \\infty$, the Student T distribution is a normal distribution. Below, the T distribution is plotted for various $\\nu$."
    ]
   },
   {
@@ -1160,9 +1160,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1174,7 +1174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.5"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Updated two links to pymc.io in the Robust Linear Regression example.
