### PR TITLE
ENH: Add progressbar to model.predict()

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -4,6 +4,8 @@
 import logging
 import warnings
 
+from tqdm.auto import tqdm
+
 from copy import deepcopy
 from importlib.metadata import version
 
@@ -866,6 +868,7 @@ class Model:
         include_group_specific=True,
         sample_new_groups=False,
         random_seed=None,
+        progressbar=True,
     ):
         """Predict method for Bambi models
 
@@ -904,6 +907,10 @@ class Model:
             The method implemented is equivalent to `sample_new_levels="uncertainty"` in brms.
         random_seed : int, RandomState or Generator, optional
             Seed for the random number generator.
+        progressbar : bool, optional
+            Whether to display a progress bar during prediction. Defaults to `True`.
+            Set to `False` to suppress the progress bar. Uses `tqdm.auto` so it renders
+            correctly in both terminals and Jupyter notebooks.
 
         Returns
         -------
@@ -936,6 +943,7 @@ class Model:
             include_group_specific=include_group_specific,
             sample_new_groups=sample_new_groups,
             random_seed=random_seed,
+            progressbar=progressbar,
         )
 
         # Only if requested predict the predictive distribution
@@ -1072,6 +1080,7 @@ class Model:
         include_group_specific=True,
         sample_new_groups=False,
         random_seed=None,
+        progressbar=True,
     ):
         """Computes the parameters of the likelihood (response distribution)
 
@@ -1085,8 +1094,19 @@ class Model:
         hsgp_dict = {}  # To store the HSGP contributions (they are added to the posterior dataset)
         response_dim = "__obs__"
 
-        for name, component in self.distributional_components.items():
+        components_iter = self.distributional_components.items()
+        if progressbar:
+            components_iter = tqdm(
+                list(components_iter),
+                total=len(self.distributional_components),
+                desc="Predicting",
+                unit="component",
+            )
+
+        for name, component in components_iter:
             var_name = component.alias if component.alias else name
+            if progressbar:
+                components_iter.set_postfix({"name": var_name})
             means_dict[var_name] = component.predict(
                 idata, data, include_group_specific, hsgp_dict, sample_new_groups, random_seed
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pymc>=5.27.0,<6",
     "seaborn>=0.13.2,<0.14",
     "sparse>=0.17.0,<0.18",
+    "tqdm>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -503,6 +503,18 @@ class TestGaussian(FitPredictParent):
         idata = self.fit(model)
         self.predict_oos(model, idata)
 
+    def test_predict_progressbar(self, data_crossed):
+        """Test that model.predict runs without error with progressbar=True and progressbar=False.
+
+        Relates to GitHub Issue #818.
+        """
+        model = bmb.Model("Y ~ continuous", data_crossed)
+        idata = self.fit(model)
+
+        # Both modes should execute without raising any exception
+        model.predict(idata, progressbar=True)
+        model.predict(idata, progressbar=False)
+
 
 @pytest.mark.usefixtures("mock_pymc_sample")
 class TestBernoulli(FitPredictParent):


### PR DESCRIPTION
Fixes #818

**Summary of changes:**
* Added a `progressbar=True` keyword argument to `model.predict()`.
* Integrated `tqdm.auto` to ensure the progress bar renders correctly in both standard terminals and Jupyter Notebook environments (which is critical for Bambi users).
* Wrapped the distributional components loop in `_compute_likelihood_params` with the progress bar.
* Added `tqdm>=4.0` as a dependency in `pyproject.toml`.
* Added `test_predict_progressbar` unit test to verify the toggle works without errors.

Opening as a Draft to run CI/CD tests and verify everything passes cleanly before final review.
