### PR TITLE
Raise an error for prior names that match no term

### DIFF
--- a/bambi/config.py
+++ b/bambi/config.py
@@ -5,7 +5,11 @@ class Config:
     When a user tries to set a configuration variable to a non-supported value, it raises an error.
     """
 
-    __FIELDS = {"INTERPRET_VERBOSE": (True, False), "SPARSE_DOT": (False, True)}
+    __FIELDS = {
+        "INTERPRET_VERBOSE": (True, False),
+        "SPARSE_DOT": (False, True),
+        "UNUSED_PRIORS": ("warn", "error", "ignore"),
+    }
 
     def __init__(self, config_dict: dict = None):
         config_dict = {} if config_dict is None else config_dict

--- a/bambi/model_components.py
+++ b/bambi/model_components.py
@@ -75,7 +75,7 @@ class DistributionalComponent:
         for name, term in self.design.common.terms.items():
             if is_hsgp_term(term):
                 continue
-            prior = priors.pop(name, priors.get("common", None))
+            prior = priors.get(name, priors.get("common", None))
             if isinstance(prior, Prior):
                 any_hyperprior = any(isinstance(x, Prior) for x in prior.args.values())
                 if any_hyperprior:
@@ -91,13 +91,13 @@ class DistributionalComponent:
 
     def add_group_specific_terms(self, priors):
         for name, term in self.design.group.terms.items():
-            prior = priors.pop(name, priors.get("group_specific", None))
+            prior = priors.get(name, priors.get("group_specific", None))
             self.terms[name] = GroupSpecificTerm(term, prior, self.prefix)
 
     def add_hsgp_terms(self, priors):
         for name, term in self.design.common.terms.items():
             if is_hsgp_term(term):
-                prior = priors.pop(name, None)
+                prior = priors.get(name, None)
                 self.terms[name] = HSGPTerm(term, prior, self.prefix)
 
     def build_priors(self):
@@ -119,13 +119,25 @@ class DistributionalComponent:
     def update_priors(self, priors):
         """Update priors.
 
+        Priors specified by term name take precedence, while `"common"` and `"group_specific"`
+        apply to all remaining terms of the corresponding kind.
+
         Parameters
         ----------
         priors : dict
             Names are terms, values are priors
         """
-        for name, value in priors.items():
-            self.terms[name].prior = value
+        common = priors.get("common")
+        group_specific = priors.get("group_specific")
+        for name, term in self.terms.items():
+            if name in priors:
+                term.prior = priors[name]
+            elif isinstance(term, GroupSpecificTerm):
+                if group_specific is not None:
+                    term.prior = group_specific
+            elif isinstance(term, CommonTerm) and term.kind != "offset":
+                if common is not None:
+                    term.prior = common
 
     def predict(
         self,

--- a/bambi/models.py
+++ b/bambi/models.py
@@ -17,6 +17,7 @@ from pymc.backends.arviz import apply_function_over_dataset, coords_and_dims_for
 from pymc.model.transform.conditioning import remove_value_transforms
 
 from bambi.backend import PyMCModel
+from bambi.config import config
 from bambi.defaults import get_builtin_family
 from bambi.families import Family, univariate
 from bambi.formula import Formula, check_ordinal_formula
@@ -63,9 +64,15 @@ class Model:
         `"poisson"`, `"t"`, and `"wald"`. Defaults to `"gaussian"`.
     priors : dict, optional
         Optional specification of priors for one or more terms. A dictionary where the keys are
-        the names of terms in the model, "common," or "group_specific" and the values are
-        instances of class `Prior`. If priors are unset, use automatic priors inspired by
-        the R rstanarm library.
+        the names of terms in the model, "common," "group_specific," or the name of a model
+        component, and the values are instances of class `Prior`. A distributional component
+        name (e.g. "sigma" when it is modeled with a formula) maps to a nested dictionary of
+        the same form; a constant component name maps directly to a `Prior`, a number, or an
+        array. If priors are unset, use automatic priors inspired by the R rstanarm library.
+        Names that don't match any term or component are reported with a warning; set
+        `bmb.config["UNUSED_PRIORS"]` to `"error"` or `"ignore"` to change that.
+        Bare term priors can be combined with priors nested under the parent component. If both
+        specify the same term, the nested parent prior takes precedence.
     link : str or dict of str to str, optional
         The name of the link function to use. Valid names are `"cloglog"`, `"identity"`,
         `"inverse_squared"`, `"inverse"`, `"log"`, `"logit"`, `"probit"`, and
@@ -192,10 +199,11 @@ class Model:
                 "Please specify an outcome variable using the formula interface."
             )
 
-        if self.family.likelihood.parent in priors:
-            parent_priors = priors[self.family.likelihood.parent]
-        else:
-            parent_priors = priors
+        # Merge bare term priors with nested parent priors; nested entries take precedence.
+        parent_name = self.family.likelihood.parent
+        parent_priors = {name: prior for name, prior in priors.items() if name != parent_name}
+        if parent_name in priors:
+            parent_priors.update(priors[parent_name])
 
         # Add response component
         self.response_component = ResponseComponent(design.response, self)
@@ -242,6 +250,9 @@ class Model:
         for name in auxiliary_parameters:
             component_prior = priors.get(name, None)
             self.components[name] = ConstantComponent(name, component_prior, self)
+
+        # Validate prior names, now that every component and its terms are known.
+        self._check_prior_names(priors)
 
         # Validate per-component noncentered dict, now that all components are known.
         if isinstance(self.noncentered, dict):
@@ -421,13 +432,20 @@ class Model:
         Parameters
         ----------
         priors : dict or None, optional
-            Dictionary of priors to update. Keys are names of terms to update; values are the new
-            priors (either a `Prior` instance, or an int or float that scales the default priors).
+            Dictionary of priors to update. Accepts the same specification as the `priors`
+            argument of `Model`, and entries here take precedence over the `common` and
+            `group_specific` arguments. Names that don't match any term or component are
+            reported with a warning; set `bmb.config["UNUSED_PRIORS"]` to `"error"` or
+            `"ignore"` to change that.
         common : Prior, int, float or None, optional
             A prior specification to apply to all common terms included in the model.
         group_specific : Prior, int, float or None, optional
             A prior specification to apply to all group specific terms included in the model.
         """
