### PR TITLE
Fix PyMC NUTS sampler kwargs silent failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Maintenance and fixes
 
 * Non-Normal priors with random hyperpriors now build under the centered parameterization.
+* `Model.fit` now warns when `nuts_sampler_kwargs` is passed while using the default PyMC sampler, steering users to pass NUTS settings such as `target_accept` directly. Routing them through `nuts_sampler_kwargs` is silently ignored on PyMC < 6 and deprecated on PyMC >= 6.
 
 <a id="0.18.0"></a>
 # [Bambi 0.18.0](https://github.com/bambinos/bambi/releases/tag/0.18.0) - 2026-05-19

--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -206,6 +206,22 @@ class PyMCModel:
         sampler_backend,
         **kwargs,
     ):
+        # Routing NUTS settings (most commonly `target_accept`) through
+        # `nuts_sampler_kwargs` is a footgun with the default PyMC sampler: PyMC < 6
+        # silently ignores it, so the setting never takes effect, while PyMC >= 6
+        # deprecates it in favor of `pm.sample(nuts=...)`. Bambi users don't call
+        # `pm.sample` directly, so steer them to the supported, version-independent
+        # path: pass these settings straight to `Model.fit()`.
+        if sampler_backend == "pymc" and kwargs.get("nuts_sampler_kwargs"):
+            warnings.warn(
+                "Passing NUTS settings through `nuts_sampler_kwargs` is not recommended with the "
+                "default PyMC sampler (PyMC < 6 silently ignores it; PyMC >= 6 deprecates it). "
+                "Pass settings such as `target_accept` directly to `Model.fit()` instead, e.g. "
+                "`model.fit(target_accept=0.9)`.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Don't include the parameters of the likelihood, which are deterministics.
         # They can take lot of space in the trace and increase RAM requirements.
         vars_to_sample = get_default_varnames(

--- a/bambi/backend/pymc.py
+++ b/bambi/backend/pymc.py
@@ -113,6 +113,7 @@ class PyMCModel:
         chains=None,
         cores=None,
         random_seed=None,
+        nuts=None,
         **kwargs,
     ):
         """Run PyMC sampler."""
@@ -161,6 +162,7 @@ class PyMCModel:
                 chains=chains,
                 cores=cores,
                 random_seed=random_seed,
+                nuts=nuts,
                 sampler_backend=inference_method,
                 **kwargs,
             )
@@ -203,25 +205,10 @@ class PyMCModel:
         chains,
         cores,
         random_seed,
+        nuts,
         sampler_backend,
         **kwargs,
     ):
