### PR TITLE
docs: update arviz.preview to arviz in notebooks #985

### DIFF
--- a/docs/notebooks/ESCS_multiple_regression.ipynb
+++ b/docs/notebooks/ESCS_multiple_regression.ipynb
@@ -9,11 +9,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import arviz.preview as az\n",
+    "import arviz as az\n",
     "import bambi as bmb\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/docs/notebooks/fixed_random.ipynb
+++ b/docs/notebooks/fixed_random.ipynb
@@ -142,7 +142,7 @@
       "source": [
         "from typing import Any\n",
         "\n",
-        "import arviz.preview as az\n",
+        "import arviz as az\n",
         "import bambi as bmb\n",
         "import matplotlib.pyplot as plt\n",
         "import numpy as np\n",

--- a/docs/notebooks/getting_started.ipynb
+++ b/docs/notebooks/getting_started.ipynb
@@ -54,11 +54,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import arviz.preview as az\n",
+    "import arviz as az\n",
     "import bambi as bmb\n",
     "import pandas as pd"
    ]

--- a/docs/notebooks/multi-level_regression.ipynb
+++ b/docs/notebooks/multi-level_regression.ipynb
@@ -16,11 +16,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import arviz.preview as az\n",
+    "import arviz as az\n",
     "import bambi as bmb\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/docs/notebooks/sleepstudy.ipynb
+++ b/docs/notebooks/sleepstudy.ipynb
@@ -9,11 +9,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import arviz.preview as az\n",
+    "import arviz as az\n",
     "import bambi as bmb\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",


### PR DESCRIPTION
### What does this PR do?
This PR is one of the steps needed for release preparation and updates the ArviZ imports within the documentation notebooks. The change is made from `arviz.preview` to just `arviz` as the preview features are now part of the release version.

### Changes Made
Changed `import arviz.preview as az` to `import arviz as az` in the following notebooks:
- docs/notebooks/ESCS_multiple_regression.ipynb
- docs/notebooks/fixed_random.ipynb
- docs/notebooks/getting_started.ipynb
- docs/notebooks/multi-level_regression.ipynb
- docs/notebooks/sleepstudy.ipynb

### Closes
Closes #985

---

### Environment Check Note
I did not perform the local `pixi run -e dev pre-commit run --all` check as the `pixi.toml` file in the repository allows only `linux-64` and `osx-arm64` environments. Since my development environment is Windows (`win-64`), I could not satisfy the cross-platform environment requirements locally. The formatting will be checked by the online CI/GitHub Actions.