+        if priors is not None:
+            # Validate before touching any state, so a rejected call leaves the model as it was.
+            self._check_prior_names(priors)
+
         kwargs = dict(zip(["priors", "common", "group_specific"], [priors, common, group_specific]))
         self._added_priors.update(kwargs)
         self._build_priors()  # After updating, we need to rebuild priors.
@@ -460,13 +478,47 @@ class Model:
             self.scaler = PriorScaler(self)
             self.scaler.scale()
 
+    def _check_prior_names(self, priors):
+        """Report names in `priors` that don't match any term or component."""
+        behavior = config["UNUSED_PRIORS"]
+        if behavior == "ignore":
+            return
+
+        parent_name = self.family.likelihood.parent
+        valid = (
+            set(self.components)
+            | set(self.components[parent_name].terms)
+            | {"common", "group_specific"}
+        )
+
+        unused = []
+        for name, value in priors.items():
+            if name not in valid:
+                unused.append(name)
+            elif isinstance(value, dict) and name in self.distributional_components:
+                nested_valid = set(self.components[name].terms) | {"common", "group_specific"}
+                unused.extend(f"{name}.{n}" for n in sorted(set(value) - nested_valid))
+
+        if not unused:
+            return
+
+        message = f"Unused name(s) in `priors`: {sorted(unused)}."
+        hint = ' Set `bmb.config["UNUSED_PRIORS"]` to change this.'
+        if behavior == "warn":
+            warnings.warn(message + " They will be ignored." + hint, UserWarning)
+        else:
+            raise ValueError(f"{message} Valid names for this model: {sorted(valid)}.{hint}")
+
     def _set_priors(self, priors=None, common=None, group_specific=None):
         """Internal version of `set_priors()`, with same arguments.
 
         Runs during `Model._build_priors()`.
         """
-        # 'common' and 'group_specific' only apply to the parent component
-        parent_component = self.components[self.family.likelihood.parent]
+        # Arguments `common` and `group_specific` only affect the parent component.
+        # Same names could also be used in a nested dictionary for other distributional components.
+        parent_name = self.family.likelihood.parent
+        parent_component = self.components[parent_name]
+
         if common is not None:
             for term in parent_component.common_terms.values():
                 term.prior = common
@@ -476,23 +528,26 @@ class Model:
                 term.prior = group_specific
 
         if priors is not None:
