### PR TITLE
Add ExGaussian family (closes #995)

### DIFF
--- a/bambi/defaults/families.py
+++ b/bambi/defaults/families.py
@@ -7,6 +7,7 @@ from bambi.families.univariate import (
     Binomial,
     Categorical,
     Cumulative,
+    ExGaussian,
     Exponential,
     Gamma,
     Gaussian,
@@ -106,6 +107,16 @@ BUILTIN_FAMILIES = {
         },
         "link": {"a": "log"},
         "family": DirichletMultinomial,
+    },
+    "exgaussian": {
+        "likelihood": {
+            "name": "ExGaussian",
+            "params": ["mu", "sigma", "nu"],
+            "parent": "mu",
+        },
+        "link": {"mu": "identity", "sigma": "log", "nu": "log"},
+        "family": ExGaussian,
+        "default_priors": {"sigma": "HalfNormal", "nu": "HalfNormal"},
     },
     "exponential": {
         "likelihood": {

--- a/bambi/families/univariate.py
+++ b/bambi/families/univariate.py
@@ -271,6 +271,10 @@ class Exponential(UnivariateFamily):
         return kwargs
 
 
+class ExGaussian(UnivariateFamily):
+    SUPPORTED_LINKS = {"mu": ["identity", "log", "inverse"], "sigma": ["log"], "nu": ["log"]}
+
+
 class Gamma(UnivariateFamily):
     SUPPORTED_LINKS = {"mu": ["identity", "log", "inverse"], "alpha": ["log"]}
 

--- a/tests/test_model_construction.py
+++ b/tests/test_model_construction.py
@@ -254,6 +254,7 @@ def test_hyperprior_on_common_effect(data_random_n100):
     "family",
     [
         "asymmetriclaplace",
+        "exgaussian",
         "gaussian",
         "negativebinomial",
         "bernoulli",
@@ -274,6 +275,7 @@ def test_links(data_random_n100):
         "asymmetriclaplace": ["identity", "log", "inverse"],
         "bernoulli": ["identity", "logit", "probit", "cloglog"],
         "beta": ["logit", "probit", "cloglog"],
+        "exgaussian": ["identity", "log", "inverse"],
         "gamma": ["identity", "inverse", "log"],
         "gaussian": ["identity", "log", "inverse"],
         "negativebinomial": ["identity", "log", "cloglog"],
@@ -295,6 +297,7 @@ def test_bad_links(data_random_n100):
     FAMILIES = {
         "bernoulli": ["inverse", "inverse_squared", "log"],
         "beta": ["inverse", "inverse_squared", "log"],
+        "exgaussian": ["logit", "probit", "cloglog"],
         "gamma": ["logit", "probit", "cloglog"],
         "gaussian": ["logit", "probit", "cloglog"],
         "negativebinomial": ["logit", "probit", "inverse", "inverse_squared"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -807,6 +807,21 @@ class TestVonMises(FitPredictParent):
         ).item()
 
 
+@pytest.mark.usefixtures("mock_pymc_sample")
+class TestExGaussian(FitPredictParent):
+    def test_exgaussian_regression(self):
+        rng = np.random.default_rng(1234)
+        # Reaction time like data: Gaussian component plus exponential component
+        x = rng.normal(size=100)
+        y = 0.4 + 0.2 * x + rng.normal(0, 0.05, size=100) + rng.exponential(0.15, size=100)
+        data = pd.DataFrame({"y": y, "x": x})
+        model = bmb.Model("y ~ x", data, family="exgaussian")
+        idata = self.fit(model)
+        assert set(idata.posterior.data_vars) == {"Intercept", "x", "sigma", "nu"}
+        idata = self.predict_oos(model, idata)
+        assert "y" in idata.posterior_predictive
+
+
 # NOTE: We don't use mock_pymc_sample because the assertion needs actual posterior samples to work.
 class TestAsymmetricLaplace(FitPredictParent):
     # This test doesn't follow the previous pattern but it works...


### PR DESCRIPTION
This PR adds the ExGaussian family, resolving #995.

The ExGaussian distribution (Gaussian convolved with an exponential
component) is commonly used to model reaction time data. It uses PyMC's
`pm.ExGaussian(mu, sigma, nu)` parametrization directly, so no
reparametrization in `transform_kwargs` is needed.

Design notes:
- Links: `mu` gets identity/log/inverse (matching Gaussian); `sigma` and
  `nu` get `log` since both must be positive.
- Default priors: `HalfNormal` for both `sigma` and `nu`. Note that unlike
  StudentT, whose `nu` is degrees of freedom and uses a `Gamma` prior,
  ExGaussian's `nu` is the scale of the exponential component, so
  `HalfNormal` is consistent with how `sigma` is handled.

Tests: added a fit/predict test plus entries in the family/link
construction tests. Verified locally that the model builds with correct
automatic priors, NUTS sampling recovers the true parameters on synthetic
data, posterior predictive works, and invalid links are rejected.

I followed the existing built-in family pattern (e.g. VonMises, Wald) and
didn't add a separate example notebook, since those families don't have
dedicated ones either but I'd be happy to add one if you'd prefer.