### PR TITLE
Auto-detect sparse matmul for JAX backends

### DIFF
--- a/bambi/backend/model_components.py
+++ b/bambi/backend/model_components.py
@@ -6,10 +6,8 @@ from pytensor import sparse as ps
 
 from bambi.backend.terms import CommonTerm, GroupSpecificTerm, HSGPTerm, InterceptTerm, ResponseTerm
 from bambi.backend.utils import get_distribution_from_prior
-from bambi.config import config as bmb_config
 from bambi.families.multivariate import MultivariateFamily
 from bambi.families.univariate import Categorical, Cumulative, StoppingRatio
-
 
 ORDINAL_FAMILIES = (Cumulative, StoppingRatio)
 
@@ -154,7 +152,7 @@ class DistributionalComponent:
             predictors.append(term.predictor)
             group_indexes.append(term.group_index)
 
-        if bmb_config["SPARSE_DOT"]:
+        if bmb_model.sparse_dot:
             coefs_reshaped = []
             for coef in coefs:
                 if as_multivariate and coef.ndim == 3:

--- a/bambi/backend/utils.py
+++ b/bambi/backend/utils.py
@@ -205,19 +205,22 @@ def make_weighted_distribution(dist: pm.Distribution):
 
 
 def should_use_sparse_dot(inference_method=None):
-    """Determine whether to use sparse matrix multiplication for group effects.
+    """Determine whether to use sparse matrix multiplication for group-specific effects.
 
-    Sparse matmul is faster on JAX/GPU backends but may be slower on CPU backends.
+    Sparse matrix multiplication is faster on JAX/GPU backends (numpyro, blackjax) but may be
+    slower on CPU backends (pymc, nutpie). This function is used for auto-detection when the
+    user has not explicitly set the `sparse_dot` parameter.
 
     Parameters
     ----------
-    inference_method : str, optional
-        The sampling backend: "pymc", "numpyro", "blackjax", "nutpie", "vi", "laplace".
+    inference_method : str or None, optional
+        The sampling backend: `"pymc"`, `"numpyro"`, `"blackjax"`, `"nutpie"`,
+        `"vi"`, `"laplace"`. If `None`, returns `False`.
 
     Returns
     -------
     bool
-        True for JAX backends (numpyro, blackjax), False otherwise.
+        `True` for JAX backends (numpyro, blackjax), `False` otherwise.
     """
     if inference_method is None:
         return False

--- a/bambi/backend/utils.py
+++ b/bambi/backend/utils.py
@@ -202,3 +202,24 @@ def make_weighted_distribution(dist: pm.Distribution):
             )
 
     return WeightedDistribution
+
+
+def should_use_sparse_dot(inference_method=None):
+    """Determine whether to use sparse matrix multiplication for group effects.
+
+    Sparse matmul is faster on JAX/GPU backends but may be slower on CPU backends.
+
+    Parameters
+    ----------
+    inference_method : str, optional
+        The sampling backend: "pymc", "numpyro", "blackjax", "nutpie", "vi", "laplace".
+
+    Returns
+    -------
+    bool
+        True for JAX backends (numpyro, blackjax), False otherwise.
+    """
+    if inference_method is None:
+        return False
+    # JAX backends benefit from sparse matmul on GPU/TPU
+    return inference_method.lower() in {"numpyro", "blackjax"}

--- a/bambi/config.py
+++ b/bambi/config.py
@@ -5,7 +5,7 @@ class Config:
     When a user tries to set a configuration variable to a non-supported value, it raises an error.
     """
 
-    __FIELDS = {"INTERPRET_VERBOSE": (True, False), "SPARSE_DOT": (False, True)}
+    __FIELDS = {"INTERPRET_VERBOSE": (True, False), "SPARSE_DOT": (False, True, None)}
 
     def __init__(self, config_dict: dict = None):
         config_dict = {} if config_dict is None else config_dict

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -403,11 +403,13 @@ class Model:
         """
         from bambi.backend.utils import should_use_sparse_dot
 
+        # Model parameter takes precedence
         if self.sparse_dot is not None:
             return self.sparse_dot
-        if config.SPARSE_DOT is True:
-            return True
-        # config.SPARSE_DOT is False or None: auto-detect from backend
+        # Global config takes precedence over auto-detection
+        if config.SPARSE_DOT is not None:
+            return config.SPARSE_DOT
+        # Auto-detect based on inference method
         return should_use_sparse_dot(inference_method)
 
     def set_priors(self, priors=None, common=None, group_specific=None):


### PR DESCRIPTION
I was looking into how PyMC was taking advantage of MLX and found [this thread](https://discourse.pymc.io/t/how-to-use-pymc-with-mlx/17394/9) so I ended up trying to fix what @tomicapretto (Hola!) had mentioned:
> This is one of the cases where I want to change how Bambi works under the hood.
It would be great if Bambi did a (sparse) matmul under the hood for the group-specific effects (also known under many other names). But it does not do it right now, it does some indexing thing to avoid multiplying a large dense matrix. My guess is that if you do implement it with a matmul, perhaps even dense, it should be faster in mlx. 

The sparse matmul for group-specific effects was implemented in PR #950 by @tomicapretto, this PR makes it automatically enabled for JAX backends.

**Changes:**
- Add `sparse_dot` parameter to `Model()` for explicit control
- Auto-detect JAX backends in `fit()` and enable sparse matmul
- Add `None` to valid `config.SPARSE_DOT` values for auto-detect mode

**Priority:** model param > `config.SPARSE_DOT=True` > auto-detect