-        # Routing NUTS settings (most commonly `target_accept`) through
-        # `nuts_sampler_kwargs` is a footgun with the default PyMC sampler: PyMC < 6
-        # silently ignores it, so the setting never takes effect, while PyMC >= 6
-        # deprecates it in favor of `pm.sample(nuts=...)`. Bambi users don't call
-        # `pm.sample` directly, so steer them to the supported, version-independent
-        # path: pass these settings straight to `Model.fit()`.
-        if sampler_backend == "pymc" and kwargs.get("nuts_sampler_kwargs"):
-            warnings.warn(
-                "Passing NUTS settings through `nuts_sampler_kwargs` is not recommended with the "
-                "default PyMC sampler (PyMC < 6 silently ignores it; PyMC >= 6 deprecates it). "
-                "Pass settings such as `target_accept` directly to `Model.fit()` instead, e.g. "
-                "`model.fit(target_accept=0.9)`.",
-                UserWarning,
-                stacklevel=2,
-            )
-
         # Don't include the parameters of the likelihood, which are deterministics.
         # They can take lot of space in the trace and increase RAM requirements.
         vars_to_sample = get_default_varnames(
@@ -234,6 +221,11 @@ class PyMCModel:
             is_deterministic = variable in self.model.deterministics
             if is_likelihood_param and is_deterministic:
                 vars_to_sample.remove(name)
+
+        # pm.sample routes nuts settings via kwargs.pop("nuts", {}); only inject when provided
+        # to avoid passing nuts=None which causes pm.sample's internal nuts_kwargs.copy() to fail.
+        if nuts is not None:
+            kwargs["nuts"] = nuts
 
         with self.model:
             try:

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -3,22 +3,24 @@
 # pylint: disable=too-many-positional-arguments
 import logging
 import warnings
-
 from copy import deepcopy
 from importlib.metadata import version
 
 import formulae as fm
-import pymc as pm
 import pandas as pd
-
+import pymc as pm
 from arviz_plots import plot_dist
 from arviz_stats import residual_r2
 
 from bambi.backend import PyMCModel
 from bambi.defaults import get_builtin_family
-from bambi.model_components import ConstantComponent, DistributionalComponent, ResponseComponent
 from bambi.families import Family, univariate
 from bambi.formula import Formula, check_ordinal_formula
+from bambi.model_components import (
+    ConstantComponent,
+    DistributionalComponent,
+    ResponseComponent,
+)
 from bambi.priors import Prior, PriorScaler
 from bambi.transformations import transformations_namespace
 from bambi.utils import (
@@ -168,7 +170,11 @@ class Model:
             # linear dependencies with the cutpoints.
             # Then the intercept is removed from the design matrix because of the cutpoints.
             design = fm.design_matrices(
-                self.formula.main + " + 1", self.data, na_action, 1, additional_namespace
+                self.formula.main + " + 1",
+                self.data,
+                na_action,
+                1,
+                additional_namespace,
             )
             design = remove_common_intercept(design)
         else:
@@ -210,7 +216,11 @@ class Model:
 
             # Create design matrix, only for the response part
             design = fm.design_matrices(
-                clean_formula_lhs(extra_formula), self.data, na_action, 1, additional_namespace
+                clean_formula_lhs(extra_formula),
+                self.data,
+                na_action,
+                1,
+                additional_namespace,
             )
 
             # If priors were not passed, pass an empty dictionary
@@ -255,6 +265,7 @@ class Model:
         chains=None,
         cores=None,
         random_seed=None,
+        nuts=None,
         **kwargs,
     ):
         """Fit the model using PyMC
@@ -320,8 +331,11 @@ class Model:
             in the system unless there are more than 4 CPUs, in which case it is set to 4.
         random_seed : int or list of ints, optional
             A list is accepted if cores is greater than one.
+        nuts : dict, optional
+            A dictionary of NUTS sampler settings passed directly to `pm.sample(nuts=...)`, e.g.
+            `model.fit(nuts={"target_accept": 0.9, "max_treedepth": 12})`.
         kwargs : dict
-            For other kwargs see the documentation for `PyMC.sample()`.
+            For other kwargs see the documentation for ``pm.sample()``.
 
         Returns
         -------
@@ -339,6 +353,19 @@ class Model:
                     FutureWarning,
                 )
                 inference_method = method
+
+        if "nuts_sampler_kwargs" in kwargs:
+            warnings.warn(
+                "'nuts_sampler_kwargs' is deprecated. Pass NUTS settings via the 'nuts' parameter "
+                "instead, e.g. model.fit(nuts={'target_accept': 0.9}).",
+                FutureWarning,
+                stacklevel=2,
+            )
+            legacy = kwargs.pop("nuts_sampler_kwargs")
+            if nuts is None:
+                nuts = legacy
+            else:
+                nuts = {**legacy, **nuts}
 
         if not self.built:
             self.build()
@@ -371,6 +398,7 @@ class Model:
             chains=chains,
             cores=cores,
             random_seed=random_seed,
+            nuts=nuts,
             **kwargs,
         )
 
@@ -789,7 +817,8 @@ class Model:
 
         if flat_rvs:
             _log.info(
-                "Variables %s have flat priors, and hence they are not plotted", ", ".join(flat_rvs)
+                "Variables %s have flat priors, and hence they are not plotted",
+                ", ".join(flat_rvs),
             )
 
         if omit_offsets:
@@ -861,7 +890,10 @@ class Model:
             var_names = [name for name in var_names if not name.endswith("_offset")]
 
         idata = pm.sample_prior_predictive(
-            draws=draws, var_names=var_names, model=self.backend.model, random_seed=random_seed
+            draws=draws,
+            var_names=var_names,
+            model=self.backend.model,
+            random_seed=random_seed,
         )
 
         for group in idata.children:
@@ -1101,7 +1133,12 @@ class Model:
         for name, component in self.distributional_components.items():
             var_name = component.alias if component.alias else name
             means_dict[var_name] = component.predict(
-                idata, data, include_group_specific, hsgp_dict, sample_new_groups, random_seed
+                idata,
+                data,
+                include_group_specific,
+                hsgp_dict,
+                sample_new_groups,
+                random_seed,
             )
 
         # Build the updated posterior dataset from the DataTree child
@@ -1300,7 +1337,10 @@ def prior_repr(term) -> str:
 
 def hsgp_repr(term) -> str:
     """Get a string representation of a Bambi HSGP term."""
-    output_list = [f"cov: {term.cov}", *[f"{key} ~ {value}" for key, value in term.prior.items()]]
+    output_list = [
+        f"cov: {term.cov}",
+        *[f"{key} ~ {value}" for key, value in term.prior.items()],
+    ]
     output_list = ["    " + element for element in output_list]
     output_list.insert(0, term.name)
     return "\n".join(output_list)

--- a/tests/test_inference_methods.py
+++ b/tests/test_inference_methods.py
@@ -1,3 +1,5 @@
+import warnings
+
 import bambi as bmb
 import numpy as np
 import pandas as pd
@@ -100,3 +102,43 @@ def test_legacy_nuts_numpyro_warning(data_random_n100):
 
     with pytest.warns(FutureWarning, match="'numpyro_nuts' has been replaced by 'numpyro'"):
         model.fit(inference_method="numpyro_nuts", draws=10, tune=10)
+
+
+# Distinctive phrase from Bambi's own warning, so we don't match PyMC's separate
+# `nuts_sampler_kwargs`-deprecation FutureWarning (which also fires on PyMC >= 6).
+_NSK_WARNING = "not recommended with the default PyMC sampler"
+
+
+def test_nuts_sampler_kwargs_on_pymc_warns(data_random_n100):
+    """Routing NUTS settings through ``nuts_sampler_kwargs`` on the default PyMC sampler warns.
+
+    Guards the footgun where settings like ``target_accept`` placed in
+    ``nuts_sampler_kwargs`` are silently ignored (PyMC < 6) or deprecated (PyMC >= 6),
+    instead of being passed directly to ``Model.fit()``.
+    """
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with pytest.warns(UserWarning, match=_NSK_WARNING):
+        model.fit(
+            inference_method="pymc",
+            draws=10,
+            tune=10,
+            nuts_sampler_kwargs={"target_accept": 0.95},
+        )
+
+
+def test_target_accept_directly_does_not_warn(data_random_n100):
+    """Passing NUTS settings directly is the supported path and must not raise our warning."""
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        model.fit(inference_method="pymc", draws=10, tune=10, target_accept=0.95)
+    assert not any(_NSK_WARNING in str(record.message) for record in records)
+
+
+def test_empty_nuts_sampler_kwargs_does_not_warn(data_random_n100):
+    """An empty / falsy ``nuts_sampler_kwargs`` does not trigger our warning."""
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        model.fit(inference_method="pymc", draws=10, tune=10, nuts_sampler_kwargs={})
+    assert not any(_NSK_WARNING in str(record.message) for record in records)

--- a/tests/test_inference_methods.py
+++ b/tests/test_inference_methods.py
@@ -1,5 +1,3 @@
-import warnings
-
 import bambi as bmb
 import numpy as np
 import pandas as pd
@@ -104,41 +102,59 @@ def test_legacy_nuts_numpyro_warning(data_random_n100):
         model.fit(inference_method="numpyro_nuts", draws=10, tune=10)
 
 
-# Distinctive phrase from Bambi's own warning, so we don't match PyMC's separate
-# `nuts_sampler_kwargs`-deprecation FutureWarning (which also fires on PyMC >= 6).
-_NSK_WARNING = "not recommended with the default PyMC sampler"
-
-
-def test_nuts_sampler_kwargs_on_pymc_warns(data_random_n100):
-    """Routing NUTS settings through ``nuts_sampler_kwargs`` on the default PyMC sampler warns.
-
-    Guards the footgun where settings like ``target_accept`` placed in
-    ``nuts_sampler_kwargs`` are silently ignored (PyMC < 6) or deprecated (PyMC >= 6),
-    instead of being passed directly to ``Model.fit()``.
-    """
+def test_nuts_parameter_for_default_sampler(data_random_n100):
+    """NUTS settings passed via nuts={} are forwarded to pm.sample and take effect."""
     model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
-    with pytest.warns(UserWarning, match=_NSK_WARNING):
-        model.fit(
+    idata = model.fit(
+        inference_method="pymc",
+        draws=10,
+        tune=10,
+        nuts={"target_accept": 0.95},
+    )
+    assert idata is not None
+
+
+def test_nuts_none_is_noop(data_random_n100):
+    """Omitting nuts (defaults to None) runs without error."""
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    idata = model.fit(inference_method="pymc", draws=10, tune=10)
+    assert idata is not None
+
+
+def test_nuts_parameter_forwarded_to_external_samplers(data_random_n100):
+    """nuts={} is forwarded as-is to _run_mcmc for external samplers."""
+    import bambi.backend.pymc as _bpymc
+    import unittest.mock as mock
+
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    captured = {}
+
+    def patched(self, *args, **kwargs):
+        captured.update(kwargs)
+        raise SystemExit
+
+    with mock.patch.object(_bpymc.PyMCModel, "_run_mcmc", patched):
+        try:
+            model.fit(
+                inference_method="nutpie",
+                draws=10,
+                tune=10,
+                nuts={"target_accept": 0.95},
+            )
+        except SystemExit:
+            pass
+
+    assert captured.get("nuts") == {"target_accept": 0.95}
+
+
+def test_nuts_sampler_kwargs_deprecated(data_random_n100):
+    """nuts_sampler_kwargs triggers a FutureWarning and is merged into nuts."""
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    with pytest.warns(FutureWarning, match="nuts_sampler_kwargs.*deprecated"):
+        idata = model.fit(
             inference_method="pymc",
             draws=10,
             tune=10,
             nuts_sampler_kwargs={"target_accept": 0.95},
         )
-
-
-def test_target_accept_directly_does_not_warn(data_random_n100):
-    """Passing NUTS settings directly is the supported path and must not raise our warning."""
-    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
-    with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter("always")
-        model.fit(inference_method="pymc", draws=10, tune=10, target_accept=0.95)
-    assert not any(_NSK_WARNING in str(record.message) for record in records)
-
-
-def test_empty_nuts_sampler_kwargs_does_not_warn(data_random_n100):
-    """An empty / falsy ``nuts_sampler_kwargs`` does not trigger our warning."""
-    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
-    with warnings.catch_warnings(record=True) as records:
-        warnings.simplefilter("always")
-        model.fit(inference_method="pymc", draws=10, tune=10, nuts_sampler_kwargs={})
-    assert not any(_NSK_WARNING in str(record.message) for record in records)
+    assert idata is not None

--- a/tests/test_inference_methods.py
+++ b/tests/test_inference_methods.py
@@ -1,13 +1,14 @@
-import bambi as bmb
 import numpy as np
 import pandas as pd
 import pytest
 
+import bambi as bmb
+
 # Skip tests if dependencies not available
 try:
+    import blackjax  # noqa: F401
     import jax  # noqa: F401
     import numpyro  # noqa: F401
-    import blackjax  # noqa: F401
 
     JAX_AVAILABLE = True
 except ImportError:
@@ -102,29 +103,31 @@ def test_legacy_nuts_numpyro_warning(data_random_n100):
         model.fit(inference_method="numpyro_nuts", draws=10, tune=10)
 
 
-def test_nuts_parameter_for_default_sampler(data_random_n100):
+def test_nuts_parameter_for_default_sampler(data_random_n100, mock_pymc_sample):
     """NUTS settings passed via nuts={} are forwarded to pm.sample and take effect."""
     model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
     idata = model.fit(
         inference_method="pymc",
         draws=10,
         tune=10,
+        chains=2,
         nuts={"target_accept": 0.95},
     )
     assert idata is not None
 
 
-def test_nuts_none_is_noop(data_random_n100):
+def test_nuts_none_is_noop(data_random_n100, mock_pymc_sample):
     """Omitting nuts (defaults to None) runs without error."""
     model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
-    idata = model.fit(inference_method="pymc", draws=10, tune=10)
+    idata = model.fit(inference_method="pymc", draws=10, tune=10, chains=2)
     assert idata is not None
 
 
 def test_nuts_parameter_forwarded_to_external_samplers(data_random_n100):
     """nuts={} is forwarded as-is to _run_mcmc for external samplers."""
-    import bambi.backend.pymc as _bpymc
     import unittest.mock as mock
+
+    import bambi.backend.pymc as _bpymc
 
     model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
     captured = {}
@@ -147,7 +150,7 @@ def test_nuts_parameter_forwarded_to_external_samplers(data_random_n100):
     assert captured.get("nuts") == {"target_accept": 0.95}
 
 
-def test_nuts_sampler_kwargs_deprecated(data_random_n100):
+def test_nuts_sampler_kwargs_deprecated(data_random_n100, mock_pymc_sample):
     """nuts_sampler_kwargs triggers a FutureWarning and is merged into nuts."""
     model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
     with pytest.warns(FutureWarning, match="nuts_sampler_kwargs.*deprecated"):
@@ -155,6 +158,7 @@ def test_nuts_sampler_kwargs_deprecated(data_random_n100):
             inference_method="pymc",
             draws=10,
             tune=10,
+            chains=2,
             nuts_sampler_kwargs={"target_accept": 0.95},
         )
     assert idata is not None


### PR DESCRIPTION
Addresses the original PR #988

We keep common MCMC parameters (draws, tune, chains, cores, random_seed, etc) as named args. Then, for NUTS specific parameters we introduce the `nuts`  parameter similar to pymc `pm.sample(..., nuts={"target_accept": 0.9})` ensuring that PyMC handles the internal routing of NUTS parameters to their appropriate samplers (blackjax, numpyro, etc.). Finally, we still keep kwargs in case the user wants to pass other things such as `idata_kwargs`, `compile_kwargs `, etc.

A control flow block is also added to: (1) raise a `FutureWarning` to inform the user that the legacy `nuts_sampler_kwargs` is deprecated, and (2) to re-route the `nuts_sampler_kwargs` to the `nuts` parameter ensuring that don't break user's code.
