### PR TITLE
REF: fix  `_re_center_intercept` to reconstruct offsets and center factors

### DIFF
--- a/bambi/models.py
+++ b/bambi/models.py
@@ -1366,50 +1366,75 @@ class Model:
         Parameters
         ----------
         idata : DataTree
-            A DataTree
+            The posterior samples as returned by ``Model.fit``.
 
         Returns
         -------
-        InferenceData or DataTree
-            A deep copy of ``idata`` with the intercept of every distributional
-            component that has both an intercept and common terms re-centered.
+        DataTree
+            A copy of ``idata`` where the intercept of every distributional component with
+            both an intercept and common terms includes the centering factor again, and the
+            offsets of non-centered group-specific terms are reconstructed. If there is
+            nothing to revert, ``idata`` is returned unchanged.
         """
-        if not self.center_predictors or self.backend is None:
+        if self.backend is None:
             return idata
 
-        idata_corrected = deepcopy(idata)
-        posterior = idata_corrected.posterior
+        posterior = as_dataset(idata["posterior"])
+        value_var_names = {value_var.name for value_var in self.backend.model.value_vars}
 
+        # Recover dropped offsets as `name / name_sigma` since `name = name_offset * name_sigma`
+        offsets = {}
         for pymc_component in self.backend.distributional_components.values():
-            bambi_component = pymc_component.component
-            if not (
-                bambi_component.intercept_term
-                and bambi_component.common_terms
-                and pymc_component.design_matrix_without_intercept is not None
-            ):
-                continue
+            for term in pymc_component.component.group_specific_terms.values():
+                term_name = get_aliased_name(term)
+                offset_name = f"{term_name}_offset"
+                if offset_name in value_var_names and offset_name not in posterior:
+                    sigma_name = f"{term_name}_{term.hyperprior_alias.get('sigma', 'sigma')}"
+                    offsets[offset_name] = (term_name, sigma_name)
 
-            chain_n = posterior["chain"].size
-            draw_n = posterior["draw"].size
-            shape, dims = (chain_n, draw_n), ("chain", "draw")
-            x_uncentered = pymc_component.design_matrix_without_intercept
+        # The backend reports `intercept - center_factor` so recompute the factor to add it back
+        center_factors = {}
+        if self.center_predictors:
+            for pymc_component in self.backend.distributional_components.values():
+                bambi_component = pymc_component.component
+                x_uncentered = pymc_component.design_matrix_without_intercept
+                if not (
+                    bambi_component.intercept_term
+                    and bambi_component.common_terms
+                    and x_uncentered is not None
+                ):
+                    continue
 
-            common_term_names = [get_aliased_name(t) for t in bambi_component.common_terms.values()]
+                shape, dims = (posterior["chain"].size, posterior["draw"].size), ("chain", "draw")
+                common_term_names = [
+                    get_aliased_name(t) for t in bambi_component.common_terms.values()
+                ]
 
-            response_coords = self.response_component.term.coords
-            if response_coords:
-                levels = list(response_coords.values())[0]
-                shape += (len(levels),)
-                dims += tuple(response_coords)
+                response_coords = self.response_component.term.coords
+                if response_coords:
+                    levels = list(response_coords.values())[0]
+                    shape += (len(levels),)
+                    dims += tuple(response_coords)
 
-            posterior_stacked = posterior.to_dataset().stack(samples=dims)
-            coefs = np.vstack(
-                [np.atleast_2d(posterior_stacked[name].values) for name in common_term_names]
-            )
-            intercept_name = get_aliased_name(bambi_component.intercept_term)
-            center_factor = np.dot(x_uncentered.mean(0), coefs).reshape(shape)
-            posterior[intercept_name] = posterior[intercept_name] - center_factor
+                posterior_stacked = posterior.stack(samples=dims)
+                coefs = np.vstack(
+                    [np.atleast_2d(posterior_stacked[name].values) for name in common_term_names]
+                )
+                intercept_name = get_aliased_name(bambi_component.intercept_term)
+                center_factors[intercept_name] = np.dot(x_uncentered.mean(0), coefs).reshape(shape)
 
+        if not center_factors and not offsets:
+            return idata
+
+        posterior = posterior.copy()
+
+        for name, center_factor in center_factors.items():
+            posterior[name] = posterior[name] + center_factor
+
+        for offset_name, (term_name, sigma_name) in offsets.items():
+            posterior[offset_name] = posterior[term_name] / posterior[sigma_name]
+
+        idata_corrected = idata.copy()
         idata_corrected["posterior"] = posterior
         return idata_corrected
 

--- a/tests/test_re_center_intercept.py
+++ b/tests/test_re_center_intercept.py
@@ -1,14 +1,18 @@
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
 import bambi as bmb
-from bambi.utils import get_aliased_name
+from bambi.utils import as_dataset, get_aliased_name
 
 
 @pytest.mark.usefixtures("mock_pymc_sample")
 class TestReCenterIntercept:
     @staticmethod
     def _check_recentering(model, idata):
+        idata = deepcopy(idata)
+
         for pymc_component in model.backend.distributional_components.values():
             bambi_component = pymc_component.component
             if not (
@@ -23,16 +27,17 @@ class TestReCenterIntercept:
             for name in common_names:
                 idata.posterior[name] = idata.posterior[name] * 0 + 1.0
 
-            intercept_before = idata.posterior["Intercept"].values.copy()
+            intercept_name = get_aliased_name(bambi_component.intercept_term)
+            intercept_before = idata.posterior[intercept_name].values.copy()
 
             idata_corrected = model._re_center_intercept(idata)
-            intercept_after = idata_corrected.posterior["Intercept"].values
+            intercept_after = idata_corrected.posterior[intercept_name].values
 
-            x_uncentered = pymc_component.design_matrix_without_intercept
-            expected_shift = x_uncentered.mean(0).sum()
+            expected_shift = pymc_component.design_matrix_without_intercept.mean(0).sum()
 
-            actual_shift = intercept_before - intercept_after
+            actual_shift = intercept_after - intercept_before
             np.testing.assert_allclose(actual_shift, expected_shift)
+            np.testing.assert_array_equal(idata.posterior[intercept_name].values, intercept_before)
 
     def test_numerical(self, integer_data_fixture):
         model, idata = integer_data_fixture
@@ -59,6 +64,54 @@ class TestReCenterIntercept:
             center_predictors=False,
         )
         idata = model.fit(tune=200, draws=200, chains=2)
-
         idata_corrected = model._re_center_intercept(idata)
         assert idata_corrected is idata
+
+    def test_offsets_match_sampled_offsets(self, data_sleepstudy):
+        model = bmb.Model("Reaction ~ Days + (Days | Subject)", data_sleepstudy)
+        idata = model.fit(tune=100, draws=100, chains=2, omit_offsets=False)
+
+        offset_names = [name for name in idata.posterior.data_vars if name.endswith("_offset")]
+        assert set(offset_names) == {"1|Subject_offset", "Days|Subject_offset"}
+
+        idata_dropped = idata.copy()
+        idata_dropped["posterior"] = as_dataset(idata["posterior"]).drop_vars(offset_names)
+
+        idata_corrected = model._re_center_intercept(idata_dropped)
+
+        for name in offset_names:
+            np.testing.assert_allclose(
+                idata_corrected.posterior[name].values, idata.posterior[name].values
+            )
+
+    def test_offsets_reconstructed_without_centering(self, data_sleepstudy):
+        model = bmb.Model(
+            "Reaction ~ Days + (Days | Subject)", data_sleepstudy, center_predictors=False
+        )
+        idata = model.fit(tune=100, draws=100, chains=2)
+
+        assert not any(name.endswith("_offset") for name in idata.posterior.data_vars)
+
+        idata_corrected = model._re_center_intercept(idata)
+
+        assert "1|Subject_offset" in idata_corrected.posterior
+        assert "Days|Subject_offset" in idata_corrected.posterior
+
+    def test_offsets_reconstructed_with_sigma_alias(self, data_sleepstudy):
+        model = bmb.Model("Reaction ~ Days + (Days | Subject)", data_sleepstudy)
+        model.set_alias({"sigma": "tau"})
+        idata = model.fit(tune=100, draws=100, chains=2)
+
+        idata_corrected = model._re_center_intercept(idata)
+
+        for base_name in ["1|Subject", "Days|Subject"]:
+            assert f"{base_name}_tau" in idata_corrected.posterior
+            assert f"{base_name}_offset" in idata_corrected.posterior
+
+    def test_no_offsets_when_centered_parametrization(self, data_sleepstudy):
+        model = bmb.Model("Reaction ~ Days + (Days | Subject)", data_sleepstudy, noncentered=False)
+        idata = model.fit(tune=100, draws=100, chains=2)
+
+        idata_corrected = model._re_center_intercept(idata)
+
+        assert not any(name.endswith("_offset") for name in idata_corrected.posterior.data_vars)


### PR DESCRIPTION
This introduces an updated `Model._re_center_intercept` that aligns the posterior with the free variables of the underlying PyMC model. From what I can see, after sampling, the backend subtracts the centering factor from the intercept of every distributional component that has both an intercept and common terms when `center_predictors=True`, and by default it drops the `*_offset` free variables of non-centered group-specific terms. 

The changes here now invert both transformations by adding the centering factor back and reconstructing the offsets (respecting hyperprior aliases), and it returns the input unchanged when there is nothing to revert.

---

This seems to fix the issues we're having with https://github.com/arviz-devs/arviz-stats/pull/373 when using Bambi models for automatic moment matching. 