-            priors = deepcopy(priors)
+            # `normalized_priors` maps component names to their prior specifications:
+            #   - a term-to-prior dict for distributional components,
+            #   - a single prior for constant components.
+            # Bare term priors are merged into the parent component, with explicitly nested
+            # parent priors taking precedence.
+            normalized_priors = {name: priors[name] for name in self.components if name in priors}
+            parent_priors = {
+                name: prior for name, prior in priors.items() if name not in self.components
+            }
+            if parent_name in normalized_priors:
+                parent_priors.update(normalized_priors[parent_name])
+            normalized_priors[parent_name] = parent_priors
 
-            # The only distributional component is the parent term
-            if len(self.distributional_components) == 1:
-                # Update priors of the constant components
-                for name, component in self.constant_components.items():
-                    prior = priors.pop(name) if name in priors else None
-                    if prior:
-                        component.update_priors(prior)
-                # Pass all the other priors to the parent component
-                parent_component.update_priors(priors)
-            # There are more than one distributional components.
-            else:
-                for name, component in self.components.items():
-                    prior = priors.get(name)
-                    if prior:
-                        component.update_priors(prior)
+            # Make sure mutation of Prior objects within update_priors does not have side effects.
+            normalized_priors = deepcopy(normalized_priors)
+
+            for name, component in self.components.items():
+                prior = normalized_priors.get(name)
+                if prior is not None:
+                    component.update_priors(prior)
 
     def _set_family(self, family, link):
         """Set the Family of the model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ jax = [
     "numpyro>=0.19,<0.20",
 ]
 nutpie = [
-    "numba>=0.61.2",
+    # Capped because pytensor requires numba<=0.65.1; numba 0.66.0 makes the solve unsatisfiable.
+    "numba>=0.61.2,<0.66",
     "nutpie>=0.16.10,<1",
 ]
 
@@ -115,7 +116,8 @@ jax = ">=0.7,<0.8"
 numpyro = ">=0.19,<0.20"
 
 [tool.pixi.feature.nutpie.dependencies]
-numba = ">=0.61.2"
+# See the note on the `nutpie` extra above: pytensor requires numba<=0.65.1.
+numba = ">=0.61.2,<0.66"
 nutpie = ">=0.16.10,<1"
 
 [tool.pixi.feature.py312.dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,3 +32,16 @@ def test_config():
 
     with pytest.raises(KeyError, match="'DOESNT_EXIST' is not a valid configuration option"):
         config.DOESNT_EXIST = "anything"
+
+
+def test_config_unused_priors():
+    config = Config()
+
+    assert config["UNUSED_PRIORS"] == "warn"
+
+    for value in ("warn", "ignore", "error"):
+        config["UNUSED_PRIORS"] = value
+        assert config.UNUSED_PRIORS == value
+
+    with pytest.raises(ValueError, match="silent is not a valid value for 'UNUSED_PRIORS'"):
+        config.UNUSED_PRIORS = "silent"

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -216,13 +216,6 @@ def test_set_priors(data_random_n100):
     assert parent_component.terms["1|categorical1"].prior == gp_prior
 
 
-def test_set_prior_unexisting_term(data_random_n100):
-    prior = bmb.Prior("Uniform", lower=0, upper=50)
-    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
-    with pytest.raises(KeyError):
-        model.set_priors(priors={"z": prior})
-
-
 def test_response_prior(data_random_n100):
     priors = {"sigma": bmb.Prior("Uniform", lower=0, upper=50)}
     model = bmb.Model("count2 ~ continuous1", data_random_n100, priors=priors)
@@ -340,3 +333,147 @@ def test_custom_prior(data_random_n100):
     model = bmb.Model("continuous1 ~ continuous2", data_random_n100, priors=priors)
     model.build()
     assert model.backend.model.free_RVs[-1].str_repr() == "continuous2 ~ Normal(0, 5)"
+
+
+def test_unused_prior_in_model_warns(data_random_n100):
+    # Issue #815: this used to be silently ignored, so the model was fit with the automatic prior.
+    prior = bmb.Prior("Normal", mu=0, sigma=1)
+    with pytest.warns(UserWarning, match=r"Unused name\(s\) in `priors`: \['TYPO'\]"):
+        bmb.Model("continuous1 ~ continuous2", data_random_n100, priors={"TYPO": prior})
+
+
+def test_unused_prior_error_mode(data_random_n100, monkeypatch):
+    monkeypatch.setattr(bmb.config, "UNUSED_PRIORS", "error")
+    prior = bmb.Prior("Normal", mu=0, sigma=1)
+    with pytest.raises(ValueError, match=r"Unused name\(s\) in `priors`: \['TYPO'\]") as info:
+        bmb.Model("continuous1 ~ continuous2", data_random_n100, priors={"TYPO": prior})
+
+    message = str(info.value)
+    assert "continuous2" in message
+    assert "Intercept" in message
+    assert "UNUSED_PRIORS" in message
+
+
+def test_unused_prior_ignore_mode(data_random_n100, monkeypatch, recwarn):
+    monkeypatch.setattr(bmb.config, "UNUSED_PRIORS", "ignore")
+    prior = bmb.Prior("Normal", mu=0, sigma=1)
+    bmb.Model("continuous1 ~ continuous2", data_random_n100, priors={"TYPO": prior})
+    assert not [w for w in recwarn.list if "Unused name" in str(w.message)]
+
+
+def test_bare_prior_with_named_parent(data_random_n100, monkeypatch):
+    monkeypatch.setattr(bmb.config, "UNUSED_PRIORS", "error")
+    intercept_prior = bmb.Prior("Normal", mu=0, sigma=1)
+    slope_prior = bmb.Prior("Normal", mu=0, sigma=2)
+    bare_slope_prior = bmb.Prior("Normal", mu=0, sigma=3)
+    model = bmb.Model(
+        "continuous1 ~ continuous2",
+        data_random_n100,
+        priors={
+            "mu": {"continuous2": slope_prior},
+            "Intercept": intercept_prior,
+            "continuous2": bare_slope_prior,
+        },
+    )
+
+    intercept_prior.auto_scale = False
+    slope_prior.auto_scale = False
+    assert model.components["mu"].terms["Intercept"].prior == intercept_prior
+    assert model.components["mu"].terms["continuous2"].prior == slope_prior
+
+
+def test_set_bare_prior_with_named_parent(data_random_n100):
+    intercept_prior = bmb.Prior("Normal", mu=0, sigma=1)
+    slope_prior = bmb.Prior("Normal", mu=0, sigma=2)
+    bare_slope_prior = bmb.Prior("Normal", mu=0, sigma=3)
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    model.set_priors(
+        priors={
+            "mu": {"continuous2": slope_prior},
+            "Intercept": intercept_prior,
+            "continuous2": bare_slope_prior,
+        }
+    )
+
+    intercept_prior.auto_scale = False
+    slope_prior.auto_scale = False
+    assert model.components["mu"].terms["Intercept"].prior == intercept_prior
+    assert model.components["mu"].terms["continuous2"].prior == slope_prior
+
+
+def test_unused_prior_nested_component(data_random_n100, monkeypatch):
+    monkeypatch.setattr(bmb.config, "UNUSED_PRIORS", "error")
+    prior = bmb.Prior("Normal", mu=0, sigma=1)
+    formula = bmb.Formula("continuous1 ~ continuous2", "sigma ~ continuous2")
+    with pytest.raises(ValueError, match=r"sigma\.TYPO"):
+        bmb.Model(formula, data_random_n100, priors={"sigma": {"TYPO": prior}})
+
+
+def test_model_applies_bare_and_component_priors(data_random_n100, monkeypatch):
+    monkeypatch.setattr(bmb.config, "UNUSED_PRIORS", "error")
+    prior = bmb.Prior("Normal", mu=0, sigma=7.5)
+    formula = bmb.Formula("continuous1 ~ continuous2", "sigma ~ continuous2")
+    model = bmb.Model(
+        formula,
+        data_random_n100,
+        priors={"continuous2": prior, "sigma": {"continuous2": prior}},
+    )
+    prior.auto_scale = False  # the one in the model is set to False
+    assert model.components["mu"].terms["continuous2"].prior == prior
+    assert model.components["sigma"].terms["continuous2"].prior == prior
+
+
+def test_set_priors_applies_bare_terms_with_several_components(data_random_n100):
+    # `_set_priors` used to dispatch strictly by component name here, so a bare term name was
+    # silently dropped while `Model(priors=...)` applied it.
+    prior = bmb.Prior("Normal", mu=0, sigma=7.5)
+    formula = bmb.Formula("continuous1 ~ continuous2", "sigma ~ continuous2")
+    model = bmb.Model(formula, data_random_n100)
+    model.set_priors(priors={"continuous2": prior})
+    prior.auto_scale = False
+    assert model.components["mu"].terms["continuous2"].prior == prior
+
+
+@pytest.mark.parametrize(
+    "priors, component",
+    [
+        ({"common": "PLACEHOLDER"}, "mu"),  # applies to the intercept too, as at construction
+        ({"sigma": {"common": "PLACEHOLDER"}}, "sigma"),  # same rule inside a named component
+    ],
+)
+def test_set_priors_common_key_matches_model(data_random_n100, priors, component):
+    # The "common" key must behave identically at construction and via set_priors -- including
+    # the intercept, which the `common` *argument* deliberately does not touch.
+    prior = bmb.Prior("Normal", mu=0, sigma=7.5)
+    priors = {k: (prior if v == "PLACEHOLDER" else {"common": prior}) for k, v in priors.items()}
+    formula = bmb.Formula("continuous1 ~ continuous2", "sigma ~ continuous2")
+
+    via_init = bmb.Model(formula, data_random_n100, priors=priors)
+    via_set = bmb.Model(formula, data_random_n100)
+    via_set.set_priors(priors=priors)
+
+    for name in ("Intercept", "continuous2"):
+        expected = via_init.components[component].terms[name].prior
+        assert via_set.components[component].terms[name].prior == expected
+
+
+def test_set_priors_dict_wins_over_arguments(data_random_n100):
+    # Entries in `priors` take precedence over the `common`/`group_specific` arguments, just as
+    # term-specific entries always have.
+    keyed = bmb.Prior("Normal", mu=0, sigma=7.5)
+    argued = bmb.Prior("Normal", mu=0, sigma=1.5)
+    model = bmb.Model("continuous1 ~ continuous2", data_random_n100)
+    model.set_priors(priors={"common": keyed}, common=argued)
+    keyed.auto_scale = False
+    assert model.components["mu"].terms["continuous2"].prior == keyed
+
+
+def test_group_specific_key_in_model(data_random_n100):
+    gs_prior = bmb.Prior("Normal", mu=0, sigma=bmb.Prior("HalfNormal", sigma=1))
+    model = bmb.Model(
+        "continuous1 ~ continuous2 + (1|binary_cat)",
+        data_random_n100,
+        priors={"group_specific": gs_prior},
+    )
+    gs_prior.auto_scale = False
+    assert model.components["mu"].terms["1|binary_cat"].prior == gs_prior


### PR DESCRIPTION
Closes #815.

A `priors` entry whose key matches no term was silently dropped, so the model was fit with Bambi's automatic prior while the user believed theirs was used.

Adds `bmb.config["UNUSED_PRIORS"]`, per your suggestion on the issue. It defaults to `"warn"` so existing code keeps working; `"error"` and `"ignore"` are also available, and the default can move to `"error"` later if that seems right.

### The two entry points disagreed

Not in the issue, and the reason the first version of this PR had an awkward `from_model` flag. `Model()` and `set_priors()` consumed the same dictionary shape by different rules:

| Input | `bmb.Model(..., priors=…)` | `model.set_priors(priors=…)` |
|---|---|---|
| `{"TYPO": p}` | silently ignored | `KeyError: 'TYPO'` |
| `{"common": p}` | accepted | `KeyError: 'common'` |
| `{"x": p}`, >1 distributional component | applied to the parent's `x` | **silently dropped** |

The last row is a bug in its own right. Rather than teach the validator about both rule sets, `_set_priors` now dispatches exactly as `Model.__init__` does:

- the parent takes the whole dictionary unless it is named explicitly
- every other component is addressed by name
- `common` / `group_specific` work as keys as well as arguments, and the arguments win when both are given

So a priors dictionary means the same thing wherever it is passed, validation needs a single rule, and the boolean is gone.

`update_priors` now skips names it doesn't have instead of raising `KeyError`, since `_check_prior_names` owns the reporting and `"warn"`/`"ignore"` must not crash afterwards. `test_set_prior_unexisting_term` is updated accordingly — it asserted the old bare `KeyError`.

### Two silent cases found while writing this

Both are the same class as the reported bug, both now caught:

- naming the parent routes its terms into that nested dictionary, so a bare term name left at the top level was never read: `{"mu": {...}, "Intercept": p}` gave `Intercept` the automatic prior
- `set_priors({"mu": {...}})` on a single-component model raised a bare `KeyError`

### Also here: a `numba` cap

Unrelated to #815, but CI could not run without it. `numba` 0.66.0 exceeds `pytensor`'s ceiling of `<=0.65.1`, so the solve failed before any test ran — this has been breaking `main` since 2026-07-17, not just this branch. Capped at `<0.66` in the two places `numba` is declared. Happy to split it out if you'd rather it were its own PR.