### PR TITLE
Warn when nuts_sampler_kwargs is used with the default PyMC sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Maintenance and fixes
 
 * Non-Normal priors with random hyperpriors now build under the centered parameterization.
+* `Model.fit` now warns when `nuts_sampler_kwargs` is passed while using the default PyMC sampler, steering users to pass NUTS settings such as `target_accept` directly. Routing them through `nuts_sampler_kwargs` is silently ignored on PyMC < 6 and deprecated on PyMC >= 6.
 
 <a id="0.18.0"></a>
 # [Bambi 0.18.0](https://github.com/bambinos/bambi/releases/tag/0.18.0) - 2026-05-19

--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -206,6 +206,22 @@ class PyMCModel:
         sampler_backend,
         **kwargs,
     ):
+        # Routing NUTS settings (most commonly `target_accept`) through
+        # `nuts_sampler_kwargs` is a footgun with the default PyMC sampler: PyMC < 6
+        # silently ignores it, so the setting never takes effect, while PyMC >= 6
+        # deprecates it in favor of `pm.sample(nuts=...)`. Bambi users don't call
+        # `pm.sample` directly, so steer them to the supported, version-independent
+        # path: pass these settings straight to `Model.fit()`.
+        if sampler_backend == "pymc" and kwargs.get("nuts_sampler_kwargs"):
+            warnings.warn(
+                "Passing NUTS settings through `nuts_sampler_kwargs` is not recommended with the "
+                "default PyMC sampler (PyMC < 6 silently ignores it; PyMC >= 6 deprecates it). "
+                "Pass settings such as `target_accept` directly to `Model.fit()` instead, e.g. "
+                "`model.fit(target_accept=0.9)`.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Don't include the parameters of the likelihood, which are deterministics.
         # They can take lot of space in the trace and increase RAM requirements.
         vars_to_sample = get_default_varnames(

--- a/tests/test_inference_methods.py
+++ b/tests/test_inference_methods.py
@@ -1,3 +1,5 @@
+import warnings
+
 import bambi as bmb
 import numpy as np
 import pandas as pd
@@ -100,3 +102,43 @@ def test_legacy_nuts_numpyro_warning(data_random_n100):
 
     with pytest.warns(FutureWarning, match="'numpyro_nuts' has been replaced by 'numpyro'"):
         model.fit(inference_method="numpyro_nuts", draws=10, tune=10)
+
+
+# Distinctive phrase from Bambi's own warning, so we don't match PyMC's separate
+# `nuts_sampler_kwargs`-deprecation FutureWarning (which also fires on PyMC >= 6).
+_NSK_WARNING = "not recommended with the default PyMC sampler"
+
+
+def test_nuts_sampler_kwargs_on_pymc_warns(data_random_n100):
+    """Routing NUTS settings through ``nuts_sampler_kwargs`` on the default PyMC sampler warns.
+
+    Guards the footgun where settings like ``target_accept`` placed in
+    ``nuts_sampler_kwargs`` are silently ignored (PyMC < 6) or deprecated (PyMC >= 6),
+    instead of being passed directly to ``Model.fit()``.
+    """
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with pytest.warns(UserWarning, match=_NSK_WARNING):
+        model.fit(
+            inference_method="pymc",
+            draws=10,
+            tune=10,
+            nuts_sampler_kwargs={"target_accept": 0.95},
+        )
+
+
+def test_target_accept_directly_does_not_warn(data_random_n100):
+    """Passing NUTS settings directly is the supported path and must not raise our warning."""
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        model.fit(inference_method="pymc", draws=10, tune=10, target_accept=0.95)
+    assert not any(_NSK_WARNING in str(record.message) for record in records)
+
+
+def test_empty_nuts_sampler_kwargs_does_not_warn(data_random_n100):
+    """An empty / falsy ``nuts_sampler_kwargs`` does not trigger our warning."""
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        model.fit(inference_method="pymc", draws=10, tune=10, nuts_sampler_kwargs={})
+    assert not any(_NSK_WARNING in str(record.message) for record in records)


### PR DESCRIPTION
## TL;DR

While working with bambi 0.17, I discovered that `nuts_sampler_kwargs` are silently ignored when using the default sampler. Looks like dev requires pymc 6, where this is (kind of) fixed — there's a FutureWarning, but it isn't bambi specific. So this adds a warning.  

The reference to PyMC < 6 can be dropped if you'd like since in *theory* by the time this gets merged users won't be allowed PyMC < 6, but up to y'all.

## Summary

Routing NUTS settings (most commonly `target_accept`) through `nuts_sampler_kwargs` is a quiet footgun with the **default PyMC sampler**:

- **PyMC < 6**: `nuts_sampler_kwargs` is *silently ignored* for the `"pymc"` sampler, so e.g. `model.fit(nuts_sampler_kwargs={"target_accept": 0.99})` runs at the default `target_accept=0.8`. Users chasing divergences can crank this value indefinitely with no effect and no feedback.
- **PyMC >= 6**: it is honored but emits a `FutureWarning` telling you to "pass NUTS keyword arguments via the `nuts={...}` argument to `pm.sample`" — guidance that's leaky in a Bambi context, since Bambi users never call `pm.sample` directly.

Because Bambi just forwards `nuts_sampler_kwargs` into `pm.sample`, neither situation is surfaced in Bambi's own terms.

This PR makes `Model.fit` emit a clear, version-independent warning when `nuts_sampler_kwargs` is passed while using the default PyMC sampler, steering users to the path that works on every PyMC version:

```python
model.fit(target_accept=0.9)   # instead of nuts_sampler_kwargs={"target_accept": 0.9}
```

The warning only fires when `sampler_backend == "pymc"` and a non-empty `nuts_sampler_kwargs` is supplied; external samplers (`nutpie`, `numpyro`, `blackjax`), for which `nuts_sampler_kwargs` is the correct channel, are unaffected.

## Changes

- `bambi/backend/pymc.py`: guard in `_run_mcmc` that warns for the default PyMC sampler.
- `tests/test_inference_methods.py`: tests that the warning fires for non-empty `nuts_sampler_kwargs`, that passing `target_accept` directly does **not** warn, and that an empty `nuts_sampler_kwargs={}` is a no-op.
- `CHANGELOG.md`: entry under *Unreleased*.

## Testing

`pytest tests/test_inference_methods.py` → 8 passed, 5 skipped (JAX/nutpie not installed). `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)