### PR TITLE
add _re_center_intercept

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from importlib.metadata import version
 
 import formulae as fm
+import numpy as np
 import pandas as pd
 import pymc as pm
 import xarray as xr
@@ -1303,6 +1304,59 @@ class Model:
             graphviz_.render(filename=name, format=fmt, cleanup=True)
 
         return graphviz
+
+    def _re_center_intercept(self, idata):
+        """Re-center the intercept in ``idata.posterior`` so it matches the PyMC value variable.
+
+        Parameters
+        ----------
+        idata : DataTree
+            A DataTree
+
+        Returns
+        -------
+        InferenceData or DataTree
+            A deep copy of ``idata`` with the intercept of every distributional
+            component that has both an intercept and common terms re-centered.
+        """
+        if not self.center_predictors or self.backend is None:
+            return idata
+
+        idata_corrected = deepcopy(idata)
+        posterior = idata_corrected.posterior
+
+        for pymc_component in self.backend.distributional_components.values():
+            bambi_component = pymc_component.component
+            if not (
+                bambi_component.intercept_term
+                and bambi_component.common_terms
+                and pymc_component.design_matrix_without_intercept is not None
+            ):
+                continue
+
+            chain_n = posterior["chain"].size
+            draw_n = posterior["draw"].size
+            shape, dims = (chain_n, draw_n), ("chain", "draw")
+            x_uncentered = pymc_component.design_matrix_without_intercept
+
+            common_term_names = [get_aliased_name(t) for t in bambi_component.common_terms.values()]
+
+            response_coords = self.response_component.term.coords
+            if response_coords:
+                levels = list(response_coords.values())[0]
+                shape += (len(levels),)
+                dims += tuple(response_coords)
+
+            posterior_stacked = posterior.to_dataset().stack(samples=dims)
+            coefs = np.vstack(
+                [np.atleast_2d(posterior_stacked[name].values) for name in common_term_names]
+            )
+            intercept_name = get_aliased_name(bambi_component.intercept_term)
+            center_factor = np.dot(x_uncentered.mean(0), coefs).reshape(shape)
+            posterior[intercept_name] = posterior[intercept_name] + center_factor
+
+        idata_corrected["posterior"] = posterior
+        return idata_corrected
 
     @property
     def formula(self):

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -1353,7 +1353,7 @@ class Model:
             )
             intercept_name = get_aliased_name(bambi_component.intercept_term)
             center_factor = np.dot(x_uncentered.mean(0), coefs).reshape(shape)
-            posterior[intercept_name] = posterior[intercept_name] + center_factor
+            posterior[intercept_name] = posterior[intercept_name] - center_factor
 
         idata_corrected["posterior"] = posterior
         return idata_corrected

--- a/tests/test_re_center_intercept.py
+++ b/tests/test_re_center_intercept.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+
+import bambi as bmb
+from bambi.utils import get_aliased_name
+
+
+@pytest.mark.usefixtures("mock_pymc_sample")
+class TestReCenterIntercept:
+    @staticmethod
+    def _check_recentering(model, idata):
+        for pymc_component in model.backend.distributional_components.values():
+            bambi_component = pymc_component.component
+            if not (
+                bambi_component.intercept_term
+                and bambi_component.common_terms
+                and pymc_component.design_matrix_without_intercept is not None
+            ):
+                continue
+
+            common_names = [get_aliased_name(t) for t in bambi_component.common_terms.values()]
+
+            for name in common_names:
+                idata.posterior[name] = idata.posterior[name] * 0 + 1.0
+
+            intercept_before = idata.posterior["Intercept"].values.copy()
+
+            idata_corrected = model._re_center_intercept(idata)
+            intercept_after = idata_corrected.posterior["Intercept"].values
+
+            x_uncentered = pymc_component.design_matrix_without_intercept
+            expected_shift = x_uncentered.mean(0).sum()
+
+            actual_shift = intercept_before - intercept_after
+            np.testing.assert_allclose(actual_shift, expected_shift)
+
+    def test_numerical(self, integer_data_fixture):
+        model, idata = integer_data_fixture
+        self._check_recentering(model, idata)
+
+    def test_categorical_and_interactions(self, mtcars_fixture):
+        model, idata = mtcars_fixture
+        self._check_recentering(model, idata)
+
+    def test_categorical_numerical(self, data_inhaler):
+        model = bmb.Model("rating ~ treat + period + carry", data_inhaler, family="categorical")
+        idata = model.fit(tune=200, draws=200, chains=2)
+        self._check_recentering(model, idata)
+
+    def test_categorical_categoricals(self, food_choice):
+        model, idata = food_choice
+        self._check_recentering(model, idata)
+
+    def test_center_predictors_false(self, data_inhaler):
+        model = bmb.Model(
+            "rating ~ treat + period + carry",
+            data_inhaler,
+            family="categorical",
+            center_predictors=False,
+        )
+        idata = model.fit(tune=200, draws=200, chains=2)
+
+        idata_corrected = model._re_center_intercept(idata)
+        assert idata_corrected is idata


### PR DESCRIPTION
Not sure this is the best approach, or even if we want to add this given the upcoming changes in Bambi. But conditional on the current state of Bambi, a function like this will be helpful for ArviZ's moment_matching and for some plotting in Kulprit. The reason is that in both cases there is a mismatch between the intercept in ``idata.posterior`` and the PyMC value variable.